### PR TITLE
Add EasyStressService to consolidate stress node lifecycle management

### DIFF
--- a/src/main/kotlin/com/rustyrazorblade/easycasslab/services/EasyStressService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easycasslab/services/EasyStressService.kt
@@ -1,0 +1,164 @@
+package com.rustyrazorblade.easycasslab.services
+
+import com.rustyrazorblade.easycasslab.configuration.Host
+import com.rustyrazorblade.easycasslab.output.OutputHandler
+import com.rustyrazorblade.easycasslab.providers.ssh.RemoteOperationsService
+import io.github.oshai.kotlinlogging.KotlinLogging
+
+private val log = KotlinLogging.logger {}
+
+/**
+ * Service for managing cassandra-easy-stress lifecycle operations.
+ *
+ * This service encapsulates all cassandra-easy-stress lifecycle logic (start, stop, restart)
+ * that was previously scattered across multiple command classes. It provides
+ * a centralized interface for stress testing operations on individual hosts.
+ *
+ * All operations return Result types for explicit error handling.
+ */
+interface EasyStressService {
+    /**
+     * Starts the cassandra-easy-stress service on the specified host.
+     *
+     * @param host The host where cassandra-easy-stress should be started
+     * @return Result indicating success or failure with exception details
+     */
+    fun start(host: Host): Result<Unit>
+
+    /**
+     * Stops the cassandra-easy-stress service on the specified host.
+     *
+     * @param host The host where cassandra-easy-stress should be stopped
+     * @return Result indicating success or failure with exception details
+     */
+    fun stop(host: Host): Result<Unit>
+
+    /**
+     * Restarts the cassandra-easy-stress service on the specified host.
+     *
+     * @param host The host where cassandra-easy-stress should be restarted
+     * @return Result indicating success or failure with exception details
+     */
+    fun restart(host: Host): Result<Unit>
+
+    /**
+     * Checks if cassandra-easy-stress is currently running on the specified host.
+     *
+     * @param host The host to check
+     * @return Result containing true if cassandra-easy-stress is active, false if inactive
+     */
+    fun isRunning(host: Host): Result<Boolean>
+
+    /**
+     * Gets the systemd status output for cassandra-easy-stress on the specified host.
+     *
+     * @param host The host to query
+     * @return Result containing the status output text
+     */
+    fun getStatus(host: Host): Result<String>
+}
+
+/**
+ * Default implementation of EasyStressService using SSH for remote operations.
+ *
+ * This implementation uses systemctl for service management of the
+ * cassandra-easy-stress systemd service on remote stress nodes.
+ *
+ * @property remoteOps Service for executing SSH commands on remote hosts
+ * @property outputHandler Handler for user-facing output messages
+ */
+class DefaultEasyStressService(
+    private val remoteOps: RemoteOperationsService,
+    private val outputHandler: OutputHandler,
+) : EasyStressService {
+    override fun start(host: Host): Result<Unit> =
+        runCatching {
+            outputHandler.handleMessage("Starting cassandra-easy-stress on ${host.alias}...")
+
+            remoteOps.executeRemotely(
+                host,
+                "sudo systemctl start cassandra-easy-stress",
+            )
+
+            log.info { "Successfully started cassandra-easy-stress on ${host.alias}" }
+        }
+
+    override fun stop(host: Host): Result<Unit> =
+        runCatching {
+            outputHandler.handleMessage("Stopping cassandra-easy-stress on ${host.alias}...")
+
+            remoteOps.executeRemotely(
+                host,
+                "sudo systemctl stop cassandra-easy-stress",
+            )
+
+            log.info { "Successfully stopped cassandra-easy-stress on ${host.alias}" }
+        }
+
+    override fun restart(host: Host): Result<Unit> =
+        runCatching {
+            outputHandler.handleMessage("Restarting cassandra-easy-stress on ${host.alias}...")
+
+            remoteOps.executeRemotely(
+                host,
+                "sudo systemctl restart cassandra-easy-stress",
+            )
+
+            log.info { "Successfully restarted cassandra-easy-stress on ${host.alias}" }
+        }
+
+    override fun isRunning(host: Host): Result<Boolean> =
+        runCatching {
+            log.debug { "Checking if cassandra-easy-stress is running on ${host.alias}" }
+
+            val response =
+                remoteOps.executeRemotely(
+                    host,
+                    "sudo systemctl is-active cassandra-easy-stress",
+                    output = false,
+                )
+
+            // systemctl is-active returns "active" if the service is running
+            // Any other response (inactive, failed, etc.) means it's not running normally
+            val isActive = response.text.trim().equals("active", ignoreCase = true)
+
+            log.debug {
+                if (isActive) {
+                    "cassandra-easy-stress is active on ${host.alias}"
+                } else {
+                    "cassandra-easy-stress is not active on ${host.alias}: ${response.text.trim()}"
+                }
+            }
+
+            isActive
+        }
+
+    override fun getStatus(host: Host): Result<String> =
+        runCatching {
+            log.debug { "Getting status of cassandra-easy-stress on ${host.alias}" }
+
+            val response =
+                remoteOps.executeRemotely(
+                    host,
+                    "sudo systemctl status cassandra-easy-stress",
+                    output = false,
+                )
+
+            response.text
+        }
+}
+
+/**
+ * Exception thrown when a cassandra-easy-stress service operation fails.
+ *
+ * @property message Description of the failure
+ * @property host The host where the operation failed
+ * @property exitCode The exit code from the failed command (if applicable)
+ * @property cause The underlying exception that caused this failure (if any)
+ */
+class EasyStressServiceException(
+    message: String,
+    val host: Host? = null,
+    val exitCode: Int? = null,
+    cause: Throwable? = null,
+) : Exception(message, cause)

