### PR TITLE
feat: Add GitHub Actions nightly builds for Cassandra 5.0 and trunk

### DIFF
--- a/.github/workflows/nightly-cassandra-build.yml
+++ b/.github/workflows/nightly-cassandra-build.yml
@@ -1,0 +1,156 @@
+name: Nightly Cassandra Builds
+
+on:
+  schedule:
+    # Run daily at 2am UTC
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+    # Allow manual triggering for testing
+
+permissions:
+  contents: write  # Required for creating releases
+
+jobs:
+  build-cassandra:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - branch: cassandra-5.0
+            version: 5.0-HEAD
+          - branch: trunk
+            version: trunk
+
+    steps:
+      - name: Checkout Cassandra repository
+        uses: actions/checkout@v4
+        with:
+          repository: apache/cassandra
+          ref: ${{ matrix.branch }}
+          fetch-depth: 1  # Shallow clone for speed
+
+      - name: Set up Java 11
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+
+      - name: Get Cassandra version from build.xml
+        id: get-version
+        run: |
+          # Extract version from build.xml
+          VERSION=$(grep -oP 'property name="base.version" value="\K[^"]+' build.xml || echo "unknown")
+          echo "cassandra_version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Building Cassandra version: $VERSION"
+
+      - name: Build Cassandra artifacts
+        run: |
+          echo "Building Cassandra ${{ matrix.branch }} with Java 11"
+          ant realclean
+          ant artifacts -Dno-checkstyle=true -Dant.gen-doc.skip=true
+        env:
+          JAVA_HOME: ${{ env.JAVA_HOME }}
+
+      - name: Locate and rename artifact
+        id: artifact
+        run: |
+          # Find the generated binary tarball
+          ARTIFACT=$(find build -name "apache-cassandra-*-bin.tar.gz" -type f | head -n 1)
+
+          if [[ -z "$ARTIFACT" ]]; then
+            echo "ERROR: No binary artifact found in build directory"
+            exit 1
+          fi
+
+          echo "Found artifact: $ARTIFACT"
+
+          # Rename to our convention: apache-cassandra-{version}-bin.tar.gz
+          TARGET_NAME="apache-cassandra-${{ matrix.version }}-bin.tar.gz"
+          cp "$ARTIFACT" "$TARGET_NAME"
+
+          # Verify file exists and is not empty
+          if [[ ! -f "$TARGET_NAME" || ! -s "$TARGET_NAME" ]]; then
+            echo "ERROR: Failed to create $TARGET_NAME"
+            exit 1
+          fi
+
+          FILE_SIZE=$(du -h "$TARGET_NAME" | cut -f1)
+          echo "Created $TARGET_NAME (size: $FILE_SIZE)"
+          echo "artifact_path=$TARGET_NAME" >> $GITHUB_OUTPUT
+          echo "artifact_size=$FILE_SIZE" >> $GITHUB_OUTPUT
+
+      - name: Upload artifact to workflow
+        uses: actions/upload-artifact@v4
+        with:
+          name: cassandra-${{ matrix.version }}
+          path: ${{ steps.artifact.outputs.artifact_path }}
+          retention-days: 7  # Keep for 7 days in workflow artifacts
+
+  create-release:
+    needs: build-cassandra
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Prepare release files
+        run: |
+          # Move artifacts to root directory for release
+          find artifacts -name "*.tar.gz" -exec cp {} . \;
+
+          # List what we're uploading
+          echo "Release artifacts:"
+          ls -lh *.tar.gz
+
+      - name: Delete existing nightly release
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release delete nightly --yes --repo ${{ github.repository }} || true
+          git push --delete origin nightly || true
+
+      - name: Create nightly release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: nightly
+          name: "Nightly Cassandra Builds"
+          prerelease: true
+          draft: false
+          body: |
+            ## Automated Nightly Builds
+
+            This release contains nightly builds of Apache Cassandra development branches:
+
+            - **5.0-HEAD**: Latest from `cassandra-5.0` branch
+            - **trunk**: Latest from `trunk` branch
+
+            ### Stable Download URLs
+
+            These URLs always point to the latest nightly builds:
+
+            ```
+            https://github.com/${{ github.repository }}/releases/download/nightly/apache-cassandra-5.0-HEAD-bin.tar.gz
+            https://github.com/${{ github.repository }}/releases/download/nightly/apache-cassandra-trunk-bin.tar.gz
+            ```
+
+            ### Build Information
+
+            - **Build Date**: ${{ github.event.repository.updated_at }}
+            - **Workflow Run**: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            - **Java Version**: 11 (Temurin)
+            - **Build Command**: `ant artifacts -Dno-checkstyle=true -Dant.gen-doc.skip=true`
+
+            ### Usage
+
+            These artifacts are compatible with the `easy-cass-lab` Packer build system and can be used as drop-in replacements for building Cassandra from source.
+
+            ---
+
+            **Note**: These are development builds and should not be used in production.
+          files: |
+            apache-cassandra-5.0-HEAD-bin.tar.gz
+            apache-cassandra-trunk-bin.tar.gz

--- a/packer/cassandra/cassandra_versions.yaml
+++ b/packer/cassandra/cassandra_versions.yaml
@@ -25,17 +25,11 @@
   python: "3.10.6"
 
 - version: "5.0-HEAD"
-  url: https://github.com/apache/cassandra.git
-  branch: cassandra-5.0
+  url: https://github.com/rustyrazorblade/easy-cass-lab/releases/download/nightly/apache-cassandra-5.0-HEAD-bin.tar.gz
   java: "11"
-  java_build: "11"
   python: "3.10.6"
-  ant_flags: "-Dant.gen-doc.skip=true"
 
 - version: "trunk"
-  url: https://github.com/apache/cassandra.git
-  branch: trunk
+  url: https://github.com/rustyrazorblade/easy-cass-lab/releases/download/nightly/apache-cassandra-trunk-bin.tar.gz
   java: "17"
-  java_build: "11"
   python: "3.10.6"
-  ant_flags: "-Dant.gen-doc.skip=true"


### PR DESCRIPTION
Implements #262 by moving Cassandra 5.0-HEAD and trunk builds from local Packer builds to automated GitHub Actions nightly workflows.

Changes:
- Add .github/workflows/nightly-cassandra-build.yml
  - Builds cassandra-5.0 and trunk branches nightly at 2am UTC
  - Uses Java 11 for both branches
  - Creates tar.gz artifacts with `ant artifacts`
  - Uploads to GitHub Releases with stable 'nightly' tag
  - Provides stable URLs that always point to latest builds

- Update packer/cassandra/cassandra_versions.yaml
  - Change 5.0-HEAD and trunk from git clone to download URLs
  - Point to nightly release artifacts
  - Remove build-related fields (branch, java_build, ant_flags)

Benefits:
- Packer builds ~15-20 minutes faster (no Cassandra compilation)
- Consistent artifacts across all usage
- Public access to latest development builds
- Stable URLs: /releases/download/nightly/apache-cassandra-{version}-bin.tar.gz

The install_cassandra.sh script already supports downloading tar.gz from URLs, so no script changes were needed for Packer integration.