### PR TITLE
Switch from pyenv to deadsnakes PPA for Python management

### DIFF
--- a/packer/base/base.pkr.hcl
+++ b/packer/base/base.pkr.hcl
@@ -69,7 +69,7 @@ build {
     ]
   }
 
-  # install pyenv and python
+  # install python via deadsnakes PPA
   provisioner "shell" {
     script = "install/install_python.sh"
   }

--- a/packer/base/install/install_python.sh
+++ b/packer/base/install/install_python.sh
@@ -4,34 +4,32 @@ set -e
 # Ensure non-interactive mode for apt
 export DEBIAN_FRONTEND=noninteractive
 
+# Add deadsnakes PPA for additional Python versions
+sudo DEBIAN_FRONTEND=noninteractive add-apt-repository ppa:deadsnakes/ppa -y
 sudo DEBIAN_FRONTEND=noninteractive apt update -y
-sudo DEBIAN_FRONTEND=noninteractive apt install -y make build-essential libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev
-curl https://pyenv.run | bash
-# add to ~/.bash_profile for use on instance
-echo 'export PATH="$HOME/.pyenv/bin:$PATH"' >> ~/.bash_profile
-echo 'eval "$(pyenv init --path)"' >> ~/.bash_profile
-echo 'eval "$(pyenv virtualenv-init -)"' >> ~/.bash_profile
 
-{
-# shellcheck disable=SC2016
-echo 'export PATH="$HOME/.pyenv/bin:$PATH"'
-# shellcheck disable=SC2016
-echo 'eval "$(pyenv init --path)"'
-# shellcheck disable=SC2016
-echo 'eval "$(pyenv virtualenv-init -)"'
-} >> ~/.bash_profile
+# Install Python 2.7 and 3.10 with development packages
+sudo DEBIAN_FRONTEND=noninteractive apt install -y python2.7 python2.7-dev
+sudo DEBIAN_FRONTEND=noninteractive apt install -y python3.10 python3.10-dev python3.10-venv python3-pip
 
+# Setup update-alternatives for python version management
+# Priority 1 for Python 2.7 (lower priority)
+sudo update-alternatives --install /usr/bin/python python /usr/bin/python2.7 1
+# Priority 2 for Python 3.10 (higher priority, becomes default)
+sudo update-alternatives --install /usr/bin/python python /usr/bin/python3.10 2
 
-# now load it in for Packer build
-export PATH="$HOME/.pyenv/bin:$PATH"
-eval "$(pyenv init --path)"
-eval "$(pyenv virtualenv-init -)"
-# now install python
-pyenv install 2.7.18
-pyenv install 3.10.6
+# Set Python 3.10 as the default
+sudo update-alternatives --set python /usr/bin/python3.10
 
-# yeah.. this next part a little gross.
-# I assume we can keep the pip3 shim around
-/home/ubuntu/.pyenv/versions/3.10.6/bin/pip3 install iostat-tool
-# shellcheck disable=SC2046
-sudo ln -s $(find /home/ubuntu/.pyenv/ -name 'iostat-cli') /usr/local/bin/iostat-cli
+# Install pip for Python 2.7 (needed for Cassandra 3.x compatibility)
+# Python 2.7 pip is deprecated but still needed for legacy Cassandra versions
+curl https://bootstrap.pypa.io/pip/2.7/get-pip.py -o /tmp/get-pip.py
+sudo python2.7 /tmp/get-pip.py
+rm /tmp/get-pip.py
+
+# Install iostat-tool using pip3
+pip3 install iostat-tool
+
+# Create symlink for iostat-cli
+# Find the installed location and create symlink
+sudo ln -sf $(which iostat-cli) /usr/local/bin/iostat-cli

--- a/packer/cassandra/bin/use-cassandra
+++ b/packer/cassandra/bin/use-cassandra
@@ -53,10 +53,17 @@ else
   exit 1
 fi
 
-# set python version
-# NOTE: a bit hacky but we have to switch back to ubuntu user for this
-#       since its expected that this script run as root by pyenv doesn't
-sudo -u ubuntu bash << EOF
-source ~/.bash_profile
-pyenv global $PY_VERSION
-EOF
+# set python version using update-alternatives
+# Extract major.minor version from full version (e.g., "3.10.6" -> "3.10", "2.7.18" -> "2.7")
+PY_MAJOR_MINOR=$(echo "$PY_VERSION" | cut -d. -f1,2)
+PY_ALTERNATIVE="/usr/bin/python${PY_MAJOR_MINOR}"
+
+# Validate that the requested Python version is installed
+if [ ! -f "$PY_ALTERNATIVE" ]; then
+  echo "Error: Python version $PY_VERSION (${PY_ALTERNATIVE}) is not installed"
+  exit 1
+fi
+
+# Switch Python version using update-alternatives
+sudo update-alternatives --set python "$PY_ALTERNATIVE"
+echo "Switched to Python $PY_VERSION (${PY_ALTERNATIVE})"


### PR DESCRIPTION
Resolves #326

## Summary
Replace pyenv-based Python installation with system-level packages from deadsnakes PPA, using update-alternatives for version switching.

## Changes

### packer/base/install/install_python.sh
- Complete rewrite to use deadsnakes PPA instead of pyenv
- Installs Python 2.7 and 3.10 via apt packages
- Configures update-alternatives with proper priorities (2.7=1, 3.10=2)
- Includes Python 2.7 pip support for Cassandra 3.x compatibility
- Removes .bash_profile modifications (no longer needed)

### packer/cassandra/bin/use-cassandra  
- Replace pyenv global command with update-alternatives --set
- Adds validation to ensure requested version is installed
- Extracts major.minor version from full version string
- Consistent with existing Java version management pattern

### packer/base/base.pkr.hcl
- Update comment to reflect new approach

## Benefits
- Faster installation (no compilation required)
- System-integrated packages with automatic security updates
- Consistent with existing Java version management using update-alternatives
- Reduced dependencies (no build tools needed just for Python)
- Better caching through apt package mirrors

## Testing
- All packer Docker tests pass (testPackerBase, testPackerCassandra)
- Python 2.7 and 3.10 installation verified
- Version switching logic validated
- iostat-tool installation working correctly

## Notes
- This changes the Python installation method in AMIs
- Existing pyenv-based AMIs will not be compatible
- New AMIs will use deadsnakes PPA packages
- Python 2.7 pip included for Cassandra 3.x compatibility