--- a/src/main/kotlin/com/rustyrazorblade/easycasslab/services/ServicesModule.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easycasslab/services/ServicesModule.kt
@@ -14,4 +14,5 @@ import org.koin.dsl.module
 val servicesModule =
     module {
         factoryOf(::DefaultCassandraService) bind CassandraService::class
+        factoryOf(::DefaultEasyStressService) bind EasyStressService::class
     }

--- a/src/test/kotlin/com/rustyrazorblade/easycasslab/services/EasyStressServiceTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easycasslab/services/EasyStressServiceTest.kt
@@ -1,0 +1,293 @@
+package com.rustyrazorblade.easycasslab.services
+
+import com.rustyrazorblade.easycasslab.BaseKoinTest
+import com.rustyrazorblade.easycasslab.configuration.Host
+import com.rustyrazorblade.easycasslab.providers.ssh.RemoteOperationsService
+import com.rustyrazorblade.easycasslab.ssh.Response
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.koin.core.module.Module
+import org.koin.dsl.module
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+/**
+ * Test suite for EasyStressService following TDD principles.
+ *
+ * These tests verify cassandra-easy-stress lifecycle operations (start, stop, restart)
+ * and status checks using mocked SSH operations.
+ */
+class EasyStressServiceTest : BaseKoinTest() {
+    private lateinit var mockRemoteOps: RemoteOperationsService
+    private lateinit var easyStressService: EasyStressService
+
+    private val testHost =
+        Host(
+            public = "54.123.45.67",
+            private = "10.0.1.10",
+            alias = "stress0",
+            availabilityZone = "us-west-2a",
+        )
+
+    override fun additionalTestModules(): List<Module> =
+        listOf(
+            module {
+                single<RemoteOperationsService> { mockRemoteOps }
+                factory<EasyStressService> { DefaultEasyStressService(get(), get()) }
+            },
+        )
+
+    @BeforeEach
+    fun setupMocks() {
+        mockRemoteOps = mock()
+        easyStressService = getKoin().get()
+    }
+
+    // ========== START OPERATION TESTS ==========
+
+    @Test
+    fun `start should execute systemctl start command successfully`() {
+        // Given
+        val expectedCommand = "sudo systemctl start cassandra-easy-stress"
+        val successResponse = Response(text = "", stderr = "")
+        whenever(mockRemoteOps.executeRemotely(eq(testHost), eq(expectedCommand), any(), any()))
+            .thenReturn(successResponse)
+
+        // When
+        val result = easyStressService.start(testHost)
+
+        // Then
+        assertThat(result.isSuccess).isTrue()
+        verify(mockRemoteOps).executeRemotely(eq(testHost), eq(expectedCommand), any(), any())
+    }
+
+    @Test
+    fun `start should return failure when SSH operation throws exception`() {
+        // Given
+        val expectedCommand = "sudo systemctl start cassandra-easy-stress"
+        whenever(mockRemoteOps.executeRemotely(eq(testHost), eq(expectedCommand), any(), any()))
+            .thenThrow(RuntimeException("Connection refused"))
+
+        // When
+        val result = easyStressService.start(testHost)
+
+        // Then
+        assertThat(result.isFailure).isTrue()
+        assertThat(result.exceptionOrNull())
+            .hasMessageContaining("Connection refused")
+    }
+
+    // ========== STOP OPERATION TESTS ==========
+
+    @Test
+    fun `stop should execute systemctl stop command successfully`() {
+        // Given
+        val expectedCommand = "sudo systemctl stop cassandra-easy-stress"
+        val successResponse = Response(text = "", stderr = "")
+        whenever(mockRemoteOps.executeRemotely(eq(testHost), eq(expectedCommand), any(), any()))
+            .thenReturn(successResponse)
+
+        // When
+        val result = easyStressService.stop(testHost)
+
+        // Then
+        assertThat(result.isSuccess).isTrue()
+        verify(mockRemoteOps).executeRemotely(eq(testHost), eq(expectedCommand), any(), any())
+    }
+
+    @Test
+    fun `stop should return failure when SSH operation throws exception`() {
+        // Given
+        val expectedCommand = "sudo systemctl stop cassandra-easy-stress"
+        whenever(mockRemoteOps.executeRemotely(eq(testHost), eq(expectedCommand), any(), any()))
+            .thenThrow(RuntimeException("Connection timeout"))
+
+        // When
+        val result = easyStressService.stop(testHost)
+
+        // Then
+        assertThat(result.isFailure).isTrue()
+        assertThat(result.exceptionOrNull())
+            .hasMessageContaining("Connection timeout")
+    }
+
+    // ========== RESTART OPERATION TESTS ==========
+
+    @Test
+    fun `restart should execute systemctl restart command successfully`() {
+        // Given
+        val expectedCommand = "sudo systemctl restart cassandra-easy-stress"
+        val successResponse = Response(text = "", stderr = "")
+        whenever(mockRemoteOps.executeRemotely(eq(testHost), eq(expectedCommand), any(), any()))
+            .thenReturn(successResponse)
+
+        // When
+        val result = easyStressService.restart(testHost)
+
+        // Then
+        assertThat(result.isSuccess).isTrue()
+        verify(mockRemoteOps).executeRemotely(eq(testHost), eq(expectedCommand), any(), any())
+    }
+
+    @Test
+    fun `restart should return failure when SSH operation throws exception`() {
+        // Given
+        val expectedCommand = "sudo systemctl restart cassandra-easy-stress"
+        whenever(mockRemoteOps.executeRemotely(eq(testHost), eq(expectedCommand), any(), any()))
+            .thenThrow(RuntimeException("Timeout restarting service"))
+
+        // When
+        val result = easyStressService.restart(testHost)
+
+        // Then
+        assertThat(result.isFailure).isTrue()
+        assertThat(result.exceptionOrNull())
+            .hasMessageContaining("Timeout restarting service")
+    }
+
+    // ========== IS RUNNING TESTS ==========
+
+    @Test
+    fun `isRunning should return true when cassandra-easy-stress is active`() {
+        // Given
+        val expectedCommand = "sudo systemctl is-active cassandra-easy-stress"
+        val activeResponse = Response(text = "active", stderr = "")
+        whenever(mockRemoteOps.executeRemotely(eq(testHost), eq(expectedCommand), any(), any()))
+            .thenReturn(activeResponse)
+
+        // When
+        val result = easyStressService.isRunning(testHost)
+
+        // Then
+        assertThat(result.isSuccess).isTrue()
+        assertThat(result.getOrNull()).isTrue()
+        verify(mockRemoteOps).executeRemotely(eq(testHost), eq(expectedCommand), any(), any())
+    }
+
+    @Test
+    fun `isRunning should return false when cassandra-easy-stress is inactive`() {
+        // Given
+        val expectedCommand = "sudo systemctl is-active cassandra-easy-stress"
+        val inactiveResponse = Response(text = "inactive", stderr = "")
+        whenever(mockRemoteOps.executeRemotely(eq(testHost), eq(expectedCommand), any(), any()))
+            .thenReturn(inactiveResponse)
+
+        // When
+        val result = easyStressService.isRunning(testHost)
+
+        // Then
+        assertThat(result.isSuccess).isTrue()
+        assertThat(result.getOrNull()).isFalse()
+        verify(mockRemoteOps).executeRemotely(eq(testHost), eq(expectedCommand), any(), any())
+    }
+
+    @Test
+    fun `isRunning should return false when cassandra-easy-stress is in failed state`() {
+        // Given
+        val expectedCommand = "sudo systemctl is-active cassandra-easy-stress"
+        val failedResponse = Response(text = "failed", stderr = "")
+        whenever(mockRemoteOps.executeRemotely(eq(testHost), eq(expectedCommand), any(), any()))
+            .thenReturn(failedResponse)
+
+        // When
+        val result = easyStressService.isRunning(testHost)
+
+        // Then
+        assertThat(result.isSuccess).isTrue()
+        assertThat(result.getOrNull()).isFalse()
+        verify(mockRemoteOps).executeRemotely(eq(testHost), eq(expectedCommand), any(), any())
+    }
+
+    @Test
+    fun `isRunning should handle active status with whitespace`() {
+        // Given
+        val expectedCommand = "sudo systemctl is-active cassandra-easy-stress"
+        val activeResponse = Response(text = "active\n", stderr = "")
+        whenever(mockRemoteOps.executeRemotely(eq(testHost), eq(expectedCommand), any(), any()))
+            .thenReturn(activeResponse)
+
+        // When
+        val result = easyStressService.isRunning(testHost)
+
+        // Then
+        assertThat(result.isSuccess).isTrue()
+        assertThat(result.getOrNull()).isTrue()
+    }
+
+    @Test
+    fun `isRunning should be case insensitive for active status`() {
+        // Given
+        val expectedCommand = "sudo systemctl is-active cassandra-easy-stress"
+        val activeResponse = Response(text = "ACTIVE", stderr = "")
+        whenever(mockRemoteOps.executeRemotely(eq(testHost), eq(expectedCommand), any(), any()))
+            .thenReturn(activeResponse)
+
+        // When
+        val result = easyStressService.isRunning(testHost)
+
+        // Then
+        assertThat(result.isSuccess).isTrue()
+        assertThat(result.getOrNull()).isTrue()
+    }
+
+    @Test
+    fun `isRunning should return failure when SSH operation throws exception`() {
+        // Given
+        val expectedCommand = "sudo systemctl is-active cassandra-easy-stress"
+        whenever(mockRemoteOps.executeRemotely(eq(testHost), eq(expectedCommand), any(), any()))
+            .thenThrow(RuntimeException("SSH connection lost"))
+
+        // When
+        val result = easyStressService.isRunning(testHost)
+
+        // Then
+        assertThat(result.isFailure).isTrue()
+        assertThat(result.exceptionOrNull())
+            .hasMessageContaining("SSH connection lost")
+    }
+
+    // ========== GET STATUS TESTS ==========
+
+    @Test
+    fun `getStatus should return status output successfully`() {
+        // Given
+        val expectedCommand = "sudo systemctl status cassandra-easy-stress"
+        val statusOutput =
+            """
+            cassandra-easy-stress.service - Cassandra Easy Stress Server
+               Loaded: loaded (/etc/systemd/system/cassandra-easy-stress.service; enabled)
+               Active: active (running) since Mon 2024-01-15 10:00:00 UTC; 2h ago
+            """.trimIndent()
+        val successResponse = Response(text = statusOutput, stderr = "")
+        whenever(mockRemoteOps.executeRemotely(eq(testHost), eq(expectedCommand), any(), any()))
+            .thenReturn(successResponse)
+
+        // When
+        val result = easyStressService.getStatus(testHost)
+
+        // Then
+        assertThat(result.isSuccess).isTrue()
+        assertThat(result.getOrNull()).isEqualTo(statusOutput)
+        verify(mockRemoteOps).executeRemotely(eq(testHost), eq(expectedCommand), any(), any())
+    }
+
+    @Test
+    fun `getStatus should return failure when SSH operation throws exception`() {
+        // Given
+        val expectedCommand = "sudo systemctl status cassandra-easy-stress"
+        whenever(mockRemoteOps.executeRemotely(eq(testHost), eq(expectedCommand), any(), any()))
+            .thenThrow(RuntimeException("Failed to get status"))
+
+        // When
+        val result = easyStressService.getStatus(testHost)
+
+        // Then
+        assertThat(result.isFailure).isTrue()
+        assertThat(result.exceptionOrNull())
+            .hasMessageContaining("Failed to get status")
+    }
+}


### PR DESCRIPTION
Implements centralized service for cassandra-easy-stress operations, following the CassandraService pattern established in #300.

Changes:
- Add EasyStressService interface with 5 operations (start, stop, restart, isRunning, getStatus)
- Implement DefaultEasyStressService with Result-based error handling
- Refactor Start.kt to use service instead of hardcoded systemctl commands
- Enhance Stop.kt with stress node stop logic
- Enhance Restart.kt with stress node restart logic
- Register service with Koin dependency injection

Benefits:
- Centralizes stress node lifecycle management
- Improves testability with comprehensive test coverage (14 tests)
- Eliminates code duplication across commands
- Provides consistent error handling via Result types
- Maintains parallel execution for performance

Resolves #299