### PR TITLE
Fix Kotlin 2.2.21 annotation target warnings

### DIFF
--- a/src/main/kotlin/com/rustyrazorblade/easycasslab/configuration/CassandraVersion.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easycasslab/configuration/CassandraVersion.kt
@@ -24,20 +24,20 @@ data class CassandraVersion(
     @JsonIgnoreProperties(ignoreUnknown = true)
     val axonops: String? = null,
     @JsonIgnoreProperties(ignoreUnknown = true)
-    @JsonProperty("jvm_options")
+    @param:JsonProperty("jvm_options")
     val jvmOptions: String?,
     @JsonIgnoreProperties(ignoreUnknown = true)
-    @JsonProperty("ant_flags")
+    @param:JsonProperty("ant_flags")
     val antFlags: String? = null,
     @JsonIgnoreProperties(ignoreUnknown = true)
     val url: String? = null,
     @JsonIgnoreProperties(ignoreUnknown = true)
     val branch: String? = null,
     @JsonIgnoreProperties(ignoreUnknown = true)
-    @JsonProperty("java_build")
+    @param:JsonProperty("java_build")
     val javaBuild: String? = null,
     @JsonIgnoreProperties(ignoreUnknown = true)
-    @JsonProperty("jvm_config")
+    @param:JsonProperty("jvm_config")
     val jvmConfig: String? = null,
 ) {
     companion object {

--- a/src/main/kotlin/com/rustyrazorblade/easycasslab/configuration/HostInfo.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easycasslab/configuration/HostInfo.kt
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class HostInfo(
     @JsonIgnore var address: String = "",
-    @JsonProperty("instance") var name: String = "",
+    @param:JsonProperty("instance") var name: String = "",
     var environment: String = "",
     var cluster: String = "",
     var datacenter: String = "",

--- a/src/main/kotlin/com/rustyrazorblade/easycasslab/configuration/Prometheus.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easycasslab/configuration/Prometheus.kt
@@ -26,18 +26,18 @@ class Prometheus(
      *     Prometheus Scrape Config</a>
      */
     class ScrapeConfig(
-        @JsonInclude(JsonInclude.Include.NON_EMPTY)
+        @param:JsonInclude(JsonInclude.Include.NON_EMPTY)
         var job_name: String = "",
-        @JsonInclude(JsonInclude.Include.NON_NULL)
+        @param:JsonInclude(JsonInclude.Include.NON_NULL)
         var scrape_interval: String? = null,
-        @JsonProperty("static_configs")
-        @JsonInclude(JsonInclude.Include.NON_EMPTY)
+        @param:JsonProperty("static_configs")
+        @param:JsonInclude(JsonInclude.Include.NON_EMPTY)
         var staticConfigList: MutableList<StaticConfig> = mutableListOf(),
-        @JsonInclude(JsonInclude.Include.NON_EMPTY)
-        @JsonProperty("relabel_configs")
+        @param:JsonInclude(JsonInclude.Include.NON_EMPTY)
+        @param:JsonProperty("relabel_configs")
         var relabelConfigList: MutableList<RelabelConfig> = mutableListOf(),
-        @JsonInclude(JsonInclude.Include.NON_EMPTY)
-        @JsonProperty("file_sd_configs")
+        @param:JsonInclude(JsonInclude.Include.NON_EMPTY)
+        @param:JsonProperty("file_sd_configs")
         var fileSdConfigs: List<Map<String, MutableList<String>>> = listOf(mapOf("files" to mutableListOf())),
     ) {
         @Suppress("FunctionName")

--- a/src/main/kotlin/com/rustyrazorblade/easycasslab/providers/aws/terraform/AWSResources.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easycasslab/providers/aws/terraform/AWSResources.kt
@@ -207,13 +207,13 @@ data class CoreInstanceGroup(
 data class Ec2Attributes(
     @JsonIgnore
     val securityGroup: SecurityGroupResource,
-    @JsonProperty("subnet_id")
+    @param:JsonProperty("subnet_id")
     val subnetId: String,
-    @JsonProperty("emr_managed_master_security_group")
+    @param:JsonProperty("emr_managed_master_security_group")
     val masterSecurityGroupId: String = securityGroup.id(),
-    @JsonProperty("emr_managed_slave_security_group")
+    @param:JsonProperty("emr_managed_slave_security_group")
     val slaveSecurityGroupId: String = securityGroup.id(),
-    @JsonProperty("instance_profile")
+    @param:JsonProperty("instance_profile")
     val instanceProfile: String,
 )
 
@@ -223,15 +223,15 @@ data class Ec2Attributes(
 data class EMRCluster(
     val name: String = "cluster",
     val applications: List<String> = listOf("Spark"),
-    @JsonProperty("service_role")
+    @param:JsonProperty("service_role")
     val serviceRole: String = AWS.SERVICE_ROLE,
-    @JsonProperty("release_label")
+    @param:JsonProperty("release_label")
     val releaseLabel: String = "emr-7.9.0",
-    @JsonProperty("master_instance_group")
+    @param:JsonProperty("master_instance_group")
     val masterInstanceGroup: MasterInstanceGroup,
-    @JsonProperty("core_instance_group")
+    @param:JsonProperty("core_instance_group")
     val coreInstanceGroup: CoreInstanceGroup,
-    @JsonProperty("ec2_attributes")
+    @param:JsonProperty("ec2_attributes")
     val ec2Attributes: Ec2Attributes,
 ) {
     companion object {


### PR DESCRIPTION
## Summary
Fixes compiler warnings introduced by Kotlin 2.2.21 about annotation targets on data class constructor parameters.

## Changes
Added `@param:` prefix to Jackson `@JsonProperty` and `@JsonInclude` annotations on data class constructor parameters in 4 files:

- **AWSResources.kt**: Ec2Attributes and EMRCluster classes (9 annotations)
- **CassandraVersion.kt**: CassandraVersion class (4 annotations)
- **Prometheus.kt**: ScrapeConfig class (8 annotations)
- **HostInfo.kt**: HostInfo class (1 annotation)

## Why
Kotlin 2.2.21 warns that annotations on constructor parameters will apply to both the parameter and backing field in future versions. Using `@param:` explicitly maintains current parameter-only behavior and eliminates warnings.

## Testing
- All tests pass
- Compiler warnings eliminated
- Detekt static analysis passed
- ktlint formatting compliant
- Code coverage verified with Kover

Fixes #302