### PR TITLE
feat: add status command to display comprehensive environment info

### DIFF
--- a/bin/end-to-end-test
+++ b/bin/end-to-end-test
@@ -112,6 +112,9 @@ kubectl wait --for=condition=Ready nodes --all --timeout=120s
 echo "=== Listing cluster hosts ==="
 "$PROJECT_ROOT/bin/easy-db-lab" hosts
 
+echo "=== Status Without Cassandra Version ==="
+"$PROJECT_ROOT/bin/easy-db-lab" status
+
 echo "=== Listing available Cassandra versions ==="
 "$PROJECT_ROOT/bin/easy-db-lab" list
 
@@ -123,6 +126,9 @@ echo "=== Updating configuration ==="
 
 echo "=== Starting Cassandra ==="
 "$PROJECT_ROOT/bin/easy-db-lab" start
+
+echo "=== Status With Cassandra Running ==="
+"$PROJECT_ROOT/bin/easy-db-lab" status
 
 echo "=== Stopping Cassandra ==="
 "$PROJECT_ROOT/bin/easy-db-lab" stop

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,4 @@
-
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 buildscript {
     repositories {
@@ -21,6 +21,10 @@ plugins {
 }
 
 group = "com.rustyrazorblade"
+
+tasks.withType<ShadowJar> {
+    isZip64 = true
+}
 
 java {
     sourceCompatibility = JavaVersion.VERSION_21
@@ -105,6 +109,9 @@ dependencies {
     // MCP SDK and dependencies
     implementation(libs.mcp.sdk)
     implementation(libs.kotlinx.io)
+
+    // Kubernetes
+    implementation(libs.fabric8.kubernetes.client)
 
     // Testing
     testImplementation(libs.bundles.testing)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -51,6 +51,7 @@ commons-io = "2.21.0"
 # Other
 classgraph = "4.8.184"
 resilience4j = "2.3.0"
+fabric8-kubernetes = "7.4.0"
 
 # Gradle Plugins
 shadow = "8.1.1"
@@ -129,6 +130,8 @@ kotlinx-io = { module = "org.jetbrains.kotlinx:kotlinx-io-core", version.ref = "
 resilience4j-retry = { module = "io.github.resilience4j:resilience4j-retry", version.ref = "resilience4j" }
 resilience4j-kotlin = { module = "io.github.resilience4j:resilience4j-kotlin", version.ref = "resilience4j" }
 
+# Kubernetes
+fabric8-kubernetes-client = { module = "io.fabric8:kubernetes-client", version.ref = "fabric8-kubernetes" }
 
 [bundles]
 # Logging bundle

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/CommandLineParser.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/CommandLineParser.kt
@@ -26,6 +26,7 @@ import com.rustyrazorblade.easydblab.commands.SetupInstance
 import com.rustyrazorblade.easydblab.commands.SetupProfile
 import com.rustyrazorblade.easydblab.commands.ShowIamPolicies
 import com.rustyrazorblade.easydblab.commands.Start
+import com.rustyrazorblade.easydblab.commands.Status
 import com.rustyrazorblade.easydblab.commands.Stop
 import com.rustyrazorblade.easydblab.commands.Up
 import com.rustyrazorblade.easydblab.commands.UpdateConfig
@@ -112,6 +113,7 @@ class CommandLineParser(
                 PicoCommandEntry("hosts", { Hosts(context) }),
                 PicoCommandEntry("stop", { Stop(context) }),
                 PicoCommandEntry("start", { Start(context) }),
+                PicoCommandEntry("status", { Status(context) }),
                 PicoCommandEntry("restart", { Restart(context) }),
                 PicoCommandEntry("exec", { Exec(context) }),
                 PicoCommandEntry("down", { Down(context) }),

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/Constants.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/Constants.kt
@@ -183,6 +183,11 @@ object Constants {
         const val DEFAULT_SERVER_URL = "https://127.0.0.1:6443"
     }
 
+    // Proxy configuration
+    object Proxy {
+        const val DEFAULT_SOCKS5_PORT = 1080
+    }
+
     // VPC and tagging configuration
     object Vpc {
         /** Default VPC CIDR block */

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Start.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Start.kt
@@ -3,7 +3,6 @@ package com.rustyrazorblade.easydblab.commands
 import com.github.ajalt.mordant.TermColors
 import com.rustyrazorblade.easydblab.Context
 import com.rustyrazorblade.easydblab.annotations.McpCommand
-import com.rustyrazorblade.easydblab.annotations.RequireDocker
 import com.rustyrazorblade.easydblab.annotations.RequireProfileSetup
 import com.rustyrazorblade.easydblab.annotations.RequireSSHKey
 import com.rustyrazorblade.easydblab.commands.mixins.HostsMixin
@@ -24,7 +23,6 @@ import java.io.File
  * Start cassandra on all nodes via service command.
  */
 @McpCommand
-@RequireDocker
 @RequireProfileSetup
 @RequireSSHKey
 @Command(

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Status.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Status.kt
@@ -1,0 +1,390 @@
+package com.rustyrazorblade.easydblab.commands
+
+import com.rustyrazorblade.easydblab.Context
+import com.rustyrazorblade.easydblab.annotations.McpCommand
+import com.rustyrazorblade.easydblab.annotations.RequireProfileSetup
+import com.rustyrazorblade.easydblab.configuration.ClusterHost
+import com.rustyrazorblade.easydblab.configuration.ClusterStateManager
+import com.rustyrazorblade.easydblab.configuration.Host
+import com.rustyrazorblade.easydblab.configuration.ServerType
+import com.rustyrazorblade.easydblab.configuration.User
+import com.rustyrazorblade.easydblab.configuration.s3Path
+import com.rustyrazorblade.easydblab.kubernetes.getLocalKubeconfigPath
+import com.rustyrazorblade.easydblab.output.OutputHandler
+import com.rustyrazorblade.easydblab.providers.aws.EC2InstanceService
+import com.rustyrazorblade.easydblab.providers.aws.EMRService
+import com.rustyrazorblade.easydblab.providers.aws.SecurityGroupRuleInfo
+import com.rustyrazorblade.easydblab.providers.aws.SecurityGroupService
+import com.rustyrazorblade.easydblab.providers.ssh.RemoteOperationsService
+import com.rustyrazorblade.easydblab.services.K3sService
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+import picocli.CommandLine.Command
+import java.io.File
+import java.nio.file.Paths
+import java.time.Duration
+import java.time.format.DateTimeFormatter
+
+/**
+ * Displays comprehensive, human-readable environment status including:
+ * - Nodes (cassandra, stress, control) with instance IDs, IPs, aliases, and live state
+ * - Networking info (VPC, IGW, subnets, route tables)
+ * - Security group rules (full ingress/egress)
+ * - Kubernetes jobs running on K3s cluster
+ * - Cassandra version (live via SSH, fallback to cached)
+ */
+@McpCommand
+@RequireProfileSetup
+@Command(
+    name = "status",
+    description = ["Display full environment status"],
+)
+@Suppress("TooManyFunctions")
+class Status(
+    private val context: Context,
+) : PicoCommand,
+    KoinComponent {
+    companion object {
+        private val log = KotlinLogging.logger {}
+        private val DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+        private const val JOB_NAME_MAX_LENGTH = 30
+        private const val HOURS_PER_DAY = 24
+    }
+
+    private val outputHandler: OutputHandler by inject()
+    private val clusterStateManager: ClusterStateManager by inject()
+    private val ec2InstanceService: EC2InstanceService by inject()
+    private val securityGroupService: SecurityGroupService by inject()
+    private val k3sService: K3sService by inject()
+    private val remoteOperationsService: RemoteOperationsService by inject()
+    private val emrService: EMRService by inject()
+    private val userConfig: User by inject()
+
+    private val clusterState by lazy { clusterStateManager.load() }
+
+    override fun execute() {
+        if (!clusterStateManager.exists()) {
+            outputHandler.handleMessage(
+                "Cluster state does not exist yet. Run 'easy-db-lab init' first.",
+            )
+            return
+        }
+
+        displayClusterSection()
+        displayNodesSection()
+        displayNetworkingSection()
+        displaySecurityGroupSection()
+        displaySparkClusterSection()
+        displayS3BucketSection()
+        displayKubernetesSection()
+        displayCassandraVersionSection()
+    }
+
+    /**
+     * Display cluster overview section
+     */
+    private fun displayClusterSection() {
+        outputHandler.handleMessage("")
+        outputHandler.handleMessage("=== CLUSTER STATUS ===")
+        outputHandler.handleMessage("Cluster ID: ${clusterState.clusterId}")
+        outputHandler.handleMessage("Name: ${clusterState.name}")
+        outputHandler.handleMessage("Created: ${clusterState.createdAt.atZone(java.time.ZoneId.systemDefault()).format(DATE_FORMATTER)}")
+        outputHandler.handleMessage("Infrastructure: ${clusterState.infrastructureStatus}")
+    }
+
+    /**
+     * Display nodes section with live instance state from EC2
+     */
+    private fun displayNodesSection() {
+        outputHandler.handleMessage("")
+        outputHandler.handleMessage("=== NODES ===")
+
+        val allInstanceIds = clusterState.getAllInstanceIds()
+
+        // Get live instance states from EC2
+        val instanceStates =
+            if (allInstanceIds.isNotEmpty()) {
+                runCatching {
+                    ec2InstanceService
+                        .describeInstances(allInstanceIds)
+                        .associateBy { it.instanceId }
+                }.getOrElse {
+                    log.warn(it) { "Failed to get instance states from EC2" }
+                    emptyMap()
+                }
+            } else {
+                emptyMap()
+            }
+
+        displayNodesByType(ServerType.Cassandra, "CASSANDRA NODES", instanceStates)
+        displayNodesByType(ServerType.Stress, "STRESS NODES", instanceStates)
+        displayNodesByType(ServerType.Control, "CONTROL NODES", instanceStates)
+    }
+
+    private fun displayNodesByType(
+        serverType: ServerType,
+        header: String,
+        instanceStates: Map<String, com.rustyrazorblade.easydblab.providers.aws.InstanceDetails>,
+    ) {
+        val hosts = clusterState.hosts[serverType] ?: emptyList()
+        if (hosts.isEmpty()) return
+
+        outputHandler.handleMessage("")
+        outputHandler.handleMessage("$header:")
+
+        hosts.forEach { host ->
+            val state = instanceStates[host.instanceId]?.state ?: "UNKNOWN"
+            outputHandler.handleMessage(
+                "  %-12s %-20s %-16s %-16s %-12s %s".format(
+                    host.alias,
+                    host.instanceId.ifEmpty { "(no id)" },
+                    "${host.publicIp} (public)",
+                    "${host.privateIp} (private)",
+                    host.availabilityZone,
+                    state.uppercase(),
+                ),
+            )
+        }
+    }
+
+    /**
+     * Display networking section
+     */
+    private fun displayNetworkingSection() {
+        outputHandler.handleMessage("")
+        outputHandler.handleMessage("=== NETWORKING ===")
+
+        val infrastructure = clusterState.infrastructure
+        if (infrastructure == null) {
+            outputHandler.handleMessage("(no infrastructure data)")
+            return
+        }
+
+        outputHandler.handleMessage("VPC:              ${infrastructure.vpcId}")
+        outputHandler.handleMessage("Internet Gateway: ${infrastructure.internetGatewayId ?: "(none)"}")
+        outputHandler.handleMessage("Subnets:          ${infrastructure.subnetIds.joinToString(", ")}")
+        outputHandler.handleMessage("Route Tables:     ${infrastructure.routeTableId ?: "(default)"}")
+    }
+
+    /**
+     * Display security group rules section
+     */
+    private fun displaySecurityGroupSection() {
+        outputHandler.handleMessage("")
+        outputHandler.handleMessage("=== SECURITY GROUP ===")
+
+        val sgId = clusterState.infrastructure?.securityGroupId
+        if (sgId == null) {
+            outputHandler.handleMessage("(no security group configured)")
+            return
+        }
+
+        val sgDetails =
+            runCatching {
+                securityGroupService.describeSecurityGroup(sgId)
+            }.getOrNull()
+
+        if (sgDetails == null) {
+            outputHandler.handleMessage("Security Group: $sgId (unable to fetch details)")
+            return
+        }
+
+        outputHandler.handleMessage("Security Group: ${sgDetails.securityGroupId} (${sgDetails.name})")
+
+        outputHandler.handleMessage("")
+        outputHandler.handleMessage("Inbound Rules:")
+        displaySecurityRules(sgDetails.inboundRules)
+
+        outputHandler.handleMessage("")
+        outputHandler.handleMessage("Outbound Rules:")
+        displaySecurityRules(sgDetails.outboundRules)
+    }
+
+    private fun displaySecurityRules(rules: List<SecurityGroupRuleInfo>) {
+        if (rules.isEmpty()) {
+            outputHandler.handleMessage("  (none)")
+            return
+        }
+
+        rules.forEach { rule ->
+            val portRange =
+                when {
+                    rule.fromPort == null && rule.toPort == null -> "All"
+                    rule.fromPort == rule.toPort -> "${rule.fromPort}"
+                    else -> "${rule.fromPort}-${rule.toPort}"
+                }
+
+            val cidrs = rule.cidrBlocks.joinToString(", ").ifEmpty { "(none)" }
+            val description = rule.description ?: ""
+
+            outputHandler.handleMessage(
+                "  %-6s %-8s %-20s %s".format(
+                    rule.protocol,
+                    portRange,
+                    cidrs,
+                    description,
+                ),
+            )
+        }
+    }
+
+    /**
+     * Display Spark/EMR cluster section
+     */
+    private fun displaySparkClusterSection() {
+        outputHandler.handleMessage("")
+        outputHandler.handleMessage("=== SPARK CLUSTER ===")
+
+        val emrCluster = clusterState.emrCluster
+        if (emrCluster == null) {
+            outputHandler.handleMessage("(no Spark cluster configured)")
+            return
+        }
+
+        // Try to get live status from AWS, fall back to cached state
+        val liveState =
+            runCatching {
+                emrService.getClusterStatus(emrCluster.clusterId).state
+            }.getOrElse { emrCluster.state }
+
+        outputHandler.handleMessage("Cluster ID:   ${emrCluster.clusterId}")
+        outputHandler.handleMessage("Name:         ${emrCluster.clusterName}")
+        outputHandler.handleMessage("State:        $liveState")
+        emrCluster.masterPublicDns?.let {
+            outputHandler.handleMessage("Master DNS:   $it")
+        }
+    }
+
+    /**
+     * Display S3 bucket section
+     */
+    private fun displayS3BucketSection() {
+        outputHandler.handleMessage("")
+        outputHandler.handleMessage("=== S3 BUCKET ===")
+
+        if (userConfig.s3Bucket.isBlank()) {
+            outputHandler.handleMessage("(no S3 bucket configured)")
+            return
+        }
+
+        val s3Path = clusterState.s3Path(userConfig)
+        outputHandler.handleMessage("Bucket:       ${userConfig.s3Bucket}")
+        outputHandler.handleMessage("Spark JARs:   ${s3Path.sparkJars()}")
+        outputHandler.handleMessage("Logs:         ${s3Path.logs()}")
+        outputHandler.handleMessage("EMR Logs:     ${s3Path.emrLogs()}")
+    }
+
+    /**
+     * Display Kubernetes jobs section
+     */
+    private fun displayKubernetesSection() {
+        outputHandler.handleMessage("")
+        outputHandler.handleMessage("=== KUBERNETES JOBS ===")
+
+        val controlHost = clusterState.getControlHost()
+        if (controlHost == null) {
+            outputHandler.handleMessage("(no control node configured)")
+            return
+        }
+
+        // Check if kubeconfig exists locally
+        val kubeconfigPath = getLocalKubeconfigPath(context.workingDirectory.absolutePath)
+        if (!File(kubeconfigPath).exists()) {
+            outputHandler.handleMessage("(kubeconfig not found - K3s may not be initialized)")
+            return
+        }
+
+        // Try to connect and list jobs via K3sService
+        val result = k3sService.listJobs(controlHost, Paths.get(kubeconfigPath))
+
+        result.fold(
+            onSuccess = { jobs ->
+                if (jobs.isEmpty()) {
+                    outputHandler.handleMessage("(no jobs running)")
+                } else {
+                    outputHandler.handleMessage("%-12s %-30s %-12s %s".format("NAMESPACE", "NAME", "STATUS", "AGE"))
+                    jobs.forEach { job ->
+                        outputHandler.handleMessage(
+                            "%-12s %-30s %-12s %s".format(
+                                job.namespace,
+                                job.name.take(JOB_NAME_MAX_LENGTH),
+                                job.status,
+                                formatAge(job.age),
+                            ),
+                        )
+                    }
+                }
+            },
+            onFailure = { e ->
+                log.debug(e) { "Failed to get Kubernetes jobs" }
+                outputHandler.handleMessage("(unable to connect to K3s: ${e.message})")
+            },
+        )
+    }
+
+    /**
+     * Display Cassandra version section
+     */
+    private fun displayCassandraVersionSection() {
+        outputHandler.handleMessage("")
+        outputHandler.handleMessage("=== CASSANDRA VERSION ===")
+
+        val cassandraHosts = clusterState.hosts[ServerType.Cassandra] ?: emptyList()
+        if (cassandraHosts.isEmpty()) {
+            outputHandler.handleMessage("(no Cassandra nodes configured)")
+            return
+        }
+
+        // Try to get live version from first available node
+        val liveVersion = tryGetLiveVersion(cassandraHosts)
+
+        if (liveVersion != null) {
+            outputHandler.handleMessage("Version: $liveVersion (all nodes)")
+        } else {
+            // Fall back to cached version
+            val cachedVersion = clusterState.default.version.ifEmpty { "unknown" }
+            outputHandler.handleMessage("Version: $cachedVersion (cached - nodes unavailable)")
+        }
+    }
+
+    private fun tryGetLiveVersion(hosts: List<ClusterHost>): String? {
+        for (host in hosts) {
+            val version =
+                runCatching {
+                    val sshHost = host.toHost()
+                    val result = remoteOperationsService.getRemoteVersion(sshHost)
+                    result.versionString
+                }.onFailure { e ->
+                    log.debug(e) { "Failed to get version from ${host.alias}" }
+                }.getOrNull()
+
+            if (!version.isNullOrEmpty()) {
+                return version
+            }
+        }
+        return null
+    }
+
+    private fun formatAge(duration: Duration): String {
+        val hours = duration.toHours()
+        val minutes = duration.toMinutesPart()
+
+        return when {
+            hours > HOURS_PER_DAY -> "${hours / HOURS_PER_DAY}d"
+            hours > 0 -> "${hours}h"
+            else -> "${minutes}m"
+        }
+    }
+}
+
+/**
+ * Extension function to convert ClusterHost to Host for SSH operations
+ */
+private fun ClusterHost.toHost(): Host =
+    Host(
+        public = this.publicIp,
+        private = this.privateIp,
+        alias = this.alias,
+        availabilityZone = this.availabilityZone,
+    )

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Up.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Up.kt
@@ -4,7 +4,6 @@ import com.github.ajalt.mordant.TermColors
 import com.rustyrazorblade.easydblab.Constants
 import com.rustyrazorblade.easydblab.Context
 import com.rustyrazorblade.easydblab.annotations.McpCommand
-import com.rustyrazorblade.easydblab.annotations.RequireDocker
 import com.rustyrazorblade.easydblab.annotations.RequireProfileSetup
 import com.rustyrazorblade.easydblab.commands.mixins.HostsMixin
 import com.rustyrazorblade.easydblab.configuration.AxonOpsWorkbenchConfig
@@ -43,7 +42,6 @@ import java.time.Duration
  * Starts instances and sets up the cluster.
  */
 @McpCommand
-@RequireDocker
 @RequireProfileSetup
 @Command(
     name = "up",
@@ -115,14 +113,12 @@ class Up(
 
         // Get AMI ID
         val amiId =
-            if (initConfig.ami.isNotBlank()) {
-                initConfig.ami
-            } else {
+            initConfig.ami.ifBlank {
                 val arch = initConfig.arch.lowercase()
                 val amiPattern = Constants.AWS.AMI_PATTERN_TEMPLATE.format(arch)
                 val amis = ec2Service.listPrivateAMIs(amiPattern)
                 if (amis.isEmpty()) {
-                    error("No AMI found for architecture $arch. Please build an AMI first with 'easy-db-lab build-ami'.")
+                    error("No AMI found for architecture $arch. Please build an AMI first with 'easy-db-lab build-image'.")
                 }
                 // Get the most recently created AMI
                 amis.maxByOrNull { it.creationDate }?.id

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/ClusterState.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/ClusterState.kt
@@ -1,5 +1,6 @@
 package com.rustyrazorblade.easydblab.configuration
 
+import com.rustyrazorblade.easydblab.commands.Init
 import java.time.Instant
 import java.util.UUID
 
@@ -82,7 +83,46 @@ data class InitConfig(
     val sparkMasterInstanceType: String = "m5.xlarge",
     val sparkWorkerInstanceType: String = "m5.xlarge",
     val sparkWorkerCount: Int = 3,
-)
+) {
+    companion object {
+        /**
+         * Factory method to create InitConfig from an Init command instance.
+         * Encapsulates the transformation logic in a single location.
+         *
+         * @param init The Init command instance containing user-specified configuration
+         * @param region The AWS region from user configuration
+         * @return A new InitConfig with values from the Init command
+         */
+        fun fromInit(
+            init: Init,
+            region: String,
+        ): InitConfig =
+            InitConfig(
+                cassandraInstances = init.cassandraInstances,
+                stressInstances = init.stressInstances,
+                instanceType = init.instanceType,
+                stressInstanceType = init.stressInstanceType,
+                azs = init.azs,
+                ami = init.ami,
+                region = region,
+                name = init.name,
+                ebsType = init.ebsType,
+                ebsSize = init.ebsSize,
+                ebsIops = init.ebsIops,
+                ebsThroughput = init.ebsThroughput,
+                ebsOptimized = init.ebsOptimized,
+                open = init.open,
+                controlInstances = 1,
+                controlInstanceType = "t3.xlarge",
+                tags = init.tags,
+                arch = init.arch.name,
+                sparkEnabled = init.spark.enable,
+                sparkMasterInstanceType = init.spark.masterInstanceType,
+                sparkWorkerInstanceType = init.spark.workerInstanceType,
+                sparkWorkerCount = init.spark.workerCount,
+            )
+    }
+}
 
 /**
  * Pure data class representing cluster state.

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/di/KoinModules.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/di/KoinModules.kt
@@ -1,9 +1,11 @@
 package com.rustyrazorblade.easydblab.di
 
 import com.rustyrazorblade.easydblab.Context
+import com.rustyrazorblade.easydblab.kubernetes.kubernetesModule
 import com.rustyrazorblade.easydblab.providers.aws.awsModule
 import com.rustyrazorblade.easydblab.providers.docker.dockerModule
 import com.rustyrazorblade.easydblab.providers.ssh.sshModule
+import com.rustyrazorblade.easydblab.proxy.proxyModule
 import com.rustyrazorblade.easydblab.services.servicesModule
 import org.koin.core.module.Module
 
@@ -22,6 +24,8 @@ object KoinModules {
             outputModule,
             dockerModule,
             sshModule,
+            proxyModule,
+            kubernetesModule,
             awsModule,
             servicesModule,
             configurationModule,

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/kubernetes/DefaultKubernetesService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/kubernetes/DefaultKubernetesService.kt
@@ -1,0 +1,190 @@
+package com.rustyrazorblade.easydblab.kubernetes
+
+import io.fabric8.kubernetes.api.model.Node
+import io.fabric8.kubernetes.api.model.Pod
+import io.fabric8.kubernetes.api.model.batch.v1.Job
+import io.fabric8.kubernetes.client.KubernetesClient
+import io.github.oshai.kotlinlogging.KotlinLogging
+import java.nio.file.Path
+import java.time.Duration
+import java.time.OffsetDateTime
+import java.time.format.DateTimeFormatter
+
+/**
+ * Default implementation of KubernetesService using the Fabric8 Kubernetes Client.
+ *
+ * This service uses a lazy-initialized client that connects through a SOCKS proxy
+ * for access to private K3s clusters.
+ *
+ * @property clientFactory Factory for creating Kubernetes clients
+ * @property kubeconfigPath Path to the kubeconfig file
+ */
+class DefaultKubernetesService(
+    private val clientFactory: KubernetesClientFactory,
+    private val kubeconfigPath: Path,
+) : KubernetesService {
+    companion object {
+        private val log = KotlinLogging.logger {}
+    }
+
+    private val client: KubernetesClient by lazy {
+        clientFactory.createClient(kubeconfigPath)
+    }
+
+    override fun listJobs(namespace: String?): Result<List<KubernetesJob>> =
+        runCatching {
+            log.debug { "Listing jobs${namespace?.let { " in namespace $it" } ?: " across all namespaces"}" }
+
+            val jobs =
+                if (namespace != null) {
+                    client
+                        .batch()
+                        .v1()
+                        .jobs()
+                        .inNamespace(namespace)
+                        .list()
+                } else {
+                    client
+                        .batch()
+                        .v1()
+                        .jobs()
+                        .inAnyNamespace()
+                        .list()
+                }
+
+            jobs.items.map { it.toKubernetesJob() }
+        }.onFailure { e ->
+            log.warn(e) { "Failed to list jobs" }
+        }
+
+    override fun listPods(namespace: String?): Result<List<KubernetesPod>> =
+        runCatching {
+            log.debug { "Listing pods${namespace?.let { " in namespace $it" } ?: " across all namespaces"}" }
+
+            val pods =
+                if (namespace != null) {
+                    client.pods().inNamespace(namespace).list()
+                } else {
+                    client.pods().inAnyNamespace().list()
+                }
+
+            pods.items.map { it.toKubernetesPod() }
+        }.onFailure { e ->
+            log.warn(e) { "Failed to list pods" }
+        }
+
+    override fun getNodes(): Result<List<KubernetesNode>> =
+        runCatching {
+            log.debug { "Getting cluster nodes" }
+
+            val nodes = client.nodes().list()
+            nodes.items.map { it.toKubernetesNode() }
+        }.onFailure { e ->
+            log.warn(e) { "Failed to get nodes" }
+        }
+
+    override fun isReachable(): Result<Boolean> =
+        runCatching {
+            log.debug { "Checking Kubernetes API reachability" }
+
+            // Try to list namespaces - a lightweight call that works on any cluster
+            client.namespaces().list()
+            true
+        }.onFailure { e ->
+            log.debug(e) { "Kubernetes API not reachable" }
+        }
+}
+
+/**
+ * Convert Fabric8 Job to KubernetesJob
+ */
+private fun Job.toKubernetesJob(): KubernetesJob {
+    val now = OffsetDateTime.now()
+    val creationTime =
+        metadata?.creationTimestamp?.let { parseK8sTimestamp(it) } ?: now
+    val age = Duration.between(creationTime, now)
+
+    val succeeded = status?.succeeded ?: 0
+    val completions = spec?.completions ?: 1
+    val completionsStr = "$succeeded/$completions"
+
+    val jobStatus =
+        when {
+            status?.active != null && status?.active!! > 0 -> "Running"
+            status?.succeeded != null && status?.succeeded!! > 0 -> "Completed"
+            status?.failed != null && status?.failed!! > 0 -> "Failed"
+            else -> "Unknown"
+        }
+
+    return KubernetesJob(
+        namespace = metadata?.namespace ?: "default",
+        name = metadata?.name ?: "unknown",
+        status = jobStatus,
+        completions = completionsStr,
+        age = age,
+    )
+}
+
+/**
+ * Convert Fabric8 Pod to KubernetesPod
+ */
+private fun Pod.toKubernetesPod(): KubernetesPod {
+    val now = OffsetDateTime.now()
+    val creationTime =
+        metadata?.creationTimestamp?.let { parseK8sTimestamp(it) } ?: now
+    val age = Duration.between(creationTime, now)
+
+    val containerStatuses = status?.containerStatuses ?: emptyList()
+    val readyContainers = containerStatuses.count { it.ready == true }
+    val totalContainers = containerStatuses.size.coerceAtLeast(spec?.containers?.size ?: 1)
+    val readyStr = "$readyContainers/$totalContainers"
+
+    val totalRestarts = containerStatuses.sumOf { it.restartCount ?: 0 }
+
+    return KubernetesPod(
+        namespace = metadata?.namespace ?: "default",
+        name = metadata?.name ?: "unknown",
+        status = status?.phase ?: "Unknown",
+        ready = readyStr,
+        restarts = totalRestarts,
+        age = age,
+    )
+}
+
+/**
+ * Convert Fabric8 Node to KubernetesNode
+ */
+private fun Node.toKubernetesNode(): KubernetesNode {
+    val labels = metadata?.labels ?: emptyMap()
+
+    // Extract roles from labels (e.g., "node-role.kubernetes.io/master" -> "master")
+    val roles =
+        labels.keys
+            .filter { it.startsWith("node-role.kubernetes.io/") }
+            .map { it.removePrefix("node-role.kubernetes.io/") }
+            .ifEmpty { listOf("<none>") }
+
+    // Get node status from conditions
+    val conditions = status?.conditions ?: emptyList()
+    val isReady = conditions.any { it.type == "Ready" && it.status == "True" }
+    val nodeStatus = if (isReady) "Ready" else "NotReady"
+
+    return KubernetesNode(
+        name = metadata?.name ?: "unknown",
+        status = nodeStatus,
+        roles = roles,
+        version = status?.nodeInfo?.kubeletVersion ?: "unknown",
+    )
+}
+
+/**
+ * Parse Kubernetes ISO 8601 timestamp string to OffsetDateTime.
+ * Handles both standard ISO format and Kubernetes format (with/without microseconds).
+ */
+private fun parseK8sTimestamp(timestamp: String): OffsetDateTime =
+    try {
+        OffsetDateTime.parse(timestamp, DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+    } catch (_: Exception) {
+        // Fallback for timestamps without offset (e.g., "2024-01-15T10:30:00Z")
+        OffsetDateTime.parse(timestamp)
+    }

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/kubernetes/KubernetesClientFactory.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/kubernetes/KubernetesClientFactory.kt
@@ -1,0 +1,48 @@
+package com.rustyrazorblade.easydblab.kubernetes
+
+import io.fabric8.kubernetes.client.Config
+import io.fabric8.kubernetes.client.KubernetesClient
+import io.fabric8.kubernetes.client.KubernetesClientBuilder
+import java.nio.file.Path
+
+/**
+ * Factory interface for creating Kubernetes clients.
+ *
+ * Abstracts the client creation to allow different configurations
+ * (direct connection, SOCKS proxy, etc.)
+ */
+interface KubernetesClientFactory {
+    /**
+     * Create a Kubernetes client from a kubeconfig file.
+     *
+     * @param kubeconfigPath Path to the kubeconfig file
+     * @return Configured KubernetesClient ready for API calls
+     */
+    fun createClient(kubeconfigPath: Path): KubernetesClient
+}
+
+/**
+ * Kubernetes client factory that configures SOCKS5 proxy for access to private clusters.
+ *
+ * This is used when accessing K3s clusters running on private IPs through an SSH tunnel.
+ *
+ * @property proxyHost The SOCKS5 proxy host (typically "localhost")
+ * @property proxyPort The SOCKS5 proxy port
+ */
+class ProxiedKubernetesClientFactory(
+    private val proxyHost: String = "localhost",
+    private val proxyPort: Int,
+) : KubernetesClientFactory {
+    override fun createClient(kubeconfigPath: Path): KubernetesClient {
+        // Load kubeconfig from file
+        val kubeconfigContent = kubeconfigPath.toFile().readText()
+        val config = Config.fromKubeconfig(kubeconfigContent)
+
+        // Configure SOCKS5 proxy
+        config.httpProxy = "socks5://$proxyHost:$proxyPort"
+
+        return KubernetesClientBuilder()
+            .withConfig(config)
+            .build()
+    }
+}

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/kubernetes/KubernetesModule.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/kubernetes/KubernetesModule.kt
@@ -1,0 +1,43 @@
+package com.rustyrazorblade.easydblab.kubernetes
+
+import com.rustyrazorblade.easydblab.Constants
+import com.rustyrazorblade.easydblab.proxy.SocksProxyService
+import org.koin.dsl.module
+import java.nio.file.Paths
+
+/**
+ * Koin module for Kubernetes-related dependency injection.
+ *
+ * Provides:
+ * - KubernetesClientFactory: Creates K8s API clients with SOCKS proxy support
+ * - KubernetesService: High-level service for K8s operations
+ *
+ * Note: Requires SocksProxyService from proxyModule and expects kubeconfig
+ * to be downloaded to the local filesystem.
+ */
+val kubernetesModule =
+    module {
+        // Kubernetes client factory - uses SOCKS proxy for private cluster access
+        factory<KubernetesClientFactory> {
+            val proxyService = get<SocksProxyService>()
+            ProxiedKubernetesClientFactory(
+                proxyHost = "localhost",
+                proxyPort = proxyService.getLocalPort(),
+            )
+        }
+
+        // Kubernetes service - factory because it holds state (API client) tied to proxy session
+        // The kubeconfigPath is resolved at runtime when the service is requested
+        factory<KubernetesService> { (kubeconfigPath: String) ->
+            DefaultKubernetesService(
+                clientFactory = get(),
+                kubeconfigPath = Paths.get(kubeconfigPath),
+            )
+        }
+    }
+
+/**
+ * Local kubeconfig path based on Constants.K3s configuration.
+ * The kubeconfig is downloaded from the control node during cluster setup.
+ */
+fun getLocalKubeconfigPath(profileDir: String): String = "$profileDir/${Constants.K3s.LOCAL_KUBECONFIG}"

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/kubernetes/KubernetesService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/kubernetes/KubernetesService.kt
@@ -1,0 +1,39 @@
+package com.rustyrazorblade.easydblab.kubernetes
+
+/**
+ * High-level service interface for Kubernetes operations.
+ *
+ * Provides business-level operations for interacting with a Kubernetes cluster.
+ * Implementations handle connection management and error handling.
+ */
+interface KubernetesService {
+    /**
+     * List jobs in the cluster.
+     *
+     * @param namespace Optional namespace to filter jobs. If null, lists jobs across all namespaces.
+     * @return Result containing list of jobs or an error
+     */
+    fun listJobs(namespace: String? = null): Result<List<KubernetesJob>>
+
+    /**
+     * List pods in the cluster.
+     *
+     * @param namespace Optional namespace to filter pods. If null, lists pods across all namespaces.
+     * @return Result containing list of pods or an error
+     */
+    fun listPods(namespace: String? = null): Result<List<KubernetesPod>>
+
+    /**
+     * Get all nodes in the cluster.
+     *
+     * @return Result containing list of nodes or an error
+     */
+    fun getNodes(): Result<List<KubernetesNode>>
+
+    /**
+     * Check if the Kubernetes API is reachable.
+     *
+     * @return Result indicating success or connection failure
+     */
+    fun isReachable(): Result<Boolean>
+}

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/kubernetes/KubernetesTypes.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/kubernetes/KubernetesTypes.kt
@@ -1,0 +1,54 @@
+package com.rustyrazorblade.easydblab.kubernetes
+
+import java.time.Duration
+
+/**
+ * Represents a Kubernetes Job
+ *
+ * @property namespace The namespace the job is in
+ * @property name The name of the job
+ * @property status The current status (e.g., "Running", "Completed", "Failed")
+ * @property completions Completion status string (e.g., "1/1", "0/3")
+ * @property age How long ago the job was created
+ */
+data class KubernetesJob(
+    val namespace: String,
+    val name: String,
+    val status: String,
+    val completions: String,
+    val age: Duration,
+)
+
+/**
+ * Represents a Kubernetes Pod
+ *
+ * @property namespace The namespace the pod is in
+ * @property name The name of the pod
+ * @property status The current status (e.g., "Running", "Pending", "Succeeded")
+ * @property ready Ready status string (e.g., "1/1", "0/1")
+ * @property restarts Number of container restarts
+ * @property age How long ago the pod was created
+ */
+data class KubernetesPod(
+    val namespace: String,
+    val name: String,
+    val status: String,
+    val ready: String,
+    val restarts: Int,
+    val age: Duration,
+)
+
+/**
+ * Represents a Kubernetes Node
+ *
+ * @property name The name of the node
+ * @property status The current status (e.g., "Ready", "NotReady")
+ * @property roles List of roles assigned to the node
+ * @property version The Kubernetes version running on the node
+ */
+data class KubernetesNode(
+    val name: String,
+    val status: String,
+    val roles: List<String>,
+    val version: String,
+)

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/providers/aws/AWSModule.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/providers/aws/AWSModule.kt
@@ -195,4 +195,9 @@ val awsModule =
                 get<OutputHandler>(),
             )
         }
+
+        // Provide SecurityGroupService as singleton
+        single<SecurityGroupService> {
+            EC2SecurityGroupService(get<Ec2Client>())
+        }
     }

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/providers/aws/SecurityGroupService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/providers/aws/SecurityGroupService.kt
@@ -1,0 +1,173 @@
+package com.rustyrazorblade.easydblab.providers.aws
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import software.amazon.awssdk.services.ec2.Ec2Client
+import software.amazon.awssdk.services.ec2.model.DescribeSecurityGroupsRequest
+
+/**
+ * Represents a security group rule info (inbound or outbound) for display purposes.
+ * Different from SecurityGroupRule which is used for creating rules.
+ *
+ * @property protocol Protocol (e.g., "TCP", "UDP", "All")
+ * @property fromPort Start of port range (null for all traffic)
+ * @property toPort End of port range (null for all traffic)
+ * @property cidrBlocks List of CIDR blocks allowed
+ * @property description Optional description of the rule
+ */
+data class SecurityGroupRuleInfo(
+    val protocol: String,
+    val fromPort: Int?,
+    val toPort: Int?,
+    val cidrBlocks: List<String>,
+    val description: String?,
+)
+
+/**
+ * Represents detailed information about a security group for status display
+ *
+ * @property securityGroupId The security group ID
+ * @property name The security group name
+ * @property description The security group description
+ * @property vpcId The VPC ID the security group belongs to
+ * @property inboundRules List of inbound (ingress) rules
+ * @property outboundRules List of outbound (egress) rules
+ */
+data class SecurityGroupDetails(
+    val securityGroupId: String,
+    val name: String,
+    val description: String,
+    val vpcId: String,
+    val inboundRules: List<SecurityGroupRuleInfo>,
+    val outboundRules: List<SecurityGroupRuleInfo>,
+)
+
+/**
+ * Service interface for security group operations.
+ */
+interface SecurityGroupService {
+    /**
+     * Get detailed information about a security group.
+     *
+     * @param securityGroupId The security group ID
+     * @return SecurityGroupDetails or null if not found
+     */
+    fun describeSecurityGroup(securityGroupId: String): SecurityGroupDetails?
+}
+
+/**
+ * AWS EC2 implementation of SecurityGroupService.
+ */
+class EC2SecurityGroupService(
+    private val ec2Client: Ec2Client,
+) : SecurityGroupService {
+    companion object {
+        private val log = KotlinLogging.logger {}
+    }
+
+    override fun describeSecurityGroup(securityGroupId: String): SecurityGroupDetails? {
+        log.debug { "Describing security group: $securityGroupId" }
+
+        val request =
+            DescribeSecurityGroupsRequest
+                .builder()
+                .groupIds(securityGroupId)
+                .build()
+
+        val response =
+            RetryUtil.withAwsRetry("describe-security-group") {
+                ec2Client.describeSecurityGroups(request)
+            }
+
+        val sg = response.securityGroups().firstOrNull() ?: return null
+
+        val inboundRules =
+            sg.ipPermissions().map { permission ->
+                SecurityGroupRuleInfo(
+                    protocol = formatProtocol(permission.ipProtocol()),
+                    fromPort = permission.fromPort(),
+                    toPort = permission.toPort(),
+                    cidrBlocks = permission.ipRanges().mapNotNull { it.cidrIp() },
+                    description =
+                        permission.ipRanges().firstOrNull()?.description()
+                            ?: getPortDescription(permission.fromPort(), permission.toPort()),
+                )
+            }
+
+        val outboundRules =
+            sg.ipPermissionsEgress().map { permission ->
+                SecurityGroupRuleInfo(
+                    protocol = formatProtocol(permission.ipProtocol()),
+                    fromPort = permission.fromPort(),
+                    toPort = permission.toPort(),
+                    cidrBlocks = permission.ipRanges().mapNotNull { it.cidrIp() },
+                    description =
+                        permission.ipRanges().firstOrNull()?.description()
+                            ?: getPortDescription(permission.fromPort(), permission.toPort()),
+                )
+            }
+
+        return SecurityGroupDetails(
+            securityGroupId = sg.groupId(),
+            name = sg.groupName(),
+            description = sg.description(),
+            vpcId = sg.vpcId(),
+            inboundRules = inboundRules,
+            outboundRules = outboundRules,
+        )
+    }
+
+    /**
+     * Format protocol for display
+     */
+    private fun formatProtocol(protocol: String): String =
+        when (protocol) {
+            "-1" -> "All"
+            else -> protocol.uppercase()
+        }
+
+    /**
+     * Get a human-readable description for common ports
+     */
+    @Suppress("MagicNumber", "CyclomaticComplexMethod")
+    private fun getPortDescription(
+        fromPort: Int?,
+        toPort: Int?,
+    ): String? {
+        if (fromPort == null || toPort == null) return "All traffic"
+        if (fromPort != toPort) return null
+
+        return when (fromPort) {
+            WellKnownPorts.SSH -> "SSH"
+            WellKnownPorts.HTTP -> "HTTP"
+            WellKnownPorts.HTTPS -> "HTTPS"
+            WellKnownPorts.MYSQL -> "MySQL"
+            WellKnownPorts.POSTGRESQL -> "PostgreSQL"
+            WellKnownPorts.REDIS -> "Redis"
+            WellKnownPorts.CASSANDRA_INTERNODE -> "Cassandra Inter-node"
+            WellKnownPorts.CASSANDRA_INTERNODE_SSL -> "Cassandra Inter-node SSL"
+            WellKnownPorts.CASSANDRA_CQL -> "Cassandra CQL"
+            WellKnownPorts.CASSANDRA_CQL_SSL -> "Cassandra CQL SSL"
+            WellKnownPorts.CASSANDRA_THRIFT -> "Cassandra Thrift"
+            WellKnownPorts.CASSANDRA_JMX -> "Cassandra JMX"
+            else -> null
+        }
+    }
+}
+
+/**
+ * Well-known port numbers for common services
+ */
+private object WellKnownPorts {
+    const val SSH = 22
+    const val HTTP = 80
+    const val HTTPS = 443
+    const val MYSQL = 3306
+    const val POSTGRESQL = 5432
+    const val REDIS = 6379
+    const val CASSANDRA_INTERNODE = 7000
+    const val CASSANDRA_INTERNODE_SSL = 7001
+    const val CASSANDRA_CQL = 9042
+    const val CASSANDRA_CQL_SSL = 9142
+    const val CASSANDRA_THRIFT = 9160
+    const val CASSANDRA_JMX = 10000
+}

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/proxy/MinaSocksProxyService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/proxy/MinaSocksProxyService.kt
@@ -1,0 +1,168 @@
+package com.rustyrazorblade.easydblab.proxy
+
+import com.rustyrazorblade.easydblab.configuration.ClusterHost
+import com.rustyrazorblade.easydblab.configuration.Host
+import com.rustyrazorblade.easydblab.providers.ssh.SSHConnectionProvider
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.apache.sshd.client.session.ClientSession
+import org.apache.sshd.common.util.net.SshdSocketAddress
+import java.net.ServerSocket
+import java.time.Instant
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+
+/**
+ * Apache MINA-based SOCKS5 proxy service using SSH dynamic port forwarding.
+ *
+ * This service creates a SOCKS5 proxy by establishing an SSH connection to a gateway host
+ * and setting up dynamic port forwarding. All traffic sent through the local proxy port
+ * is tunneled through the SSH connection.
+ *
+ * Thread-safety: Uses ReentrantLock for safe concurrent access in server mode.
+ *
+ * @property sshConnectionProvider Provider for SSH connections
+ */
+class MinaSocksProxyService(
+    private val sshConnectionProvider: SSHConnectionProvider,
+) : SocksProxyService {
+    companion object {
+        private val log = KotlinLogging.logger {}
+    }
+
+    private val lock = ReentrantLock()
+    private var session: ClientSession? = null
+    private var state: SocksProxyState? = null
+    private var localAddress: SshdSocketAddress? = null
+    private var actualLocalPort: Int = 0
+
+    override fun ensureRunning(gatewayHost: ClusterHost): SocksProxyState =
+        lock.withLock {
+            // Already running to same host? Return existing state
+            if (isRunningInternal() && state?.gatewayHost?.alias == gatewayHost.alias) {
+                state!!.connectionCount.incrementAndGet()
+                log.debug { "Proxy already running to ${gatewayHost.alias}, reusing (connections: ${state!!.connectionCount.get()})" }
+                return@withLock state!!
+            }
+
+            // Running to different host? Stop first
+            if (isRunningInternal()) {
+                log.info { "Proxy running to ${state?.gatewayHost?.alias}, switching to ${gatewayHost.alias}" }
+                stopInternal()
+            }
+
+            return@withLock startInternal(gatewayHost)
+        }
+
+    override fun start(gatewayHost: ClusterHost): SocksProxyState =
+        lock.withLock {
+            if (isRunningInternal()) {
+                if (state?.gatewayHost?.alias != gatewayHost.alias) {
+                    error("Proxy already running to ${state?.gatewayHost?.alias}, cannot start to ${gatewayHost.alias}")
+                }
+                return@withLock state!!
+            }
+            return@withLock startInternal(gatewayHost)
+        }
+
+    private fun startInternal(gatewayHost: ClusterHost): SocksProxyState {
+        // Find an available port dynamically
+        val port = findAvailablePort()
+        actualLocalPort = port
+        localAddress = SshdSocketAddress("localhost", port)
+
+        log.info { "Starting SOCKS5 proxy to ${gatewayHost.alias} (${gatewayHost.publicIp}) on port $port" }
+
+        // Convert ClusterHost to Host for SSH connection provider
+        val host = gatewayHost.toHost()
+
+        // Get SSH connection and extract the underlying session
+        val sshClient = sshConnectionProvider.getConnection(host)
+
+        // The SSHClient wraps a ClientSession - we need to access it for port forwarding
+        // We use reflection as a workaround since the interface doesn't expose the session directly
+        val clientSession = extractClientSession(sshClient)
+
+        // Start dynamic port forwarding (SOCKS5 proxy)
+        clientSession.startDynamicPortForwarding(localAddress)
+
+        session = clientSession
+        state =
+            SocksProxyState(
+                localPort = port,
+                gatewayHost = gatewayHost,
+                startTime = Instant.now(),
+            )
+
+        log.info { "SOCKS5 proxy started successfully on localhost:$port" }
+        return state!!
+    }
+
+    /**
+     * Find an available local port by binding to port 0 and letting the OS assign one.
+     */
+    private fun findAvailablePort(): Int =
+        ServerSocket(0).use { socket ->
+            socket.localPort
+        }
+
+    override fun stop() {
+        lock.withLock { stopInternal() }
+    }
+
+    private fun stopInternal() {
+        val currentState = state
+        if (currentState != null) {
+            log.info { "Stopping SOCKS5 proxy to ${currentState.gatewayHost.alias}" }
+        }
+
+        session?.let { s ->
+            localAddress?.let { addr ->
+                @Suppress("TooGenericExceptionCaught")
+                try {
+                    s.stopDynamicPortForwarding(addr)
+                    log.debug { "Dynamic port forwarding stopped" }
+                } catch (e: Exception) {
+                    log.warn(e) { "Error stopping dynamic port forwarding" }
+                }
+            }
+        }
+
+        session = null
+        state = null
+        localAddress = null
+        actualLocalPort = 0
+    }
+
+    override fun isRunning(): Boolean = lock.withLock { isRunningInternal() }
+
+    private fun isRunningInternal(): Boolean = session?.isOpen == true
+
+    override fun getState(): SocksProxyState? = lock.withLock { state }
+
+    override fun getLocalPort(): Int = actualLocalPort
+
+    /**
+     * Extract the ClientSession from an ISSHClient.
+     * This uses reflection since the interface doesn't expose the session directly.
+     */
+    private fun extractClientSession(sshClient: com.rustyrazorblade.easydblab.ssh.ISSHClient): ClientSession {
+        // The SSHClient class has a private 'session' field
+        val sshClientClass = sshClient::class.java
+        val sessionField =
+            sshClientClass.getDeclaredField("session").apply {
+                isAccessible = true
+            }
+        return sessionField.get(sshClient) as ClientSession
+    }
+}
+
+/**
+ * Extension function to convert ClusterHost to Host for SSH operations
+ */
+private fun ClusterHost.toHost(): Host =
+    Host(
+        public = this.publicIp,
+        private = this.privateIp,
+        alias = this.alias,
+        availabilityZone = this.availabilityZone,
+    )

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/proxy/ProxyModule.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/proxy/ProxyModule.kt
@@ -1,0 +1,19 @@
+package com.rustyrazorblade.easydblab.proxy
+
+import org.koin.dsl.module
+
+/**
+ * Koin module for proxy-related dependency injection.
+ *
+ * Provides:
+ * - SocksProxyService as a singleton (manages proxy lifecycle across requests in server mode)
+ *
+ * Note: SSHConnectionProvider must be provided by sshModule
+ */
+val proxyModule =
+    module {
+        // SOCKS proxy service - singleton because it maintains proxy state across requests
+        // in server mode. In CLI mode, it's started/stopped per command.
+        // Port is dynamically selected at startup to avoid conflicts.
+        single<SocksProxyService> { MinaSocksProxyService(get()) }
+    }

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/proxy/SocksProxyService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/proxy/SocksProxyService.kt
@@ -1,0 +1,79 @@
+package com.rustyrazorblade.easydblab.proxy
+
+import com.rustyrazorblade.easydblab.configuration.ClusterHost
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * State of an active SOCKS5 proxy connection
+ *
+ * @property localPort The local port the proxy listens on
+ * @property gatewayHost Full host info for the SSH gateway
+ * @property startTime When the proxy was started
+ * @property connectionCount Tracks usage in server mode
+ */
+data class SocksProxyState(
+    val localPort: Int,
+    val gatewayHost: ClusterHost,
+    val startTime: Instant,
+    val connectionCount: AtomicInteger = AtomicInteger(0),
+)
+
+/**
+ * Service interface for managing a SOCKS5 proxy via SSH dynamic port forwarding.
+ *
+ * Supports two usage modes:
+ * - CLI mode: Start proxy -> use -> stop (per-command lifecycle)
+ * - Server mode (MCP): Start proxy once -> reuse across multiple requests -> stop on shutdown
+ *
+ * The implementation is thread-safe and gateway-agnostic, meaning it can connect
+ * to any SSH-accessible host (not hardcoded to a specific node type).
+ */
+interface SocksProxyService {
+    /**
+     * Starts proxy if not running, or returns existing state if already running.
+     * Idempotent - safe to call multiple times.
+     *
+     * If a proxy is already running to a different host, it will be stopped first.
+     *
+     * @param gatewayHost The host to use as SSH gateway for the proxy
+     * @return The proxy state
+     */
+    fun ensureRunning(gatewayHost: ClusterHost): SocksProxyState
+
+    /**
+     * Explicitly start a new proxy connection.
+     *
+     * @param gatewayHost The host to use as SSH gateway for the proxy
+     * @return The proxy state
+     * @throws IllegalStateException if already running to a different host
+     */
+    fun start(gatewayHost: ClusterHost): SocksProxyState
+
+    /**
+     * Stop the proxy and release resources.
+     * Safe to call multiple times.
+     */
+    fun stop()
+
+    /**
+     * Check if proxy is currently running and healthy.
+     *
+     * @return true if the proxy is running and the underlying session is open
+     */
+    fun isRunning(): Boolean
+
+    /**
+     * Get current proxy state.
+     *
+     * @return The current state, or null if not running
+     */
+    fun getState(): SocksProxyState?
+
+    /**
+     * Get the local port the proxy listens on.
+     *
+     * @return The configured local port
+     */
+    fun getLocalPort(): Int
+}

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/BaseKoinTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/BaseKoinTest.kt
@@ -2,12 +2,14 @@ package com.rustyrazorblade.easydblab
 
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.io.TempDir
 import org.koin.core.context.GlobalContext
 import org.koin.core.context.startKoin
 import org.koin.core.context.stopKoin
 import org.koin.core.module.Module
 import org.koin.test.KoinTest
 import org.koin.test.get
+import java.io.File
 
 /**
  * Base test class that provides automatic Koin dependency injection setup and teardown.
@@ -31,6 +33,13 @@ import org.koin.test.get
  */
 abstract class BaseKoinTest : KoinTest {
     /**
+     * JUnit-managed temporary directory for test isolation.
+     * Automatically created before each test and cleaned up after.
+     */
+    @TempDir
+    lateinit var tempDir: File
+
+    /**
      * Context instance retrieved from Koin DI for use in tests. Available after setupKoin() is
      * called (automatically via @BeforeEach).
      */
@@ -44,7 +53,7 @@ abstract class BaseKoinTest : KoinTest {
      * Override this only if you need to replace core mocks (rare). Usually you want to override
      * additionalTestModules() instead.
      */
-    protected open fun coreTestModules(): List<Module> = TestModules.coreTestModules()
+    protected open fun coreTestModules(): List<Module> = TestModules.coreTestModules(tempDir)
 
     /**
      * Additional test-specific modules. Override this to add modules needed for your specific test.

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/ContextFactoryTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/ContextFactoryTest.kt
@@ -2,12 +2,9 @@ package com.rustyrazorblade.easydblab
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.io.TempDir
 import java.io.File
 
 class ContextFactoryTest : BaseKoinTest() {
-    @TempDir lateinit var tempDir: File
-
     @Test
     fun `getContext caches contexts by key`() {
         val factory = ContextFactory(tempDir)

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/ContextTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/ContextTest.kt
@@ -2,13 +2,8 @@ package com.rustyrazorblade.easydblab
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.io.TempDir
-import java.io.File
 
 class ContextTest : BaseKoinTest() {
-    @TempDir
-    lateinit var tempDir: File
-
     @Test
     fun `default Context should have isMcp false`() {
         val context = Context(tempDir)

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/TestContextFactory.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/TestContextFactory.kt
@@ -13,16 +13,17 @@ object TestContextFactory {
      * Creates a Context instance configured for testing.
      * Creates a temporary directory and a fake user configuration.
      *
+     * @param tempDir JUnit @TempDir directory for test isolation (automatically cleaned up)
      * @param workingDirectory Optional working directory for lab operations.
      *                         Use JUnit @TempDir to provide an isolated directory for tests
      *                         that perform file operations (like Clean).
      *                         If null, defaults to the test temp directory.
      */
-    fun createTestContext(workingDirectory: File? = null): Context {
-        val tmpContentParent = File("test/contexts")
-        tmpContentParent.mkdirs()
-
-        val testTempDirectory = Files.createTempDirectory(tmpContentParent.toPath(), "easydblab")
+    fun createTestContext(
+        tempDir: File,
+        workingDirectory: File? = null,
+    ): Context {
+        val testTempDirectory = Files.createTempDirectory(tempDir.toPath(), "easydblab")
         assert(testTempDirectory != null)
 
         // Create a default profile with a fake user

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/TestModules.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/TestModules.kt
@@ -34,11 +34,12 @@ object TestModules {
      * - Output handlers (to capture output for testing)
      * - SSH services (to prevent real SSH connections)
      *
+     * @param tempDir JUnit @TempDir directory for test isolation
      * @return List of core modules that should always be present in tests
      */
-    fun coreTestModules(): List<Module> =
+    fun coreTestModules(tempDir: File): List<Module> =
         listOf(
-            testContextModule(),
+            testContextModule(tempDir),
             testAWSModule(),
             testOutputModule(),
             testSSHModule(),
@@ -48,10 +49,11 @@ object TestModules {
      * Test module that provides a fresh Context instance for each test. Creates a new temporary
      * directory and test user configuration. This ensures test isolation and allows safe cleanup.
      *
+     * @param tempDir JUnit @TempDir directory for test isolation
      * @return Module providing a test Context
      */
-    fun testContextModule(): Module {
-        val testContext = TestContextFactory.createTestContext()
+    fun testContextModule(tempDir: File): Module {
+        val testContext = TestContextFactory.createTestContext(tempDir)
         val contextFactory = ContextFactory(testContext.easyDbLabUserDirectory)
         return module {
             // Include all context module definitions

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/commands/CleanTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/commands/CleanTest.kt
@@ -26,7 +26,7 @@ class CleanTest : BaseKoinTest() {
         assertThat(envFile).exists()
         assertThat(environmentFile).exists()
 
-        val testContext = TestContextFactory.createTestContext(workingDirectory = workingDir)
+        val testContext = TestContextFactory.createTestContext(tempDir, workingDirectory = workingDir)
         Clean(testContext).execute()
 
         assertThat(stateFile).doesNotExist()
@@ -43,7 +43,7 @@ class CleanTest : BaseKoinTest() {
 
         assertThat(provisioningDir).exists()
 
-        val testContext = TestContextFactory.createTestContext(workingDirectory = workingDir)
+        val testContext = TestContextFactory.createTestContext(tempDir, workingDirectory = workingDir)
         Clean(testContext).execute()
 
         assertThat(provisioningDir).doesNotExist()
@@ -58,7 +58,7 @@ class CleanTest : BaseKoinTest() {
 
         assertThat(logsDir).exists()
 
-        val testContext = TestContextFactory.createTestContext(workingDirectory = workingDir)
+        val testContext = TestContextFactory.createTestContext(tempDir, workingDirectory = workingDir)
         Clean(testContext).execute()
 
         assertThat(logsDir).doesNotExist()
@@ -73,7 +73,7 @@ class CleanTest : BaseKoinTest() {
 
         assertThat(artifactsDir).exists()
 
-        val testContext = TestContextFactory.createTestContext(workingDirectory = workingDir)
+        val testContext = TestContextFactory.createTestContext(tempDir, workingDirectory = workingDir)
         Clean(testContext).execute()
 
         // artifacts should still exist because it contains files
@@ -88,7 +88,7 @@ class CleanTest : BaseKoinTest() {
 
         assertThat(artifactsDir).exists()
 
-        val testContext = TestContextFactory.createTestContext(workingDirectory = workingDir)
+        val testContext = TestContextFactory.createTestContext(tempDir, workingDirectory = workingDir)
         Clean(testContext).execute()
 
         // artifacts should be deleted because it's empty
@@ -108,7 +108,7 @@ class CleanTest : BaseKoinTest() {
         projectRootFile.createNewFile()
 
         try {
-            val testContext = TestContextFactory.createTestContext(workingDirectory = workingDir)
+            val testContext = TestContextFactory.createTestContext(tempDir, workingDirectory = workingDir)
             Clean(testContext).execute()
 
             // Working directory file should be deleted
@@ -138,7 +138,7 @@ class CleanTest : BaseKoinTest() {
         assertThat(hostsFile).exists()
         assertThat(seedsFile).exists()
 
-        val testContext = TestContextFactory.createTestContext(workingDirectory = workingDir)
+        val testContext = TestContextFactory.createTestContext(tempDir, workingDirectory = workingDir)
         Clean(testContext).execute()
 
         assertThat(sshConfig).doesNotExist()

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/commands/StatusTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/commands/StatusTest.kt
@@ -1,0 +1,516 @@
+package com.rustyrazorblade.easydblab.commands
+
+import com.rustyrazorblade.easydblab.BaseKoinTest
+import com.rustyrazorblade.easydblab.configuration.ClusterHost
+import com.rustyrazorblade.easydblab.configuration.ClusterState
+import com.rustyrazorblade.easydblab.configuration.ClusterStateManager
+import com.rustyrazorblade.easydblab.configuration.EMRClusterState
+import com.rustyrazorblade.easydblab.configuration.InfrastructureState
+import com.rustyrazorblade.easydblab.configuration.InfrastructureStatus
+import com.rustyrazorblade.easydblab.configuration.NodeState
+import com.rustyrazorblade.easydblab.configuration.ServerType
+import com.rustyrazorblade.easydblab.configuration.User
+import com.rustyrazorblade.easydblab.output.OutputHandler
+import com.rustyrazorblade.easydblab.providers.aws.EC2InstanceService
+import com.rustyrazorblade.easydblab.providers.aws.EMRClusterStatus
+import com.rustyrazorblade.easydblab.providers.aws.EMRService
+import com.rustyrazorblade.easydblab.providers.aws.InstanceDetails
+import com.rustyrazorblade.easydblab.providers.aws.SecurityGroupDetails
+import com.rustyrazorblade.easydblab.providers.aws.SecurityGroupRuleInfo
+import com.rustyrazorblade.easydblab.providers.aws.SecurityGroupService
+import com.rustyrazorblade.easydblab.providers.ssh.RemoteOperationsService
+import com.rustyrazorblade.easydblab.proxy.SocksProxyService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.koin.core.module.Module
+import org.koin.dsl.module
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.atLeast
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.time.Instant
+
+class StatusTest : BaseKoinTest() {
+    // Create mocks upfront so they can be referenced in module and test methods
+    private val mockOutputHandler: OutputHandler = mock()
+    private val mockClusterStateManager: ClusterStateManager = mock()
+    private val mockEc2InstanceService: EC2InstanceService = mock()
+    private val mockSecurityGroupService: SecurityGroupService = mock()
+    private val mockSocksProxyService: SocksProxyService = mock()
+    private val mockRemoteOperationsService: RemoteOperationsService = mock()
+    private val mockEmrService: EMRService = mock()
+    private val mockUserConfig: User = mock()
+
+    private val testHosts =
+        mapOf(
+            ServerType.Cassandra to
+                listOf(
+                    ClusterHost(
+                        publicIp = "54.1.2.3",
+                        privateIp = "10.0.1.100",
+                        alias = "cassandra0",
+                        availabilityZone = "us-west-2a",
+                        instanceId = "i-cassandra0",
+                    ),
+                    ClusterHost(
+                        publicIp = "54.1.2.4",
+                        privateIp = "10.0.1.101",
+                        alias = "cassandra1",
+                        availabilityZone = "us-west-2b",
+                        instanceId = "i-cassandra1",
+                    ),
+                ),
+            ServerType.Stress to
+                listOf(
+                    ClusterHost(
+                        publicIp = "54.2.3.4",
+                        privateIp = "10.0.2.100",
+                        alias = "stress0",
+                        availabilityZone = "us-west-2a",
+                        instanceId = "i-stress0",
+                    ),
+                ),
+            ServerType.Control to
+                listOf(
+                    ClusterHost(
+                        publicIp = "54.3.4.5",
+                        privateIp = "10.0.3.100",
+                        alias = "control0",
+                        availabilityZone = "us-west-2a",
+                        instanceId = "i-control0",
+                    ),
+                ),
+        )
+
+    private val testInfrastructure =
+        InfrastructureState(
+            vpcId = "vpc-12345",
+            internetGatewayId = "igw-12345",
+            subnetIds = listOf("subnet-a", "subnet-b", "subnet-c"),
+            routeTableId = "rtb-12345",
+            securityGroupId = "sg-12345",
+        )
+
+    override fun additionalTestModules(): List<Module> =
+        listOf(
+            module {
+                single<OutputHandler> { mockOutputHandler }
+                single<ClusterStateManager> { mockClusterStateManager }
+                single<EC2InstanceService> { mockEc2InstanceService }
+                single<SecurityGroupService> { mockSecurityGroupService }
+                single<SocksProxyService> { mockSocksProxyService }
+                single<RemoteOperationsService> { mockRemoteOperationsService }
+                single<EMRService> { mockEmrService }
+                single<User> { mockUserConfig }
+            },
+        )
+
+    @Test
+    fun `execute displays message when cluster state does not exist`() {
+        whenever(mockClusterStateManager.exists()).thenReturn(false)
+
+        val command = Status(context)
+        command.execute()
+
+        val captor = argumentCaptor<String>()
+        verify(mockOutputHandler).handleMessage(captor.capture())
+        assertThat(captor.firstValue).contains("Cluster state does not exist")
+    }
+
+    @Test
+    fun `execute displays cluster section`() {
+        setupBasicClusterState()
+
+        val command = Status(context)
+        command.execute()
+
+        val captor = argumentCaptor<String>()
+        verify(mockOutputHandler, atLeast(5)).handleMessage(captor.capture())
+
+        val allMessages = captor.allValues.joinToString("\n")
+        assertThat(allMessages).contains("=== CLUSTER STATUS ===")
+        assertThat(allMessages).contains("Cluster ID: test-123")
+        assertThat(allMessages).contains("Name: test-cluster")
+        assertThat(allMessages).contains("Infrastructure: UP")
+    }
+
+    @Test
+    fun `execute displays nodes section with instance states`() {
+        setupBasicClusterState()
+        setupInstanceStates()
+
+        val command = Status(context)
+        command.execute()
+
+        val captor = argumentCaptor<String>()
+        verify(mockOutputHandler, atLeast(10)).handleMessage(captor.capture())
+
+        val allMessages = captor.allValues.joinToString("\n")
+        assertThat(allMessages).contains("=== NODES ===")
+        assertThat(allMessages).contains("CASSANDRA NODES")
+        assertThat(allMessages).contains("cassandra0")
+        assertThat(allMessages).contains("i-cassandra0")
+        assertThat(allMessages).contains("RUNNING")
+    }
+
+    @Test
+    fun `execute displays networking section`() {
+        setupBasicClusterState()
+
+        val command = Status(context)
+        command.execute()
+
+        val captor = argumentCaptor<String>()
+        verify(mockOutputHandler, atLeast(5)).handleMessage(captor.capture())
+
+        val allMessages = captor.allValues.joinToString("\n")
+        assertThat(allMessages).contains("=== NETWORKING ===")
+        assertThat(allMessages).contains("vpc-12345")
+        assertThat(allMessages).contains("igw-12345")
+        assertThat(allMessages).contains("subnet-a")
+    }
+
+    @Test
+    fun `execute displays security group section`() {
+        setupBasicClusterState()
+        setupSecurityGroup()
+
+        val command = Status(context)
+        command.execute()
+
+        val captor = argumentCaptor<String>()
+        verify(mockOutputHandler, atLeast(10)).handleMessage(captor.capture())
+
+        val allMessages = captor.allValues.joinToString("\n")
+        assertThat(allMessages).contains("=== SECURITY GROUP ===")
+        assertThat(allMessages).contains("sg-12345")
+        assertThat(allMessages).contains("Inbound Rules")
+        assertThat(allMessages).contains("TCP")
+        assertThat(allMessages).contains("22")
+    }
+
+    @Test
+    fun `execute handles missing infrastructure gracefully`() {
+        val clusterState =
+            ClusterState(
+                name = "test-cluster",
+                clusterId = "test-123",
+                versions = mutableMapOf(),
+                hosts = testHosts,
+                infrastructure = null,
+                infrastructureStatus = InfrastructureStatus.UP,
+                default = NodeState(version = "5.0"),
+            )
+
+        whenever(mockClusterStateManager.exists()).thenReturn(true)
+        whenever(mockClusterStateManager.load()).thenReturn(clusterState)
+        whenever(mockUserConfig.s3Bucket).thenReturn("")
+
+        val command = Status(context)
+        command.execute()
+
+        val captor = argumentCaptor<String>()
+        verify(mockOutputHandler, atLeast(5)).handleMessage(captor.capture())
+
+        val allMessages = captor.allValues.joinToString("\n")
+        assertThat(allMessages).contains("(no infrastructure data)")
+    }
+
+    @Test
+    fun `execute handles empty hosts gracefully`() {
+        val clusterState =
+            ClusterState(
+                name = "test-cluster",
+                clusterId = "test-123",
+                versions = mutableMapOf(),
+                hosts = emptyMap(),
+                infrastructure = testInfrastructure,
+                infrastructureStatus = InfrastructureStatus.UP,
+                default = NodeState(version = "5.0"),
+            )
+
+        whenever(mockClusterStateManager.exists()).thenReturn(true)
+        whenever(mockClusterStateManager.load()).thenReturn(clusterState)
+        whenever(mockUserConfig.s3Bucket).thenReturn("")
+
+        val command = Status(context)
+        command.execute()
+
+        val captor = argumentCaptor<String>()
+        verify(mockOutputHandler, atLeast(5)).handleMessage(captor.capture())
+
+        val allMessages = captor.allValues.joinToString("\n")
+        // Should not contain node headers if no nodes exist
+        assertThat(allMessages).contains("=== CLUSTER STATUS ===")
+    }
+
+    @Test
+    fun `execute displays cassandra version section with cached version when nodes unavailable`() {
+        val clusterState =
+            ClusterState(
+                name = "test-cluster",
+                clusterId = "test-123",
+                versions = mutableMapOf(),
+                hosts = testHosts,
+                infrastructure = testInfrastructure,
+                infrastructureStatus = InfrastructureStatus.UP,
+                default = NodeState(version = "5.0.2"),
+            )
+
+        whenever(mockClusterStateManager.exists()).thenReturn(true)
+        whenever(mockClusterStateManager.load()).thenReturn(clusterState)
+        whenever(mockUserConfig.s3Bucket).thenReturn("")
+        // Make getRemoteVersion throw an exception to simulate unavailable nodes
+        whenever(mockRemoteOperationsService.getRemoteVersion(any(), any()))
+            .thenThrow(RuntimeException("Connection refused"))
+
+        val command = Status(context)
+        command.execute()
+
+        val captor = argumentCaptor<String>()
+        verify(mockOutputHandler, atLeast(5)).handleMessage(captor.capture())
+
+        val allMessages = captor.allValues.joinToString("\n")
+        assertThat(allMessages).contains("=== CASSANDRA VERSION ===")
+        assertThat(allMessages).contains("5.0.2")
+        assertThat(allMessages).contains("cached")
+    }
+
+    @Test
+    fun `execute displays kubernetes jobs message when no control node`() {
+        val clusterState =
+            ClusterState(
+                name = "test-cluster",
+                clusterId = "test-123",
+                versions = mutableMapOf(),
+                hosts =
+                    mapOf(
+                        ServerType.Cassandra to testHosts[ServerType.Cassandra]!!,
+                    ),
+                infrastructure = testInfrastructure,
+                infrastructureStatus = InfrastructureStatus.UP,
+                default = NodeState(version = "5.0"),
+            )
+
+        whenever(mockClusterStateManager.exists()).thenReturn(true)
+        whenever(mockClusterStateManager.load()).thenReturn(clusterState)
+        whenever(mockUserConfig.s3Bucket).thenReturn("")
+
+        val command = Status(context)
+        command.execute()
+
+        val captor = argumentCaptor<String>()
+        verify(mockOutputHandler, atLeast(5)).handleMessage(captor.capture())
+
+        val allMessages = captor.allValues.joinToString("\n")
+        assertThat(allMessages).contains("=== KUBERNETES JOBS ===")
+        assertThat(allMessages).contains("(no control node configured)")
+    }
+
+    @Test
+    fun `execute displays spark cluster section with live state`() {
+        setupBasicClusterStateWithEmr()
+        whenever(mockEmrService.getClusterStatus("j-TESTABC123"))
+            .thenReturn(EMRClusterStatus("j-TESTABC123", "WAITING", null))
+
+        val command = Status(context)
+        command.execute()
+
+        val captor = argumentCaptor<String>()
+        verify(mockOutputHandler, atLeast(10)).handleMessage(captor.capture())
+
+        val allMessages = captor.allValues.joinToString("\n")
+        assertThat(allMessages).contains("=== SPARK CLUSTER ===")
+        assertThat(allMessages).contains("j-TESTABC123")
+        assertThat(allMessages).contains("test-spark-cluster")
+        assertThat(allMessages).contains("WAITING")
+    }
+
+    @Test
+    fun `execute displays spark cluster section with cached state when EMR unavailable`() {
+        setupBasicClusterStateWithEmr()
+        whenever(mockEmrService.getClusterStatus("j-TESTABC123"))
+            .thenThrow(RuntimeException("EMR service unavailable"))
+
+        val command = Status(context)
+        command.execute()
+
+        val captor = argumentCaptor<String>()
+        verify(mockOutputHandler, atLeast(10)).handleMessage(captor.capture())
+
+        val allMessages = captor.allValues.joinToString("\n")
+        assertThat(allMessages).contains("=== SPARK CLUSTER ===")
+        assertThat(allMessages).contains("j-TESTABC123")
+        assertThat(allMessages).contains("RUNNING") // Falls back to cached state
+    }
+
+    @Test
+    fun `execute handles missing spark cluster gracefully`() {
+        setupBasicClusterState()
+
+        val command = Status(context)
+        command.execute()
+
+        val captor = argumentCaptor<String>()
+        verify(mockOutputHandler, atLeast(5)).handleMessage(captor.capture())
+
+        val allMessages = captor.allValues.joinToString("\n")
+        assertThat(allMessages).contains("=== SPARK CLUSTER ===")
+        assertThat(allMessages).contains("(no Spark cluster configured)")
+    }
+
+    @Test
+    fun `execute displays S3 bucket section`() {
+        setupBasicClusterState()
+        whenever(mockUserConfig.s3Bucket).thenReturn("test-bucket-123")
+
+        val command = Status(context)
+        command.execute()
+
+        val captor = argumentCaptor<String>()
+        verify(mockOutputHandler, atLeast(10)).handleMessage(captor.capture())
+
+        val allMessages = captor.allValues.joinToString("\n")
+        assertThat(allMessages).contains("=== S3 BUCKET ===")
+        assertThat(allMessages).contains("test-bucket-123")
+        assertThat(allMessages).contains("spark-jars")
+        assertThat(allMessages).contains("logs")
+        assertThat(allMessages).contains("emr-logs")
+    }
+
+    @Test
+    fun `execute handles missing S3 bucket gracefully`() {
+        setupBasicClusterState()
+        whenever(mockUserConfig.s3Bucket).thenReturn("")
+
+        val command = Status(context)
+        command.execute()
+
+        val captor = argumentCaptor<String>()
+        verify(mockOutputHandler, atLeast(5)).handleMessage(captor.capture())
+
+        val allMessages = captor.allValues.joinToString("\n")
+        assertThat(allMessages).contains("=== S3 BUCKET ===")
+        assertThat(allMessages).contains("(no S3 bucket configured)")
+    }
+
+    private fun setupBasicClusterStateWithEmr() {
+        val clusterState =
+            ClusterState(
+                name = "test-cluster",
+                clusterId = "test-123",
+                versions = mutableMapOf(),
+                hosts = testHosts,
+                infrastructure = testInfrastructure,
+                infrastructureStatus = InfrastructureStatus.UP,
+                createdAt = Instant.parse("2024-01-15T10:00:00Z"),
+                default = NodeState(version = "5.0"),
+                emrCluster =
+                    EMRClusterState(
+                        clusterId = "j-TESTABC123",
+                        clusterName = "test-spark-cluster",
+                        masterPublicDns = "ec2-54-1-2-3.compute-1.amazonaws.com",
+                        state = "RUNNING",
+                    ),
+            )
+
+        whenever(mockClusterStateManager.exists()).thenReturn(true)
+        whenever(mockClusterStateManager.load()).thenReturn(clusterState)
+        whenever(mockUserConfig.s3Bucket).thenReturn("")
+    }
+
+    private fun setupBasicClusterState() {
+        val clusterState =
+            ClusterState(
+                name = "test-cluster",
+                clusterId = "test-123",
+                versions = mutableMapOf(),
+                hosts = testHosts,
+                infrastructure = testInfrastructure,
+                infrastructureStatus = InfrastructureStatus.UP,
+                createdAt = Instant.parse("2024-01-15T10:00:00Z"),
+                default = NodeState(version = "5.0"),
+            )
+
+        whenever(mockClusterStateManager.exists()).thenReturn(true)
+        whenever(mockClusterStateManager.load()).thenReturn(clusterState)
+        whenever(mockUserConfig.s3Bucket).thenReturn("")
+    }
+
+    private fun setupInstanceStates() {
+        val instanceDetails =
+            listOf(
+                InstanceDetails(
+                    instanceId = "i-cassandra0",
+                    state = "running",
+                    publicIp = "54.1.2.3",
+                    privateIp = "10.0.1.100",
+                    availabilityZone = "us-west-2a",
+                ),
+                InstanceDetails(
+                    instanceId = "i-cassandra1",
+                    state = "running",
+                    publicIp = "54.1.2.4",
+                    privateIp = "10.0.1.101",
+                    availabilityZone = "us-west-2b",
+                ),
+                InstanceDetails(
+                    instanceId = "i-stress0",
+                    state = "running",
+                    publicIp = "54.2.3.4",
+                    privateIp = "10.0.2.100",
+                    availabilityZone = "us-west-2a",
+                ),
+                InstanceDetails(
+                    instanceId = "i-control0",
+                    state = "running",
+                    publicIp = "54.3.4.5",
+                    privateIp = "10.0.3.100",
+                    availabilityZone = "us-west-2a",
+                ),
+            )
+
+        whenever(mockEc2InstanceService.describeInstances(any())).thenReturn(instanceDetails)
+    }
+
+    private fun setupSecurityGroup() {
+        val sgDetails =
+            SecurityGroupDetails(
+                securityGroupId = "sg-12345",
+                name = "test-cluster-sg",
+                description = "Security group for test cluster",
+                vpcId = "vpc-12345",
+                inboundRules =
+                    listOf(
+                        SecurityGroupRuleInfo(
+                            protocol = "TCP",
+                            fromPort = 22,
+                            toPort = 22,
+                            cidrBlocks = listOf("0.0.0.0/0"),
+                            description = "SSH",
+                        ),
+                        SecurityGroupRuleInfo(
+                            protocol = "TCP",
+                            fromPort = 9042,
+                            toPort = 9042,
+                            cidrBlocks = listOf("10.0.0.0/8"),
+                            description = "CQL",
+                        ),
+                    ),
+                outboundRules =
+                    listOf(
+                        SecurityGroupRuleInfo(
+                            protocol = "All",
+                            fromPort = null,
+                            toPort = null,
+                            cidrBlocks = listOf("0.0.0.0/0"),
+                            description = "All traffic",
+                        ),
+                    ),
+            )
+
+        whenever(mockSecurityGroupService.describeSecurityGroup("sg-12345")).thenReturn(sgDetails)
+    }
+}

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/configuration/UserConfigProviderTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/configuration/UserConfigProviderTest.kt
@@ -3,14 +3,10 @@ package com.rustyrazorblade.easydblab.configuration
 import com.rustyrazorblade.easydblab.BaseKoinTest
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.io.TempDir
 import java.io.File
 import kotlin.test.assertEquals
 
 class UserConfigProviderTest : BaseKoinTest() {
-    @TempDir
-    lateinit var tempDir: File
-
     private lateinit var userConfigProvider: UserConfigProvider
     private lateinit var profileDir: File
     private lateinit var userConfigFile: File

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/providers/aws/EC2SecurityGroupServiceTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/providers/aws/EC2SecurityGroupServiceTest.kt
@@ -1,0 +1,303 @@
+package com.rustyrazorblade.easydblab.providers.aws
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import software.amazon.awssdk.services.ec2.Ec2Client
+import software.amazon.awssdk.services.ec2.model.DescribeSecurityGroupsRequest
+import software.amazon.awssdk.services.ec2.model.DescribeSecurityGroupsResponse
+import software.amazon.awssdk.services.ec2.model.IpPermission
+import software.amazon.awssdk.services.ec2.model.IpRange
+import software.amazon.awssdk.services.ec2.model.SecurityGroup
+
+internal class EC2SecurityGroupServiceTest {
+    private val mockEc2Client: Ec2Client = mock()
+    private val securityGroupService = EC2SecurityGroupService(mockEc2Client)
+
+    @Test
+    fun `describeSecurityGroup returns null when security group not found`() {
+        val response =
+            DescribeSecurityGroupsResponse
+                .builder()
+                .securityGroups(emptyList())
+                .build()
+
+        whenever(mockEc2Client.describeSecurityGroups(any<DescribeSecurityGroupsRequest>())).thenReturn(response)
+
+        val result = securityGroupService.describeSecurityGroup("sg-nonexistent")
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `describeSecurityGroup returns details with inbound and outbound rules`() {
+        val inboundPermission =
+            IpPermission
+                .builder()
+                .ipProtocol("tcp")
+                .fromPort(22)
+                .toPort(22)
+                .ipRanges(
+                    IpRange
+                        .builder()
+                        .cidrIp("10.0.0.0/8")
+                        .description("SSH access")
+                        .build(),
+                ).build()
+
+        val outboundPermission =
+            IpPermission
+                .builder()
+                .ipProtocol("-1")
+                .ipRanges(
+                    IpRange
+                        .builder()
+                        .cidrIp("0.0.0.0/0")
+                        .build(),
+                ).build()
+
+        val securityGroup =
+            SecurityGroup
+                .builder()
+                .groupId("sg-12345")
+                .groupName("test-security-group")
+                .description("Test security group for cluster")
+                .vpcId("vpc-abc123")
+                .ipPermissions(inboundPermission)
+                .ipPermissionsEgress(outboundPermission)
+                .build()
+
+        val response =
+            DescribeSecurityGroupsResponse
+                .builder()
+                .securityGroups(securityGroup)
+                .build()
+
+        whenever(mockEc2Client.describeSecurityGroups(any<DescribeSecurityGroupsRequest>())).thenReturn(response)
+
+        val result = securityGroupService.describeSecurityGroup("sg-12345")
+
+        assertThat(result).isNotNull
+        assertThat(result!!.securityGroupId).isEqualTo("sg-12345")
+        assertThat(result.name).isEqualTo("test-security-group")
+        assertThat(result.description).isEqualTo("Test security group for cluster")
+        assertThat(result.vpcId).isEqualTo("vpc-abc123")
+
+        // Verify inbound rules
+        assertThat(result.inboundRules).hasSize(1)
+        assertThat(result.inboundRules[0].protocol).isEqualTo("TCP")
+        assertThat(result.inboundRules[0].fromPort).isEqualTo(22)
+        assertThat(result.inboundRules[0].toPort).isEqualTo(22)
+        assertThat(result.inboundRules[0].cidrBlocks).containsExactly("10.0.0.0/8")
+        assertThat(result.inboundRules[0].description).isEqualTo("SSH access")
+
+        // Verify outbound rules
+        assertThat(result.outboundRules).hasSize(1)
+        assertThat(result.outboundRules[0].protocol).isEqualTo("All")
+        assertThat(result.outboundRules[0].fromPort).isNull()
+        assertThat(result.outboundRules[0].toPort).isNull()
+        assertThat(result.outboundRules[0].cidrBlocks).containsExactly("0.0.0.0/0")
+    }
+
+    @Test
+    fun `describeSecurityGroup handles multiple CIDR blocks`() {
+        val permission =
+            IpPermission
+                .builder()
+                .ipProtocol("tcp")
+                .fromPort(9042)
+                .toPort(9042)
+                .ipRanges(
+                    IpRange.builder().cidrIp("10.0.0.0/8").build(),
+                    IpRange.builder().cidrIp("192.168.0.0/16").build(),
+                    IpRange.builder().cidrIp("172.16.0.0/12").build(),
+                ).build()
+
+        val securityGroup =
+            SecurityGroup
+                .builder()
+                .groupId("sg-multi")
+                .groupName("multi-cidr-sg")
+                .description("Security group with multiple CIDRs")
+                .vpcId("vpc-xyz")
+                .ipPermissions(permission)
+                .ipPermissionsEgress(emptyList())
+                .build()
+
+        val response =
+            DescribeSecurityGroupsResponse
+                .builder()
+                .securityGroups(securityGroup)
+                .build()
+
+        whenever(mockEc2Client.describeSecurityGroups(any<DescribeSecurityGroupsRequest>())).thenReturn(response)
+
+        val result = securityGroupService.describeSecurityGroup("sg-multi")
+
+        assertThat(result).isNotNull
+        assertThat(result!!.inboundRules).hasSize(1)
+        assertThat(result.inboundRules[0].cidrBlocks)
+            .containsExactly("10.0.0.0/8", "192.168.0.0/16", "172.16.0.0/12")
+    }
+
+    @Test
+    fun `describeSecurityGroup provides default descriptions for well-known ports`() {
+        val sshPermission =
+            IpPermission
+                .builder()
+                .ipProtocol("tcp")
+                .fromPort(22)
+                .toPort(22)
+                .ipRanges(IpRange.builder().cidrIp("0.0.0.0/0").build())
+                .build()
+
+        val cqlPermission =
+            IpPermission
+                .builder()
+                .ipProtocol("tcp")
+                .fromPort(9042)
+                .toPort(9042)
+                .ipRanges(IpRange.builder().cidrIp("10.0.0.0/8").build())
+                .build()
+
+        val securityGroup =
+            SecurityGroup
+                .builder()
+                .groupId("sg-known-ports")
+                .groupName("known-ports-sg")
+                .description("SG with well-known ports")
+                .vpcId("vpc-xyz")
+                .ipPermissions(sshPermission, cqlPermission)
+                .ipPermissionsEgress(emptyList())
+                .build()
+
+        val response =
+            DescribeSecurityGroupsResponse
+                .builder()
+                .securityGroups(securityGroup)
+                .build()
+
+        whenever(mockEc2Client.describeSecurityGroups(any<DescribeSecurityGroupsRequest>())).thenReturn(response)
+
+        val result = securityGroupService.describeSecurityGroup("sg-known-ports")
+
+        assertThat(result).isNotNull
+        assertThat(result!!.inboundRules).hasSize(2)
+
+        val sshRule = result.inboundRules.find { it.fromPort == 22 }
+        assertThat(sshRule).isNotNull
+        assertThat(sshRule!!.description).isEqualTo("SSH")
+
+        val cqlRule = result.inboundRules.find { it.fromPort == 9042 }
+        assertThat(cqlRule).isNotNull
+        assertThat(cqlRule!!.description).isEqualTo("Cassandra CQL")
+    }
+
+    @Test
+    fun `describeSecurityGroup handles port ranges`() {
+        val rangePermission =
+            IpPermission
+                .builder()
+                .ipProtocol("tcp")
+                .fromPort(7000)
+                .toPort(7001)
+                .ipRanges(IpRange.builder().cidrIp("10.0.0.0/8").build())
+                .build()
+
+        val securityGroup =
+            SecurityGroup
+                .builder()
+                .groupId("sg-range")
+                .groupName("port-range-sg")
+                .description("SG with port range")
+                .vpcId("vpc-xyz")
+                .ipPermissions(rangePermission)
+                .ipPermissionsEgress(emptyList())
+                .build()
+
+        val response =
+            DescribeSecurityGroupsResponse
+                .builder()
+                .securityGroups(securityGroup)
+                .build()
+
+        whenever(mockEc2Client.describeSecurityGroups(any<DescribeSecurityGroupsRequest>())).thenReturn(response)
+
+        val result = securityGroupService.describeSecurityGroup("sg-range")
+
+        assertThat(result).isNotNull
+        assertThat(result!!.inboundRules).hasSize(1)
+        assertThat(result.inboundRules[0].fromPort).isEqualTo(7000)
+        assertThat(result.inboundRules[0].toPort).isEqualTo(7001)
+        // Port range should not have a default description
+        assertThat(result.inboundRules[0].description).isNull()
+    }
+
+    @Test
+    fun `describeSecurityGroup handles all traffic rule`() {
+        val allTrafficPermission =
+            IpPermission
+                .builder()
+                .ipProtocol("-1")
+                .ipRanges(IpRange.builder().cidrIp("0.0.0.0/0").build())
+                .build()
+
+        val securityGroup =
+            SecurityGroup
+                .builder()
+                .groupId("sg-all")
+                .groupName("all-traffic-sg")
+                .description("SG allowing all traffic")
+                .vpcId("vpc-xyz")
+                .ipPermissions(allTrafficPermission)
+                .ipPermissionsEgress(emptyList())
+                .build()
+
+        val response =
+            DescribeSecurityGroupsResponse
+                .builder()
+                .securityGroups(securityGroup)
+                .build()
+
+        whenever(mockEc2Client.describeSecurityGroups(any<DescribeSecurityGroupsRequest>())).thenReturn(response)
+
+        val result = securityGroupService.describeSecurityGroup("sg-all")
+
+        assertThat(result).isNotNull
+        assertThat(result!!.inboundRules).hasSize(1)
+        assertThat(result.inboundRules[0].protocol).isEqualTo("All")
+        assertThat(result.inboundRules[0].fromPort).isNull()
+        assertThat(result.inboundRules[0].toPort).isNull()
+        assertThat(result.inboundRules[0].description).isEqualTo("All traffic")
+    }
+
+    @Test
+    fun `describeSecurityGroup handles empty rules`() {
+        val securityGroup =
+            SecurityGroup
+                .builder()
+                .groupId("sg-empty")
+                .groupName("empty-rules-sg")
+                .description("SG with no rules")
+                .vpcId("vpc-xyz")
+                .ipPermissions(emptyList())
+                .ipPermissionsEgress(emptyList())
+                .build()
+
+        val response =
+            DescribeSecurityGroupsResponse
+                .builder()
+                .securityGroups(securityGroup)
+                .build()
+
+        whenever(mockEc2Client.describeSecurityGroups(any<DescribeSecurityGroupsRequest>())).thenReturn(response)
+
+        val result = securityGroupService.describeSecurityGroup("sg-empty")
+
+        assertThat(result).isNotNull
+        assertThat(result!!.inboundRules).isEmpty()
+        assertThat(result.outboundRules).isEmpty()
+    }
+}

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/services/K3sServiceTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/services/K3sServiceTest.kt
@@ -3,6 +3,7 @@ package com.rustyrazorblade.easydblab.services
 import com.rustyrazorblade.easydblab.BaseKoinTest
 import com.rustyrazorblade.easydblab.configuration.Host
 import com.rustyrazorblade.easydblab.providers.ssh.RemoteOperationsService
+import com.rustyrazorblade.easydblab.proxy.SocksProxyService
 import com.rustyrazorblade.easydblab.ssh.Response
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -23,6 +24,7 @@ import org.mockito.kotlin.whenever
  */
 class K3sServiceTest : BaseKoinTest() {
     private lateinit var mockRemoteOps: RemoteOperationsService
+    private lateinit var mockSocksProxyService: SocksProxyService
     private lateinit var k3sService: K3sService
 
     private val testHost =
@@ -37,13 +39,15 @@ class K3sServiceTest : BaseKoinTest() {
         listOf(
             module {
                 single<RemoteOperationsService> { mockRemoteOps }
-                factory<K3sService> { DefaultK3sService(get(), get()) }
+                single<SocksProxyService> { mockSocksProxyService }
+                factory<K3sService> { DefaultK3sService(get(), get(), get()) }
             },
         )
 
     @BeforeEach
     fun setupMocks() {
         mockRemoteOps = mock()
+        mockSocksProxyService = mock()
         k3sService = getKoin().get()
     }
 

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/ssh/SSHClientTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/ssh/SSHClientTest.kt
@@ -7,7 +7,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.io.TempDir
 import org.koin.core.component.KoinComponent
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
@@ -31,9 +30,6 @@ import java.nio.charset.Charset
 class SSHClientTest :
     BaseKoinTest(),
     KoinComponent {
-    @TempDir
-    lateinit var tempDir: File
-
     private lateinit var mockSession: ClientSession
     private lateinit var mockIoSession: IoSession
     private lateinit var sshClient: SSHClient


### PR DESCRIPTION
## Summary

- Add new `status` command that displays comprehensive environment information
- Cluster overview (ID, name, created date, infrastructure status)
- Nodes with live instance states from EC2 (RUNNING/STOPPED/UNKNOWN)
- Networking info (VPC, IGW, subnets, route tables)
- Security group rules (inbound/outbound with ports and CIDRs)
- Kubernetes jobs running on K3s cluster via K8s Java Client
- Cassandra version (live via SSH, fallback to cached when unavailable)

### Key Components Added

- **SocksProxyService**: Thread-safe SOCKS5 proxy using Apache MINA SSHD, reusable for CLI and MCP server modes
- **KubernetesService**: Kubernetes Java Client with SOCKS proxy support for accessing K3s through the control node
- **SecurityGroupService**: EC2 security group details retrieval with human-readable port descriptions

Closes #225