### PR TITLE
Add EBS Support for Cassandra Instances

### DIFF
--- a/src/main/kotlin/com/rustyrazorblade/easycasslab/commands/Init.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easycasslab/commands/Init.kt
@@ -55,7 +55,7 @@ class Init(val context: Context) : ICommand {
     @Parameter(description = "EBS Volume Size (in GB)", names = ["--ebs.size"])
     var ebs_size = 256
 
-    @Parameter(description = "EBS Volume IOPS", names = ["--ebs.iops"])
+    @Parameter(description = "EBS Volume IOPS (note: only applies if '--ebs.type gp3'", names = ["--ebs.iops"])
     var ebs_iops = 0
 
     @Parameter(description = "EBS Volume Throughput (note: only applies if '--ebs.type gp3')", names = ["--ebs.throughput"])

--- a/src/main/kotlin/com/rustyrazorblade/easycasslab/commands/Init.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easycasslab/commands/Init.kt
@@ -55,6 +55,12 @@ class Init(val context: Context) : ICommand {
     @Parameter(description = "EBS Volume Size (in GB)", names = ["--ebs.size"])
     var ebs_size = 256
 
+    @Parameter(description = "EBS Volume IOPS", names = ["--ebs.iops"])
+    var ebs_iops = 0
+
+    @Parameter(description = "EBS Volume Throughput (note: only applies if '--ebs.type gp3')", names = ["--ebs.throughput"])
+    var ebs_throughput = 0
+
     @Parameter(description = "Cluster name")
     var name = "test"
 
@@ -82,7 +88,7 @@ class Init(val context: Context) : ICommand {
         // Added because if we're reusing a directory, we don't want any of the previous state
         Clean().execute()
 
-        val ebs = EBSConfiguration(ebs_type, ebs_size)
+        val ebs = EBSConfiguration(ebs_type, ebs_size, ebs_iops, ebs_throughput)
         var config = Configuration(name, context.userConfig.region, context, ami, open, ebs)
         println("Directory Initialized Configuring Terraform")
 

--- a/src/main/kotlin/com/rustyrazorblade/easycasslab/commands/Init.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easycasslab/commands/Init.kt
@@ -61,6 +61,9 @@ class Init(val context: Context) : ICommand {
     @Parameter(description = "EBS Volume Throughput (note: only applies if '--ebs.type gp3')", names = ["--ebs.throughput"])
     var ebs_throughput = 0
 
+    @Parameter(description = "Set EBS-Optimized instance (only supported for EBS-optimized instance types", names = ["--ebs.optimized"])
+    var ebs_optimized = false;
+
     @Parameter(description = "Cluster name")
     var name = "test"
 
@@ -88,7 +91,7 @@ class Init(val context: Context) : ICommand {
         // Added because if we're reusing a directory, we don't want any of the previous state
         Clean().execute()
 
-        val ebs = EBSConfiguration(ebs_type, ebs_size, ebs_iops, ebs_throughput)
+        val ebs = EBSConfiguration(ebs_type, ebs_size, ebs_iops, ebs_throughput, ebs_optimized)
         var config = Configuration(name, context.userConfig.region, context, ami, open, ebs)
         println("Directory Initialized Configuring Terraform")
 

--- a/src/main/kotlin/com/rustyrazorblade/easycasslab/commands/Init.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easycasslab/commands/Init.kt
@@ -11,6 +11,8 @@ import  com.rustyrazorblade.easycasslab.commands.converters.AZConverter
 import java.io.File
 import  com.rustyrazorblade.easycasslab.terraform.Configuration
 import  com.rustyrazorblade.easycasslab.containers.Terraform
+import com.rustyrazorblade.easycasslab.terraform.EBSConfiguration
+import com.rustyrazorblade.easycasslab.terraform.EBSType
 import org.apache.logging.log4j.kotlin.logger
 import java.time.LocalDate
 
@@ -47,6 +49,12 @@ class Init(val context: Context) : ICommand {
     @Parameter(description = "Unrestricted SSH access", names = ["--open"])
     var open = false
 
+    @Parameter(description = "EBS Volume Type", names = ["--ebs.type"])
+    var ebs_type = EBSType.NONE
+
+    @Parameter(description = "EBS Volume Size (in GB)", names = ["--ebs.size"])
+    var ebs_size = 256
+
     @Parameter(description = "Cluster name")
     var name = "test"
 
@@ -74,7 +82,8 @@ class Init(val context: Context) : ICommand {
         // Added because if we're reusing a directory, we don't want any of the previous state
         Clean().execute()
 
-        var config = Configuration(name, context.userConfig.region, context, ami, open)
+        val ebs = EBSConfiguration(ebs_type, ebs_size)
+        var config = Configuration(name, context.userConfig.region, context, ami, open, ebs)
         println("Directory Initialized Configuring Terraform")
 
         config.numCassandraInstances = cassandraInstances

--- a/src/main/kotlin/com/rustyrazorblade/easycasslab/terraform/Configuration.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easycasslab/terraform/Configuration.kt
@@ -13,11 +13,23 @@ import kotlin.random.Random
 
 typealias Ami = String
 
+enum class EBSType(val type: String) {
+    NONE(""),
+    GP2("gp2"),
+    GP3("gp3")
+}
+
+data class EBSConfiguration(
+    val type: EBSType,
+    val size: Int
+)
+
 class Configuration(var name: String,
                     var region: String,
                     var context: Context,
                     val ami: Ami,
-                    val open: Boolean) {
+                    val open: Boolean,
+                    val ebs: EBSConfiguration) {
 
 
     var numCassandraInstances = 3
@@ -75,7 +87,8 @@ class Configuration(var name: String,
                                     count: Int,
                                     securityGroups: List<String>,
                                     tags: Map<String, String>) : Configuration {
-        val conf = InstanceResource(ami, instanceType, tags, vpc_security_group_ids = securityGroups, count = count)
+        val ebsConf = if (ebs.type != EBSType.NONE) createEbsConf(ebs) else null
+        val conf = InstanceResource(ami, instanceType, tags, vpc_security_group_ids = securityGroups, count = count, ebs_block_device = ebsConf)
         config.resource.aws_instance[key] = conf
         return this
     }
@@ -153,6 +166,10 @@ class Configuration(var name: String,
 
             return mapper.readValue(f, TerraformConfig::class.java)
         }
+
+        fun createEbsConf(ebs: EBSConfiguration): InstanceEBSBlockDevice {
+            return InstanceEBSBlockDevice(volume_type = ebs.type.type, volume_size = ebs.size)
+        }
     }
 }
 
@@ -200,7 +217,8 @@ data class InstanceResource(
     val vpc_security_group_ids : List<String> = listOf(),
     val key_name : String = "\${var.key_name}",
     val availability_zone: String = "\${element(var.zones, count.index)}",
-    val count : Int
+    val count : Int,
+    val ebs_block_device: InstanceEBSBlockDevice? = null
 ) {
     init {
         if (ami == "") {
@@ -208,6 +226,16 @@ data class InstanceResource(
         }
     }
 }
+
+data class InstanceEBSBlockDevice(
+    val volume_type: String = "", // TODO (jwest): what default to use?
+    val volume_size: Int = 256,
+    val device_name: String = "/dev/xvdb", // TODO (jwest): probably not the right volume name to use
+    val iops: Int = 0,
+    val throughput: Int = 0,
+    val delete_on_termination: Boolean = true,
+    val encrypted: Boolean = false,
+)
 
 data class SecurityGroupRule(
     val description: String,

--- a/src/main/kotlin/com/rustyrazorblade/easycasslab/terraform/Configuration.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easycasslab/terraform/Configuration.kt
@@ -23,7 +23,8 @@ data class EBSConfiguration(
     val type: EBSType,
     val size: Int,
     val iops: Int,
-    val throughput: Int
+    val throughput: Int,
+    val optimized_instance: Boolean
 )
 
 class Configuration(var name: String,
@@ -90,7 +91,8 @@ class Configuration(var name: String,
                                     securityGroups: List<String>,
                                     tags: Map<String, String>) : Configuration {
         val ebsConf = if (ebs.type != EBSType.NONE && serverType == ServerType.Cassandra) createEbsConf(ebs) else null
-        val conf = InstanceResource(ami, instanceType, tags, vpc_security_group_ids = securityGroups, count = count, ebs_block_device = ebsConf)
+        val conf = InstanceResource(ami, instanceType, tags, vpc_security_group_ids = securityGroups, count = count,
+            ebs_block_device = ebsConf, ebs_optimized = ebs.optimized_instance && serverType == ServerType.Cassandra)
         config.resource.aws_instance[serverType.serverType] = conf
         return this
     }
@@ -222,7 +224,8 @@ data class InstanceResource(
     val key_name : String = "\${var.key_name}",
     val availability_zone: String = "\${element(var.zones, count.index)}",
     val count : Int,
-    val ebs_block_device: InstanceEBSBlockDevice? = null
+    val ebs_block_device: InstanceEBSBlockDevice? = null,
+    val ebs_optimized: Boolean = false,
 ) {
     init {
         if (ami == "") {

--- a/src/main/kotlin/com/rustyrazorblade/easycasslab/terraform/Configuration.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easycasslab/terraform/Configuration.kt
@@ -173,8 +173,9 @@ class Configuration(var name: String,
 
         fun createEbsConf(ebs: EBSConfiguration): InstanceEBSBlockDevice {
             val throughput = if (ebs.type != EBSType.GP3) 0 else ebs.throughput
+            val iops = if (ebs.type != EBSType.GP3) 0 else ebs.iops
             return InstanceEBSBlockDevice(volume_type = ebs.type.type, volume_size = ebs.size,
-                iops = ebs.iops, throughput = throughput)
+                iops = iops, throughput = throughput)
         }
     }
 }


### PR DESCRIPTION
Supports GP2, GP3, and ebs optimized instances. Can set throughput and iops for GP3. 