### PR TITLE
Add support for ClickHouse on K3s

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,19 +358,26 @@ easy-db-lab start
 
 ```shell
 # The ephemeral or EBS disk is automatically formatted as XFS and mounted here.
-/mnt/cassandra
+/mnt/db1
 
-# data files
-/mnt/cassandra/data
+# Database-specific subdirectories
+/mnt/db1/cassandra    # Cassandra data
+/mnt/db1/clickhouse   # ClickHouse data
+/mnt/db1/otel         # OpenTelemetry logs
+
+# Cassandra data files
+/mnt/db1/cassandra/data
 
 # hints
-/mnt/cassandra/hints
+/mnt/db1/cassandra/hints
 
 # commitlogs
-/mnt/cassandra/commitlog
+/mnt/db1/cassandra/commitlog
 
-# flame graphs
-/mnt/cassandra/artifacts
+# flame graphs and artifacts
+/mnt/db1/cassandra/artifacts
+
+# Note: /mnt/cassandra symlinks to /mnt/db1/cassandra for backwards compatibility
 
 # axonops agents for different versions of Cassandra
 /usr/local/share/axonops
@@ -421,14 +428,14 @@ You may pass extra parameters, they will be passed along automatically.
 
 On each node there are several aliases for commonly run commands:
 
-| command | action                                |
-| --------|---------------------------------------|
- | c | cqlsh (auto use the correct hostname) |
-| ts | tail cassandra system log             |
-| nt | nodetool                              |
-| d | cd to /mnt/cassandra/data directory   |
-| l | list /mnt/cassandra/logs directory    |
-| v | ls -lahG (friendly output)            |
+| command | action                                     |
+| --------|---------------------------------------------|
+ | c | cqlsh (auto use the correct hostname)      |
+| ts | tail cassandra system log                  |
+| nt | nodetool                                   |
+| d | cd to /mnt/db1/cassandra/data directory    |
+| l | cd to /mnt/db1/cassandra/logs directory    |
+| v | ls -lahG (friendly output)                 |
 
 
 ### Shut it Down

--- a/bin/end-to-end-test
+++ b/bin/end-to-end-test
@@ -2,18 +2,30 @@
 
 set -e  # Exit on any error
 
+# Check if SOCKS tunnel is running (interferes with AWS API calls)
+if pgrep -f "ssh.*-D.*1080" > /dev/null 2>&1; then
+  echo "ERROR: SOCKS5 tunnel is currently running and will interfere with AWS API calls."
+  echo "Please stop it first with: socks5-stop"
+  exit 1
+fi
+
 # Store project root directory
 PROJECT_ROOT="$(pwd)"
 
-# Shorthand function for easy-db-lab
-easy-db-lab() {
-    "$PROJECT_ROOT/bin/easy-db-lab" "$@"
-}
-export -f easy-db-lab
+# Prepend bin directory to PATH so easy-db-lab uses this worktree's version
+export PATH="$PROJECT_ROOT/bin:$PATH"
+
+# Track current step for resume functionality
+CURRENT_STEP=0
+CURRENT_STEP_NAME=""
 
 # Parse command line arguments (must be before cleanup trap setup)
 WAIT_BEFORE_TEARDOWN=false
 BUILD_IMAGE=false
+NO_SPARK=false
+NO_CASSANDRA=false
+NO_CLICKHOUSE=false
+USE_EBS=false
 while [[ $# -gt 0 ]]; do
   case $1 in
     --wait)
@@ -24,9 +36,25 @@ while [[ $# -gt 0 ]]; do
       BUILD_IMAGE=true
       shift
       ;;
+    --no-spark)
+      NO_SPARK=true
+      shift
+      ;;
+    --no-cassandra)
+      NO_CASSANDRA=true
+      shift
+      ;;
+    --no-clickhouse)
+      NO_CLICKHOUSE=true
+      shift
+      ;;
+    --ebs)
+      USE_EBS=true
+      shift
+      ;;
     *)
       echo "Unknown option: $1"
-      echo "Usage: $0 [--wait] [--build]"
+      echo "Usage: $0 [--wait] [--build] [--no-spark] [--no-cassandra] [--no-clickhouse] [--ebs]"
       exit 1
       ;;
   esac
@@ -36,32 +64,391 @@ done
 TEST_WORKDIR=$(mktemp -d -t easy-db-lab-e2e-XXXXXX)
 echo "=== Using temporary work directory: $TEST_WORKDIR ==="
 
-# Cleanup function - offers options for temp directory handling
+# ============================================================================
+# Test Step Functions
+# ============================================================================
+
+step_build_project() {
+    echo "=== Building project ==="
+    if [ "$NO_SPARK" = true ]; then
+        (cd "$PROJECT_ROOT" && ./gradlew clean test shadowJar installDist)
+    else
+        (cd "$PROJECT_ROOT" && ./gradlew clean test shadowJar installDist :spark-connector-test1:jar)
+    fi
+}
+
+step_check_version() {
+    echo "=== Checking version ==="
+    easy-db-lab version
+}
+
+step_build_image() {
+    if [ "$BUILD_IMAGE" = true ]; then
+        echo "=== Building packer images ==="
+        easy-db-lab build-image
+    else
+        echo "=== Skipping packer image build (use --build to enable) ==="
+    fi
+}
+
+step_set_policies() {
+    echo "=== Creating IAM managed policies ==="
+    "$PROJECT_ROOT/bin/set-policies" --group-name EasyDBLabUsers --profile sandbox-admin
+}
+
+step_init_cluster() {
+    echo "=== Initializing cluster ==="
+    local spark_opts=""
+    if [ "$NO_SPARK" != true ]; then
+        spark_opts="--spark.enable --spark.master.instance.type m5.xlarge --spark.worker.instance.type m5.xlarge --spark.worker.instance.count 2"
+    else
+        echo "=== Spark provisioning disabled (--no-spark) ==="
+    fi
+    local ebs_opts=""
+    if [ "$USE_EBS" = true ]; then
+        ebs_opts="--ebs.type gp3 --ebs.size 256"
+        echo "=== EBS volumes enabled (gp3, 256GB) ==="
+    fi
+    easy-db-lab init -c 3 -i c5.2xlarge test --clean --up -s 1 $spark_opts $ebs_opts
+}
+
+step_setup_kubectl() {
+    echo "=== Setting up kubectl access ==="
+    source env.sh
+}
+
+step_wait_k3s_ready() {
+    echo "=== Waiting for K3s cluster to be ready ==="
+    local timeout=60
+    local elapsed=0
+    while [ $elapsed -lt $timeout ]; do
+      if kubectl get nodes &>/dev/null; then
+        echo "kubectl connectivity established"
+        return 0
+      fi
+      echo "Waiting for kubectl to connect... ($elapsed/$timeout seconds)"
+      sleep 5
+      elapsed=$((elapsed + 5))
+    done
+    echo "ERROR: kubectl failed to connect to K3s cluster after $timeout seconds"
+    return 1
+}
+
+step_verify_k3s() {
+    echo "=== Verifying K3s cluster nodes ==="
+    kubectl get nodes
+
+    echo "=== Verifying K3s system pods ==="
+    kubectl get pods -A
+
+    echo "=== Waiting for all nodes to be Ready ==="
+    kubectl wait --for=condition=Ready nodes --all --timeout=120s
+}
+
+step_list_hosts() {
+    echo "=== Listing cluster hosts ==="
+    easy-db-lab hosts
+
+    echo "=== Status Without Cassandra Version ==="
+    easy-db-lab status
+
+    echo "=== Listing available Cassandra versions ==="
+    easy-db-lab list
+}
+
+step_setup_cassandra() {
+    if [ "$NO_CASSANDRA" = true ]; then
+        echo "=== Skipping Cassandra setup (--no-cassandra enabled) ==="
+        return 0
+    fi
+    echo "=== Setting Cassandra version to 5.0 ==="
+    easy-db-lab use 5.0
+
+    echo "=== Updating configuration ==="
+    easy-db-lab update-config
+}
+
+step_cassandra_start_stop() {
+    if [ "$NO_CASSANDRA" = true ]; then
+        echo "=== Skipping Cassandra start/stop cycle (--no-cassandra enabled) ==="
+        return 0
+    fi
+    echo "=== Starting Cassandra ==="
+    easy-db-lab start
+
+    echo "=== Status With Cassandra Running ==="
+    easy-db-lab status
+
+    echo "=== Stopping Cassandra ==="
+    easy-db-lab stop
+
+    echo "=== Waiting for Cassandra to stop ==="
+    sleep 10
+
+    echo "=== Starting Cassandra again ==="
+    easy-db-lab start
+
+    echo "=== Restarting Cassandra ==="
+    easy-db-lab restart
+}
+
+step_test_ssh_nodetool() {
+    if [ "$NO_CASSANDRA" = true ]; then
+        echo "=== Skipping SSH nodetool test (--no-cassandra enabled) ==="
+        return 0
+    fi
+    echo "=== Testing SSH access and nodetool via env.sh aliases ==="
+    ssh cassandra0 nodetool status
+}
+
+step_check_sidecar() {
+    if [ "$NO_CASSANDRA" = true ]; then
+        echo "=== Skipping Sidecar check (--no-cassandra enabled) ==="
+        return 0
+    fi
+    echo "=== Check Sidecar ==="
+    ssh cassandra0 "curl -s http://$(easy-db-lab ip cassandra0 --private):9043/api/v1/cassandra/schema" | jq 'keys'
+}
+
+step_test_exec() {
+    echo "=== Testing exec command (sequential) ==="
+    easy-db-lab exec -t cassandra hostname
+
+    echo "=== Testing exec command (parallel) ==="
+    easy-db-lab exec -t cassandra -p uptime
+
+    echo "=== Testing exec command (with host filter) ==="
+    easy-db-lab exec -t cassandra --hosts cassandra0,cassandra1 date
+}
+
+step_stress_test() {
+    if [ "$NO_CASSANDRA" = true ]; then
+        echo "=== Skipping stress test (--no-cassandra enabled) ==="
+        return 0
+    fi
+    echo "=== Running stress test ==="
+    ssh stress0 "bash -l -c 'cassandra-easy-stress run KeyValue -d 10s'"
+}
+
+step_spark_submit() {
+    if [ "$NO_SPARK" = true ]; then
+        echo "=== Skipping Spark job submission (--no-spark enabled) ==="
+        return 0
+    fi
+    echo "=== Submitting Spark job to EMR ==="
+    easy-db-lab spark submit \
+      --jar "$PROJECT_ROOT/spark-connector-test1/build/libs/spark-connector-test1-12.jar" \
+      --main-class com.rustyrazorblade.easydblab.spark.KeyValuePrefixCount \
+      --args "$(easy-db-lab ip cassandra0 --private)" \
+      --wait
+}
+
+step_spark_status() {
+    if [ "$NO_SPARK" = true ]; then
+        echo "=== Skipping Spark status check (--no-spark enabled) ==="
+        return 0
+    fi
+    echo "=== Listing Spark jobs ==="
+    easy-db-lab spark jobs
+
+    echo "=== Checking Spark job status (automatically downloads logs) ==="
+    easy-db-lab spark status
+
+    echo "=== Downloading all EMR logs (standalone command) ==="
+    easy-db-lab spark logs
+}
+
+step_clickhouse_start() {
+    if [ "$NO_CLICKHOUSE" = true ]; then
+        echo "=== Skipping ClickHouse deployment (--no-clickhouse enabled) ==="
+        return 0
+    fi
+    echo "=== Deploying ClickHouse cluster ==="
+    easy-db-lab clickhouse start
+
+    echo "=== Checking ClickHouse cluster status ==="
+    easy-db-lab clickhouse status
+
+    echo "=== Waiting for ClickHouse pods to be ready ==="
+    kubectl wait --for=condition=Ready pods --all -n clickhouse --timeout=300s
+
+    echo "=== Verifying ClickHouse pods ==="
+    kubectl get pods -n clickhouse
+}
+
+step_clickhouse_test() {
+    if [ "$NO_CLICKHOUSE" = true ]; then
+        echo "=== Skipping ClickHouse test (--no-clickhouse enabled) ==="
+        return 0
+    fi
+    echo "=== Testing ClickHouse connectivity ==="
+
+    clickhouse-query "SELECT version()"
+
+    clickhouse-query <<'EOF'
+CREATE OR REPLACE TABLE test (
+    id UInt64,
+    updated_at DateTime DEFAULT now(),
+    updated_at_date Date DEFAULT toDate(updated_at)
+) ENGINE = ReplicatedMergeTree('/clickhouse/tables/{shard}/default/test', '{replica}')
+ORDER BY id
+SETTINGS storage_policy = 's3_main'
+EOF
+
+    clickhouse-query "INSERT INTO test (id) VALUES (1)"
+}
+
+step_clickhouse_stop() {
+    if [ "$NO_CLICKHOUSE" = true ]; then
+        echo "=== Skipping ClickHouse stop (--no-clickhouse enabled) ==="
+        return 0
+    fi
+    echo "=== Stopping ClickHouse cluster ==="
+    easy-db-lab clickhouse stop --force
+
+    echo "=== Verifying ClickHouse namespace is deleted ==="
+    local timeout=60
+    local elapsed=0
+    while [ $elapsed -lt $timeout ]; do
+      if ! kubectl get namespace clickhouse &>/dev/null; then
+        echo "ClickHouse namespace successfully deleted"
+        return 0
+      fi
+      echo "Waiting for ClickHouse namespace to be deleted... ($elapsed/$timeout seconds)"
+      sleep 5
+      elapsed=$((elapsed + 5))
+    done
+}
+
+step_teardown() {
+    echo "=== Tearing down cluster ==="
+    easy-db-lab down --yes
+
+    echo "=== End-to-end test completed successfully ==="
+}
+
+# ============================================================================
+# Step Registry and Runner
+# ============================================================================
+
+# Steps that run from project root (before cd to TEST_WORKDIR)
+STEPS_PROJECT_ROOT=(
+    "step_build_project:Build project"
+    "step_check_version:Check version"
+    "step_build_image:Build packer image"
+)
+
+# Steps that run from TEST_WORKDIR
+STEPS_WORKDIR=(
+    "step_set_policies:Set IAM policies"
+    "step_init_cluster:Initialize cluster"
+    "step_setup_kubectl:Setup kubectl"
+    "step_wait_k3s_ready:Wait for K3s"
+    "step_verify_k3s:Verify K3s cluster"
+    "step_list_hosts:List hosts"
+    "step_setup_cassandra:Setup Cassandra"
+    "step_cassandra_start_stop:Cassandra start/stop cycle"
+    "step_test_ssh_nodetool:Test SSH and nodetool"
+    "step_check_sidecar:Check Sidecar"
+    "step_test_exec:Test exec command"
+    "step_stress_test:Run stress test"
+    "step_spark_submit:Submit Spark job"
+    "step_spark_status:Check Spark status"
+    "step_clickhouse_start:Start ClickHouse"
+    "step_clickhouse_test:Test ClickHouse"
+    "step_clickhouse_stop:Stop ClickHouse"
+    "step_teardown:Teardown cluster"
+)
+
+# Combined steps for resume
+ALL_STEPS=("${STEPS_PROJECT_ROOT[@]}" "${STEPS_WORKDIR[@]}")
+PROJECT_ROOT_STEP_COUNT=${#STEPS_PROJECT_ROOT[@]}
+
+run_from_step() {
+    local start_step=${1:-0}
+    local total_steps=${#ALL_STEPS[@]}
+
+    for ((i=start_step; i<total_steps; i++)); do
+        CURRENT_STEP=$i
+        local step_entry="${ALL_STEPS[$i]}"
+        local step_func="${step_entry%%:*}"
+        local step_name="${step_entry#*:}"
+        CURRENT_STEP_NAME="$step_name"
+
+        echo ""
+        echo "=========================================="
+        echo "Step $((i+1))/$total_steps: $step_name"
+        echo "=========================================="
+
+        # Determine which directory to run in and execute step
+        # Disable errexit temporarily for controlled error handling
+        set +e
+        if [ $i -lt $PROJECT_ROOT_STEP_COUNT ]; then
+            pushd "$PROJECT_ROOT" > /dev/null
+            $step_func
+            local result=$?
+            popd > /dev/null
+        else
+            pushd "$TEST_WORKDIR" > /dev/null
+            [ -f env.sh ] && source env.sh
+            $step_func
+            local result=$?
+            popd > /dev/null
+        fi
+        set -e
+        if [ $result -ne 0 ]; then return 1; fi
+    done
+
+    return 0
+}
+
+# Export variables for use in subshells (e.g., zsh session)
+export PROJECT_ROOT TEST_WORKDIR
+
+# ============================================================================
+# Cleanup Function
+# ============================================================================
+
 cleanup() {
     local exit_code=$?
     if [ "$WAIT_BEFORE_TEARDOWN" != true ]; then
         while true; do
             echo ""
             echo "=== Test work directory: $TEST_WORKDIR ==="
-            echo "What would you like to do?"
-            echo "  1) Delete temporary work directory"
-            echo "  2) Start a shell session in the directory"
-            echo "  3) Keep directory and exit"
-            echo "  4) Tear down environment (easy-db-lab down --yes)"
+            if [ -n "$CURRENT_STEP_NAME" ]; then
+                echo "Failed at step $((CURRENT_STEP+1)): $CURRENT_STEP_NAME"
+            fi
             echo ""
-            read -p "Choose [1-4]: " -n 1 -r choice
+            echo "What would you like to do?"
+            echo "  1) Retry from failed step (resume test)"
+            echo "  2) Start a shell session in the directory"
+            echo "  3) Tear down environment (easy-db-lab down --yes)"
+            echo "  4) Delete temporary work directory"
+            echo "  5) Keep directory and exit"
+            echo ""
+            read -p "Choose [1-5]: " -n 1 -r choice
             echo
             case $choice in
                 1)
-                    echo "=== Cleaning up temp directory ==="
-                    rm -rf "$TEST_WORKDIR"
-                    break
+                    if [ -n "$CURRENT_STEP" ]; then
+                        echo "=== Resuming from step $((CURRENT_STEP+1)): $CURRENT_STEP_NAME ==="
+                        if run_from_step "$CURRENT_STEP"; then
+                            echo "=== Test completed successfully ==="
+                            exit_code=0
+                            break
+                        else
+                            echo "=== Step failed again ==="
+                        fi
+                    else
+                        echo "No step to retry."
+                    fi
                     ;;
                 2)
                     echo "=== Starting shell session in $TEST_WORKDIR ==="
                     echo "Available commands:"
                     echo "  easy-db-lab  - Run easy-db-lab commands"
                     echo "  rebuild      - Rebuild the project (shadowJar + installDist)"
+                    echo "  rerun        - Rebuild and resume from failed step"
                     echo "Type 'exit' to return to cleanup menu"
                     echo ""
                     (
@@ -71,19 +458,29 @@ cleanup() {
                         TEMP_ZDOTDIR=$(mktemp -d)
 
                         # Create custom .zshrc with our functions
-                        cat > "$TEMP_ZDOTDIR/.zshrc" << 'ZSHRC_EOF'
+                        cat > "$TEMP_ZDOTDIR/.zshrc" << ZSHRC_EOF
 # Easy DB Lab shell session
 
-# Define easy-db-lab function
-easy-db-lab() {
-    "$PROJECT_ROOT/bin/easy-db-lab" "$@"
-}
+# easy-db-lab is available via PATH (set by parent script)
 
 # Rebuild function - runs gradle in project root
 rebuild() {
     echo "=== Rebuilding project ==="
-    (cd "$PROJECT_ROOT" && ./gradlew shadowJar installDist)
+    (cd "\$PROJECT_ROOT" && ./gradlew shadowJar installDist)
     echo "=== Rebuild complete ==="
+}
+
+# Rerun function - rebuild and resume from failed step
+rerun() {
+    echo "=== Rebuilding project ==="
+    (cd "\$PROJECT_ROOT" && ./gradlew shadowJar installDist)
+    if [ \$? -ne 0 ]; then
+        echo "=== Rebuild failed ==="
+        return 1
+    fi
+    echo "=== Rebuild complete ==="
+    echo "=== Resuming from step $((CURRENT_STEP+1)): $CURRENT_STEP_NAME ==="
+    echo "NOTE: For full resume with proper environment, exit shell and choose option 1"
 }
 
 # Source env.sh if it exists in current directory
@@ -105,23 +502,28 @@ ZSHRC_EOF
                     # Loop back to menu after shell exits
                     ;;
                 3)
-                    echo "=== Temp directory preserved at: $TEST_WORKDIR ==="
-                    break
-                    ;;
-                4)
                     echo "=== Tearing down environment ==="
                     (
                         cd "$TEST_WORKDIR"
                         if [ -f env.sh ]; then
                             source env.sh
                         fi
-                        "$PROJECT_ROOT/bin/easy-db-lab" down --yes
+                        easy-db-lab down --yes
                     )
                     echo "=== Environment torn down ==="
                     # Loop back to menu for directory cleanup
                     ;;
+                4)
+                    echo "=== Cleaning up temp directory ==="
+                    rm -rf "$TEST_WORKDIR"
+                    break
+                    ;;
+                5)
+                    echo "=== Temp directory preserved at: $TEST_WORKDIR ==="
+                    break
+                    ;;
                 *)
-                    echo "Invalid choice. Please enter 1, 2, 3, or 4."
+                    echo "Invalid choice. Please enter 1, 2, 3, 4, or 5."
                     ;;
             esac
         done
@@ -132,148 +534,34 @@ ZSHRC_EOF
 }
 trap cleanup EXIT
 
-echo "=== Building project ==="
-./gradlew clean test shadowJar installDist :spark-connector-test1:jar
+# ============================================================================
+# Main Execution
+# ============================================================================
 
-echo "=== Checking version ==="
-"$PROJECT_ROOT/bin/easy-db-lab" version
-
-if [ "$BUILD_IMAGE" = true ]; then
-  echo "=== Building packer images ==="
-  "$PROJECT_ROOT/bin/easy-db-lab" build-image
-fi
-
-# Change to temp directory for all easy-db-lab commands that create files
+# Change to temp directory for workdir steps
 cd "$TEST_WORKDIR"
 echo "=== Changed to work directory: $(pwd) ==="
 
-echo "=== Creating IAM managed policies ==="
-"$PROJECT_ROOT/bin/set-policies" --group-name EasyDBLabUsers --profile sandbox-admin
-
-echo "=== Initializing cluster ==="
-"$PROJECT_ROOT/bin/easy-db-lab" init -c 2 -i c5.2xlarge test --clean --up -s 1 \
-  --spark.enable \
-  --spark.master.instance.type m5.xlarge \
-  --spark.worker.instance.type m5.xlarge \
-  --spark.worker.instance.count 2
-
-echo "=== Setting up kubectl access ==="
-shopt -s expand_aliases
-source env.sh
-
-echo "=== Waiting for K3s cluster to be ready ==="
-# Wait up to 60 seconds for nodes to be ready
-timeout=60
-elapsed=0
-while [ $elapsed -lt $timeout ]; do
-  if kubectl get nodes &>/dev/null; then
-    echo "kubectl connectivity established"
-    break
-  fi
-  echo "Waiting for kubectl to connect... ($elapsed/$timeout seconds)"
-  sleep 5
-  elapsed=$((elapsed + 5))
-done
-
-if [ $elapsed -ge $timeout ]; then
-  echo "ERROR: kubectl failed to connect to K3s cluster after $timeout seconds"
-  exit 1
-fi
-
-echo "=== Verifying K3s cluster nodes ==="
-kubectl get nodes
-
-echo "=== Verifying K3s system pods ==="
-kubectl get pods -A
-
-echo "=== Waiting for all nodes to be Ready ==="
-# Wait for all nodes to reach Ready state
-kubectl wait --for=condition=Ready nodes --all --timeout=120s
-
-echo "=== Listing cluster hosts ==="
-"$PROJECT_ROOT/bin/easy-db-lab" hosts
-
-echo "=== Status Without Cassandra Version ==="
-"$PROJECT_ROOT/bin/easy-db-lab" status
-
-echo "=== Listing available Cassandra versions ==="
-"$PROJECT_ROOT/bin/easy-db-lab" list
-
-echo "=== Setting Cassandra version to 5.0 ==="
-"$PROJECT_ROOT/bin/easy-db-lab" use 5.0
-
-echo "=== Updating configuration ==="
-"$PROJECT_ROOT/bin/easy-db-lab" update-config
-
-echo "=== Starting Cassandra ==="
-"$PROJECT_ROOT/bin/easy-db-lab" start
-
-echo "=== Status With Cassandra Running ==="
-"$PROJECT_ROOT/bin/easy-db-lab" status
-
-echo "=== Stopping Cassandra ==="
-"$PROJECT_ROOT/bin/easy-db-lab" stop
-
-echo "=== Waiting for Cassandra to stop ==="
-sleep 10
-
-echo "=== Starting Cassandra again ==="
-"$PROJECT_ROOT/bin/easy-db-lab" start
-
-echo "=== Restarting Cassandra ==="
-"$PROJECT_ROOT/bin/easy-db-lab" restart
-
-echo "=== Testing SSH access and nodetool via env.sh aliases ==="
-ssh cassandra0 nodetool status
-
-echo "=== Check Sidecar ==="
-ssh cassandra0 "curl http://$("$PROJECT_ROOT/bin/easy-db-lab" ip cassandra0 --private):9043/api/v1/cassandra/schema"
-
-echo "=== Testing exec command (sequential) ==="
-"$PROJECT_ROOT/bin/easy-db-lab" exec -t cassandra hostname
-
-echo "=== Testing exec command (parallel) ==="
-"$PROJECT_ROOT/bin/easy-db-lab" exec -t cassandra -p uptime
-
-echo "=== Testing exec command (with host filter) ==="
-"$PROJECT_ROOT/bin/easy-db-lab" exec -t cassandra --hosts cassandra0,cassandra1 date
-
-echo "=== Running stress test ==="
-which ssh
-ssh stress0 "bash -l -c 'cassandra-easy-stress run KeyValue -d 10s'"
-
-echo "=== Submitting Spark job to EMR ==="
-"$PROJECT_ROOT/bin/easy-db-lab" spark submit \
-  --jar "$PROJECT_ROOT/spark-connector-test1/build/libs/spark-connector-test1-12.jar" \
-  --main-class com.rustyrazorblade.easydblab.spark.KeyValuePrefixCount \
-  --args "$("$PROJECT_ROOT/bin/easy-db-lab" ip cassandra0 --private)" \
-  --wait
-
-echo "=== Listing Spark jobs ==="
-"$PROJECT_ROOT/bin/easy-db-lab" spark jobs
-
-echo "=== Checking Spark job status (automatically downloads logs) ==="
-"$PROJECT_ROOT/bin/easy-db-lab" spark status
-
-echo "=== Downloading all EMR logs (standalone command) ==="
-"$PROJECT_ROOT/bin/easy-db-lab" spark logs
-
+# Handle --wait flag for inspection before teardown
 if [ "$WAIT_BEFORE_TEARDOWN" = true ]; then
-  echo ""
-  echo "=== Cluster is ready for inspection ==="
-  echo "The cluster is now running and ready to inspect."
-  echo "Work directory: $TEST_WORKDIR"
-  echo "You can:"
-  echo "  - Run: kubectl get nodes"
-  echo "  - Run: kubectl get pods -A"
-  echo "  - SSH to nodes using the aliases from env.sh"
-  echo "  - Test Cassandra connectivity"
-  echo ""
-  read -p "Press Enter to tear down the cluster and complete the test..."
-  echo ""
+    # Run all steps except teardown
+    TOTAL_STEPS=${#ALL_STEPS[@]}
+    run_from_step 0 || exit 1
+
+    # Remove teardown from the run and prompt instead
+    echo ""
+    echo "=== Cluster is ready for inspection ==="
+    echo "The cluster is now running and ready to inspect."
+    echo "Work directory: $TEST_WORKDIR"
+    echo "You can:"
+    echo "  - Run: kubectl get nodes"
+    echo "  - Run: kubectl get pods -A"
+    echo "  - SSH to nodes using the aliases from env.sh"
+    echo "  - Test Cassandra connectivity"
+    echo ""
+    read -p "Press Enter to tear down the cluster and complete the test..."
+    echo ""
+else
+    # Run all steps
+    run_from_step 0
 fi
-
-echo "=== Tearing down cluster ==="
-"$PROJECT_ROOT/bin/easy-db-lab" down --yes
-
-echo "=== End-to-end test completed successfully ==="

--- a/bin/set-policies
+++ b/bin/set-policies
@@ -2,6 +2,13 @@
 
 set -e  # Exit on any error
 
+# Check if SOCKS tunnel is running (interferes with AWS API calls)
+if pgrep -f "ssh.*-D.*1080" > /dev/null 2>&1; then
+  echo "ERROR: SOCKS5 tunnel is currently running and will interfere with AWS API calls."
+  echo "Please stop it first with: socks5-stop"
+  exit 1
+fi
+
 # Get the directory where this script is located
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 

--- a/packer/base/aliases.sh
+++ b/packer/base/aliases.sh
@@ -1,23 +1,23 @@
 #!/usr/bin/env bash
 
 export PATH="$PATH:/usr/share/bcc/tools:/usr/local/cassandra/current/bin:/usr/local/cassandra/current/tools/bin:/usr/local/async-profiler/bin:/usr/local/cassandra-easy-stress/bin"
-export ART="/mnt/cassandra/artifacts"
+export ART="/mnt/db1/cassandra/artifacts"
 export CASSANDRA_YAML="/usr/local/cassandra/current/conf/cassandra.yaml"
 # use ubuntu users's logs directory for nodetool commands
 export CASSANDRA_LOG_DIR=/home/ubuntu/logs
 
 alias nt="nodetool"
 alias v="ls -lahG"
-alias ts="tail -f -n1000 /mnt/cassandra/logs/system.log"
+alias ts="tail -f -n1000 /mnt/db1/cassandra/logs/system.log"
 alias as="sudo tail -f /var/log/axonops/axon-agent.log"
-alias l="cd /mnt/cassandra/logs"
-alias d="cd /mnt/cassandra/data"
+alias l="cd /mnt/db1/cassandra/logs"
+alias d="cd /mnt/db1/cassandra/data"
 alias c="cqlsh $(hostname)"
 alias drop-cache="echo 3 | sudo tee /proc/sys/vm/drop_caches"
-alias heap-dump="sudo jmap -dump:live,format=b,file=/mnt/cassandra/artifacts/heapdump-$(date +%s).hprof $(cassandra-pid)"
-alias js="sudo jstack $(cassandra-pid) | tee /mnt/cassandra/artifacts/jstack-$(date +%s).txt"
-alias cdd="cd /mnt/cassandra/data"
-alias cdl="cd /mnt/cassandra/logs"
-alias cda="cd /mnt/cassandra/artifacts"
+alias heap-dump="sudo jmap -dump:live,format=b,file=/mnt/db1/cassandra/artifacts/heapdump-$(date +%s).hprof $(cassandra-pid)"
+alias js="sudo jstack $(cassandra-pid) | tee /mnt/db1/cassandra/artifacts/jstack-$(date +%s).txt"
+alias cdd="cd /mnt/db1/cassandra/data"
+alias cdl="cd /mnt/db1/cassandra/logs"
+alias cda="cd /mnt/db1/cassandra/artifacts"
 alias cdc="cd /usr/local/cassandra/current/conf"
 

--- a/packer/cassandra/bin/flamegraph
+++ b/packer/cassandra/bin/flamegraph
@@ -2,7 +2,7 @@
 
 date=$(date +"%Y-%m-%d_%H-%M-%S")
 
-OUTFILE=/mnt/cassandra/artifacts/flame-$(hostname)-${date}.html
+OUTFILE=/mnt/db1/cassandra/artifacts/flame-$(hostname)-${date}.html
 
 sudo /usr/local/async-profiler/bin/asprof -f $OUTFILE $@ $(cassandra-pid)
 

--- a/packer/cassandra/bin/iostat-plot
+++ b/packer/cassandra/bin/iostat-plot
@@ -3,12 +3,12 @@
 # requires pip install iostat-tool to be installed
 
 DEFAULT_NAME="iostat-"$(date +%s)
-OUTPUT_BASE=/mnt/cassandra/artifacts/${1:-$DEFAULT_NAME}
+OUTPUT_BASE=/mnt/db1/cassandra/artifacts/${1:-$DEFAULT_NAME}
 RAW=${OUTPUT_BASE}.output
 PLOT=${OUTPUT_BASE}.png
 ITERATIONS=60
 
-DISK=$(lsblk | grep '/mnt/cassandra' | awk '{print $1}')
+DISK=$(lsblk | grep '/mnt/db1' | awk '{print $1}')
 
 iostat -ymxt 1 $ITERATIONS | tee $RAW
 

--- a/packer/cassandra/cassandra.in.sh
+++ b/packer/cassandra/cassandra.in.sh
@@ -75,7 +75,7 @@ fi
 
 # Set log directory based on user
 if [ "$(whoami)" = "cassandra" ]; then
-    CASSANDRA_LOG_DIR="/mnt/cassandra/logs"
+    CASSANDRA_LOG_DIR="/mnt/db1/cassandra/logs"
 else
     CASSANDRA_LOG_DIR="$HOME/logs"
 fi
@@ -86,3 +86,6 @@ mkdir -p "$CASSANDRA_LOG_DIR"
 if [ "$ECL_JAVA_VERSION" = "17" ] || [ "$ECL_JAVA_VERSION" = "21" ]; then
     export JVM_OPTS="$JVM_OPTS -Xlog:gc=info:file=${CASSANDRA_LOG_DIR}/gc.log:time,uptime,pid,tid,level,tags:filecount=10,filesize=1M"
 fi
+
+# Reduce ring delay since we control the startup sequence
+export JVM_OPTS="$JVM_OPTS -Dcassandra.ring_delay_ms=1"

--- a/packer/cassandra/cassandra.pkr.hcl
+++ b/packer/cassandra/cassandra.pkr.hcl
@@ -140,8 +140,8 @@ build {
   provisioner "shell" {
     inline = [
       "sudo mkdir -p /etc/cassandra-sidecar",
-      "sudo mkdir -p /mnt/cassandra/import",
-      "sudo chown ubuntu:ubuntu /mnt/cassandra/import"
+      "sudo mkdir -p /mnt/db1/cassandra/import",
+      "sudo chown ubuntu:ubuntu /mnt/db1/cassandra/import"
     ]
   }
 

--- a/packer/cassandra/environment
+++ b/packer/cassandra/environment
@@ -1,3 +1,3 @@
 PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin:/usr/local/cassandra/current/bin:/usr/local/async-profiler/bin/:/usr/local/cassandra-sidecar/bin"
-CASSANDRA_LOG_DIR=/mnt/cassandra/tmp
-CASSANDRA_EASY_STRESS_LOG_DIR=/mnt/cassandra/artifacts
+CASSANDRA_LOG_DIR=/mnt/db1/cassandra/tmp
+CASSANDRA_EASY_STRESS_LOG_DIR=/mnt/db1/cassandra/artifacts

--- a/packer/cassandra/install/install_cassandra.sh
+++ b/packer/cassandra/install/install_cassandra.sh
@@ -95,8 +95,8 @@ sudo useradd -m cassandra
 mkdir cassandra
 
 sudo mkdir -p /usr/local/cassandra
-sudo mkdir -p /mnt/cassandra/logs
-sudo chown -R cassandra:cassandra /mnt/cassandra
+sudo mkdir -p /mnt/db1/cassandra/logs
+sudo chown -R cassandra:cassandra /mnt/db1/cassandra
 
 # Install cqlsh globally (works with all Cassandra versions)
 echo "Installing cqlsh via uv..."

--- a/packer/cassandra/services/cassandra-sidecar.service
+++ b/packer/cassandra/services/cassandra-sidecar.service
@@ -2,7 +2,7 @@
 Description=Apache Cassandra Sidecar
 
 [Service]
-Environment="JAVA_OPTS=-Dsidecar.config=file:///etc/cassandra-sidecar/cassandra-sidecar.yaml -Dsidecar.logdir=/mnt/cassandra/logs/sidecar"
+Environment="JAVA_OPTS=-Dsidecar.config=file:///etc/cassandra-sidecar/cassandra-sidecar.yaml -Dsidecar.logdir=/mnt/db1/cassandra/logs/sidecar"
 ExecStart=/usr/local/cassandra-sidecar/bin/cassandra-sidecar
 User=cassandra
 

--- a/packer/cassandra/services/cassandra.service
+++ b/packer/cassandra/services/cassandra.service
@@ -5,8 +5,8 @@ Description=Apache Cassandra
 ExecStart=/usr/local/cassandra/current/bin/cassandra -f
 ExecStop=/usr/local/cassandra/current/bin/nodetool drain
 User=cassandra
-Environment=CASSANDRA_LOG_DIR=/mnt/cassandra/logs
-Environment=CASSANDRA_HEAPDUMP_DIR=/mnt/cassandra/artifacts
+Environment=CASSANDRA_LOG_DIR=/mnt/db1/cassandra/logs
+Environment=CASSANDRA_HEAPDUMP_DIR=/mnt/db1/cassandra/artifacts
 
 [Install]
 WantedBy=multi-user.target

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/CommandLineParser.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/CommandLineParser.kt
@@ -34,6 +34,10 @@ import com.rustyrazorblade.easydblab.commands.UploadAuthorizedKeys
 import com.rustyrazorblade.easydblab.commands.UseCassandra
 import com.rustyrazorblade.easydblab.commands.Version
 import com.rustyrazorblade.easydblab.commands.WriteConfig
+import com.rustyrazorblade.easydblab.commands.clickhouse.ClickHouse
+import com.rustyrazorblade.easydblab.commands.clickhouse.ClickHouseStart
+import com.rustyrazorblade.easydblab.commands.clickhouse.ClickHouseStatus
+import com.rustyrazorblade.easydblab.commands.clickhouse.ClickHouseStop
 import com.rustyrazorblade.easydblab.commands.k8.K8
 import com.rustyrazorblade.easydblab.commands.k8.K8Apply
 import com.rustyrazorblade.easydblab.commands.spark.Spark
@@ -182,6 +186,14 @@ class CommandLineParser(
         val k8CommandLine = CommandLine(K8())
         k8CommandLine.addSubcommand("apply", K8Apply(context))
         commandLine.addSubcommand("k8", k8CommandLine)
+
+        // Register ClickHouse parent command with its sub-commands
+        // ClickHouse is a parent command for ClickHouse cluster operations on K8s
+        val clickHouseCommandLine = CommandLine(ClickHouse())
+        clickHouseCommandLine.addSubcommand("start", ClickHouseStart(context))
+        clickHouseCommandLine.addSubcommand("status", ClickHouseStatus(context))
+        clickHouseCommandLine.addSubcommand("stop", ClickHouseStop(context))
+        commandLine.addSubcommand("clickhouse", clickHouseCommandLine)
 
         // Set execution strategy to check requirements before running commands
         commandLine.executionStrategy =

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/Constants.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/Constants.kt
@@ -164,8 +164,8 @@ object Constants {
 
     // Cassandra Sidecar configuration
     object Sidecar {
-        const val STORAGE_DIR = "/mnt/cassandra/data"
-        const val STAGING_DIR = "/mnt/cassandra/import"
+        const val STORAGE_DIR = "/mnt/db1/cassandra/data"
+        const val STAGING_DIR = "/mnt/db1/cassandra/import"
     }
 
     // Remote file existence checks
@@ -186,25 +186,28 @@ object Constants {
 
     // K8s observability configuration
     object K8s {
-        const val NAMESPACE = "observability"
+        const val NAMESPACE = "default"
         const val MANIFEST_DIR = "k8s"
+        const val RESOURCE_PACKAGE = "com.rustyrazorblade.easydblab.commands.k8s"
+        const val GRAFANA_PORT = 3000
+        const val PROMETHEUS_PORT = 9090
+        const val S3MANAGER_PORT = 8080
+    }
 
-        val CORE_MANIFEST_FILES =
-            listOf(
-                "core/namespace.yaml",
-                "core/otel-service.yaml",
-                "core/otel-configmap-control.yaml",
-                "core/otel-configmap-workers.yaml",
-                "core/otel-daemonset-control.yaml",
-                "core/otel-daemonset-workers.yaml",
-                "core/prometheus-configmap.yaml",
-                "core/prometheus-deployment.yaml",
-                "core/grafana-datasource-configmap.yaml",
-                "core/grafana-dashboards-configmap.yaml",
-                "core/grafana-deployment.yaml",
-                "core/grafana-dashboard-system.yaml",
-                "core/registry-deployment.yaml",
-            )
+    // ClickHouse configuration
+    object ClickHouse {
+        const val NAMESPACE = "default"
+        const val HTTP_PORT = 8123
+        const val NATIVE_PORT = 9000
+        const val INTERSERVER_PORT = 9009
+        const val METRICS_PORT = 9363
+        const val KEEPER_CLIENT_PORT = 2181
+        const val KEEPER_RAFT_PORT = 9234
+        const val DEFAULT_REPLICAS = 2
+        const val DEFAULT_KEEPER_REPLICAS = 3
+        const val MINIMUM_NODES_REQUIRED = 3
+        const val DATA_PATH = "/mnt/db1/clickhouse"
+        const val S3_SECRET_NAME = "clickhouse-s3-credentials"
     }
 
     // Proxy configuration

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/Context.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/Context.kt
@@ -1,7 +1,6 @@
 package com.rustyrazorblade.easydblab
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.rustyrazorblade.easydblab.core.YamlDelegate
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.koin.core.component.KoinComponent
@@ -44,7 +43,6 @@ data class Context(
         profileDir.mkdirs()
     }
 
-    val cwdPath = System.getProperty("user.dir")
     val home = File(System.getProperty("user.home"))
 
     /**
@@ -64,7 +62,4 @@ data class Context(
      * val state = mapper.readValue<MyStateObject>(json)
      */
     val yaml: ObjectMapper by YamlDelegate()
-
-    // if you need to anything funky with the mapper (settings etc) use this
-    fun getJsonMapper() = jacksonObjectMapper()
 }

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/ContextFactory.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/ContextFactory.kt
@@ -9,6 +9,7 @@ import java.util.concurrent.ConcurrentHashMap
  */
 class ContextFactory(
     private val baseDirectory: File = File(System.getProperty("user.home"), "/.easy-db-lab/"),
+    private val workingDirectory: File = File(System.getProperty("user.dir")),
 ) {
     private val contextCache = ConcurrentHashMap<String, Context>()
 
@@ -33,7 +34,7 @@ class ContextFactory(
             } else {
                 File(baseDirectory, key)
             }
-        return Context(contextDir)
+        return Context(contextDir, workingDirectory = workingDirectory)
     }
 
     /**

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/SetupProfile.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/SetupProfile.kt
@@ -123,7 +123,6 @@ class SetupProfile(
                 awsSecret = awsSecret,
                 axonOpsOrg = existingConfig["axonOpsOrg"] as? String ?: "",
                 axonOpsKey = existingConfig["axonOpsKey"] as? String ?: "",
-                s3Bucket = existingConfig["s3Bucket"] as? String ?: "",
             )
 
         userConfigProvider.saveUserConfig(userConfig)
@@ -168,15 +167,10 @@ class SetupProfile(
             outputHandler.handleMessage("Key pair saved")
         }
 
-        // Create S3 bucket and IAM role if not already present
-        if (userConfig.s3Bucket.isBlank()) {
-            outputHandler.handleMessage("Creating AWS resources (S3 bucket, IAM role)...")
-
-            awsResourceSetup.ensureAWSResources(userConfig)
-            // Service saves config automatically
-
-            outputHandler.handleMessage("AWS resources created successfully")
-        }
+        // Create IAM roles if not already present
+        outputHandler.handleMessage("Ensuring IAM roles are configured...")
+        awsResourceSetup.ensureAWSResources(userConfig)
+        outputHandler.handleMessage("IAM resources validated")
 
         // Create Packer VPC infrastructure
         outputHandler.handleMessage("Creating Packer VPC infrastructure...")

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/WriteConfig.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/WriteConfig.kt
@@ -67,9 +67,9 @@ class WriteConfig(
                                         .joinToString(",")
                             }
                     }
-                val hints_directory = "/mnt/cassandra/hints"
-                val data_file_directories = listOf("/mnt/cassandra/data")
-                val commitlog_directory = "/mnt/cassandra/commitlog"
+                val hints_directory = "/mnt/db1/cassandra/hints"
+                val data_file_directories = listOf("/mnt/db1/cassandra/data")
+                val commitlog_directory = "/mnt/db1/cassandra/commitlog"
                 val concurrent_reads = DEFAULT_CONCURRENT_READS
                 val concurrent_writes = DEFAULT_CONCURRENT_WRITES
                 val trickle_fsync = true

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/clickhouse/ClickHouse.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/clickhouse/ClickHouse.kt
@@ -1,0 +1,30 @@
+package com.rustyrazorblade.easydblab.commands.clickhouse
+
+import picocli.CommandLine.Command
+import picocli.CommandLine.Model.CommandSpec
+import picocli.CommandLine.Spec
+
+/**
+ * Parent command for ClickHouse operations on K8s.
+ *
+ * This command serves as a container for ClickHouse-related sub-commands including
+ * starting, stopping, and checking status of ClickHouse clusters deployed on K3s.
+ *
+ * Available sub-commands:
+ * - start: Deploy ClickHouse cluster to K8s
+ * - status: Check ClickHouse cluster status
+ * - stop: Remove ClickHouse cluster from K8s
+ */
+@Command(
+    name = "clickhouse",
+    description = ["ClickHouse cluster operations on K8s"],
+    mixinStandardHelpOptions = true,
+)
+class ClickHouse : Runnable {
+    @Spec
+    lateinit var spec: CommandSpec
+
+    override fun run() {
+        spec.commandLine().usage(System.out)
+    }
+}

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/clickhouse/ClickHouseStart.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/clickhouse/ClickHouseStart.kt
@@ -1,0 +1,171 @@
+package com.rustyrazorblade.easydblab.commands.clickhouse
+
+import com.rustyrazorblade.easydblab.Constants
+import com.rustyrazorblade.easydblab.Context
+import com.rustyrazorblade.easydblab.annotations.McpCommand
+import com.rustyrazorblade.easydblab.annotations.RequireProfileSetup
+import com.rustyrazorblade.easydblab.commands.PicoBaseCommand
+import com.rustyrazorblade.easydblab.configuration.ServerType
+import com.rustyrazorblade.easydblab.configuration.User
+import com.rustyrazorblade.easydblab.services.K8sService
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.koin.core.component.inject
+import picocli.CommandLine.Command
+import picocli.CommandLine.Option
+
+/**
+ * Deploy ClickHouse cluster to K8s.
+ *
+ * This command deploys a ClickHouse cluster with ClickHouse Keeper
+ * for distributed coordination.
+ *
+ * Storage policies available for tables:
+ * - 'local': Local disk storage (default)
+ * - 's3_main': S3 storage with local cache
+ *
+ * Example: CREATE TABLE t (...) SETTINGS storage_policy = 's3_main';
+ */
+@McpCommand
+@RequireProfileSetup
+@Command(
+    name = "start",
+    description = ["Deploy ClickHouse cluster to K8s"],
+)
+class ClickHouseStart(
+    context: Context,
+) : PicoBaseCommand(context) {
+    private val log = KotlinLogging.logger {}
+    private val k8sService: K8sService by inject()
+    private val userConfig: User by inject()
+
+    companion object {
+        private const val K8S_MANIFEST_BASE = "k8s/clickhouse"
+        private const val DEFAULT_TIMEOUT_SECONDS = 300
+
+        // Manifests to apply in order
+        private val MANIFESTS =
+            listOf(
+                "11-clickhouse-keeper-configmap.yaml",
+                "12-clickhouse-server-configmap.yaml",
+                "14-grafana-dashboard-clickhouse.yaml",
+                "20-clickhouse-keeper-service.yaml",
+                "21-clickhouse-server-service.yaml",
+                "30-clickhouse-keeper-statefulset.yaml",
+                "31-clickhouse-server-statefulset.yaml",
+            )
+    }
+
+    @Option(
+        names = ["--timeout"],
+        description = ["Timeout in seconds to wait for pods to be ready (default: 300)"],
+    )
+    var timeoutSeconds: Int = DEFAULT_TIMEOUT_SECONDS
+
+    @Option(
+        names = ["--skip-wait"],
+        description = ["Skip waiting for pods to be ready"],
+    )
+    var skipWait: Boolean = false
+
+    @Option(
+        names = ["--replicas"],
+        description = ["Number of ClickHouse server replicas (default: number of db nodes)"],
+    )
+    var replicas: Int? = null
+
+    override fun execute() {
+        // Get control node from cluster state
+        val controlHosts = clusterState.hosts[ServerType.Control]
+        if (controlHosts.isNullOrEmpty()) {
+            error("No control nodes found. Please ensure the environment is running.")
+        }
+        val controlNode = controlHosts.first()
+        log.debug { "Using control node: ${controlNode.alias} (${controlNode.publicIp})" }
+
+        // Get db nodes for ClickHouse deployment
+        val dbHosts = clusterState.hosts[ServerType.Cassandra]
+        if (dbHosts.isNullOrEmpty()) {
+            error("No db nodes found. Please ensure the environment is running.")
+        }
+
+        // Validate minimum node count for ClickHouse Keeper coordination
+        if (dbHosts.size < Constants.ClickHouse.MINIMUM_NODES_REQUIRED) {
+            error(
+                "ClickHouse requires at least ${Constants.ClickHouse.MINIMUM_NODES_REQUIRED} nodes " +
+                    "for Keeper coordination. Found ${dbHosts.size} node(s).",
+            )
+        }
+
+        // Determine replica count: use provided value or default to number of db nodes
+        val actualReplicas = replicas ?: dbHosts.size
+
+        outputHandler.handleMessage("Deploying ClickHouse cluster with $actualReplicas replicas...")
+
+        // Create S3 secret with endpoint URL (always created for s3_main policy)
+        val bucket = clusterState.s3Bucket
+        if (!bucket.isNullOrBlank()) {
+            log.info { "Creating S3 secret for s3_main storage policy" }
+            k8sService
+                .createClickHouseS3Secret(
+                    controlNode,
+                    Constants.ClickHouse.NAMESPACE,
+                    userConfig.region,
+                    bucket,
+                ).getOrElse { exception ->
+                    log.warn { "Failed to create S3 secret: ${exception.message}" }
+                    outputHandler.handleMessage("Warning: S3 storage policy may not work (no S3 bucket configured)")
+                }
+        } else {
+            outputHandler.handleMessage("Note: S3 bucket not configured. Only 'local' storage policy available.")
+        }
+
+        // Apply all manifests
+        log.info { "Applying ClickHouse manifests" }
+        for (manifest in MANIFESTS) {
+            val resourcePath = "$K8S_MANIFEST_BASE/$manifest"
+            log.info { "Applying manifest: $resourcePath" }
+            k8sService
+                .applyManifestFromResources(controlNode, resourcePath)
+                .getOrElse { exception ->
+                    error("Failed to apply manifest $manifest: ${exception.message}")
+                }
+        }
+
+        // Scale the ClickHouse StatefulSet to the desired replica count
+        k8sService
+            .scaleStatefulSet(controlNode, Constants.ClickHouse.NAMESPACE, "clickhouse", actualReplicas)
+            .getOrElse { exception ->
+                error("Failed to scale ClickHouse StatefulSet: ${exception.message}")
+            }
+
+        // Wait for pods to be ready
+        if (!skipWait) {
+            outputHandler.handleMessage("Waiting for ClickHouse pods to be ready (this may take a few minutes)...")
+            k8sService
+                .waitForPodsReady(controlNode, timeoutSeconds, Constants.ClickHouse.NAMESPACE)
+                .getOrElse { exception ->
+                    outputHandler.handleError("Warning: Pods may not be ready: ${exception.message}")
+                    outputHandler.handleMessage("You can check status with: easy-db-lab clickhouse status")
+                }
+        }
+
+        val dbNodeIp = dbHosts.first().privateIp
+
+        // Display access information
+        outputHandler.handleMessage("")
+        outputHandler.handleMessage("ClickHouse cluster deployed successfully!")
+        outputHandler.handleMessage("")
+        outputHandler.handleMessage("Storage policies available:")
+        outputHandler.handleMessage("  - local: Local disk storage")
+        if (!bucket.isNullOrBlank()) {
+            outputHandler.handleMessage("  - s3_main: S3 with local cache (bucket: $bucket)")
+        }
+        outputHandler.handleMessage("")
+        outputHandler.handleMessage("Example: CREATE TABLE t (...) SETTINGS storage_policy = 's3_main';")
+        outputHandler.handleMessage("")
+        outputHandler.handleMessage("HTTP Interface: http://$dbNodeIp:${Constants.ClickHouse.HTTP_PORT}")
+        outputHandler.handleMessage("Native Protocol: $dbNodeIp:${Constants.ClickHouse.NATIVE_PORT}")
+        outputHandler.handleMessage("")
+        outputHandler.handleMessage("Connect with: clickhouse-client --host $dbNodeIp")
+    }
+}

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/clickhouse/ClickHouseStatus.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/clickhouse/ClickHouseStatus.kt
@@ -1,0 +1,66 @@
+package com.rustyrazorblade.easydblab.commands.clickhouse
+
+import com.rustyrazorblade.easydblab.Constants
+import com.rustyrazorblade.easydblab.Context
+import com.rustyrazorblade.easydblab.annotations.McpCommand
+import com.rustyrazorblade.easydblab.annotations.RequireProfileSetup
+import com.rustyrazorblade.easydblab.commands.PicoBaseCommand
+import com.rustyrazorblade.easydblab.configuration.ServerType
+import com.rustyrazorblade.easydblab.output.displayClickHouseAccess
+import com.rustyrazorblade.easydblab.output.displayS3ManagerClickHouseAccess
+import com.rustyrazorblade.easydblab.services.K8sService
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.koin.core.component.inject
+import picocli.CommandLine.Command
+
+/**
+ * Check the status of the ClickHouse cluster on K8s.
+ *
+ * Displays the current state of all ClickHouse pods including
+ * Keeper nodes and server nodes.
+ */
+@McpCommand
+@RequireProfileSetup
+@Command(
+    name = "status",
+    description = ["Check ClickHouse cluster status"],
+)
+class ClickHouseStatus(
+    context: Context,
+) : PicoBaseCommand(context) {
+    private val log = KotlinLogging.logger {}
+    private val k8sService: K8sService by inject()
+
+    override fun execute() {
+        val controlHosts = clusterState.hosts[ServerType.Control]
+        if (controlHosts.isNullOrEmpty()) {
+            error("No control nodes found. Please ensure the environment is running.")
+        }
+        val controlNode = controlHosts.first()
+        log.debug { "Using control node: ${controlNode.alias} (${controlNode.publicIp})" }
+
+        // Get a db node IP for ClickHouse access (ClickHouse pods run on db nodes)
+        val dbHosts = clusterState.hosts[ServerType.Cassandra]
+        if (dbHosts.isNullOrEmpty()) {
+            error("No db nodes found. Please ensure the environment is running.")
+        }
+        val dbNodeIp = dbHosts.first().privateIp
+
+        val status =
+            k8sService
+                .getNamespaceStatus(controlNode, Constants.ClickHouse.NAMESPACE)
+                .getOrElse { exception ->
+                    error("Failed to get ClickHouse status: ${exception.message}")
+                }
+
+        outputHandler.handleMessage("ClickHouse Cluster Status:")
+        outputHandler.handleMessage("")
+        outputHandler.handleMessage(status)
+        outputHandler.displayClickHouseAccess(dbNodeIp)
+
+        val s3Bucket = clusterState.s3Bucket
+        if (!s3Bucket.isNullOrBlank()) {
+            outputHandler.displayS3ManagerClickHouseAccess(controlNode.privateIp, s3Bucket)
+        }
+    }
+}

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/clickhouse/ClickHouseStop.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/clickhouse/ClickHouseStop.kt
@@ -1,0 +1,67 @@
+package com.rustyrazorblade.easydblab.commands.clickhouse
+
+import com.rustyrazorblade.easydblab.Constants
+import com.rustyrazorblade.easydblab.Context
+import com.rustyrazorblade.easydblab.annotations.McpCommand
+import com.rustyrazorblade.easydblab.annotations.RequireProfileSetup
+import com.rustyrazorblade.easydblab.commands.PicoBaseCommand
+import com.rustyrazorblade.easydblab.configuration.ServerType
+import com.rustyrazorblade.easydblab.services.K8sService
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.koin.core.component.inject
+import picocli.CommandLine.Command
+import picocli.CommandLine.Option
+
+/**
+ * Stop and remove the ClickHouse cluster from K8s.
+ *
+ * This command deletes all ClickHouse resources by label selector,
+ * including Keeper nodes, server nodes, and persistent volume claims.
+ */
+@McpCommand
+@RequireProfileSetup
+@Command(
+    name = "stop",
+    description = ["Stop and remove ClickHouse cluster from K8s"],
+)
+class ClickHouseStop(
+    context: Context,
+) : PicoBaseCommand(context) {
+    private val log = KotlinLogging.logger {}
+    private val k8sService: K8sService by inject()
+
+    @Option(
+        names = ["--force"],
+        description = ["Force deletion without confirmation"],
+    )
+    var force: Boolean = false
+
+    override fun execute() {
+        val controlHosts = clusterState.hosts[ServerType.Control]
+        if (controlHosts.isNullOrEmpty()) {
+            error("No control nodes found. Please ensure the environment is running.")
+        }
+        val controlNode = controlHosts.first()
+        log.debug { "Using control node: ${controlNode.alias} (${controlNode.publicIp})" }
+
+        if (!force) {
+            outputHandler.handleMessage("This will delete the ClickHouse cluster and all its data.")
+            outputHandler.handleMessage("Use --force to confirm deletion.")
+            return
+        }
+
+        outputHandler.handleMessage("Stopping ClickHouse cluster...")
+
+        // Delete ClickHouse resources by label selector
+        val labelKey = "app.kubernetes.io/name"
+        val labelValues = listOf("clickhouse-server", "clickhouse-keeper")
+
+        k8sService
+            .deleteResourcesByLabel(controlNode, Constants.ClickHouse.NAMESPACE, labelKey, labelValues)
+            .getOrElse { exception ->
+                error("Failed to delete ClickHouse cluster: ${exception.message}")
+            }
+
+        outputHandler.handleMessage("ClickHouse cluster stopped and removed successfully.")
+    }
+}

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/k8/K8Apply.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/k8/K8Apply.kt
@@ -5,6 +5,7 @@ import com.rustyrazorblade.easydblab.annotations.McpCommand
 import com.rustyrazorblade.easydblab.annotations.RequireProfileSetup
 import com.rustyrazorblade.easydblab.commands.PicoBaseCommand
 import com.rustyrazorblade.easydblab.configuration.ServerType
+import com.rustyrazorblade.easydblab.output.displayObservabilityAccess
 import com.rustyrazorblade.easydblab.services.K8sService
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.koin.core.component.inject
@@ -57,8 +58,6 @@ class K8Apply(
 
     companion object {
         private const val K8S_CORE_MANIFEST_DIR = "k8s/core"
-        private const val GRAFANA_PORT = 3000
-        private const val PROMETHEUS_PORT = 9090
     }
 
     override fun execute() {
@@ -94,9 +93,6 @@ class K8Apply(
         // Display access information
         outputHandler.handleMessage("")
         outputHandler.handleMessage("Observability stack deployed successfully!")
-        outputHandler.handleMessage("  Grafana:    http://${controlNode.publicIp}:$GRAFANA_PORT")
-        outputHandler.handleMessage("  Prometheus: http://${controlNode.publicIp}:$PROMETHEUS_PORT")
-        outputHandler.handleMessage("")
-        outputHandler.handleMessage("Grafana credentials: admin/admin")
+        outputHandler.displayObservabilityAccess(controlNode.privateIp)
     }
 }

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/spark/SparkSubmit.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/spark/SparkSubmit.kt
@@ -4,7 +4,6 @@ import com.rustyrazorblade.easydblab.Context
 import com.rustyrazorblade.easydblab.annotations.McpCommand
 import com.rustyrazorblade.easydblab.annotations.RequireProfileSetup
 import com.rustyrazorblade.easydblab.commands.PicoBaseCommand
-import com.rustyrazorblade.easydblab.configuration.User
 import com.rustyrazorblade.easydblab.configuration.s3Path
 import com.rustyrazorblade.easydblab.services.ObjectStore
 import com.rustyrazorblade.easydblab.services.SparkService
@@ -31,7 +30,6 @@ class SparkSubmit(
 ) : PicoBaseCommand(context) {
     private val sparkService: SparkService by inject()
     private val objectStore: ObjectStore by inject()
-    private val userConfig: User by inject()
 
     @Option(
         names = ["--jar"],
@@ -122,8 +120,8 @@ class SparkSubmit(
         val clusterState = clusterStateManager.load()
 
         // Build cluster-specific S3 path using ClusterS3Path API
-        val s3Path = clusterState.s3Path(userConfig)
-        val jarS3Path = s3Path.sparkJars().resolve(localFile.name)
+        val s3Path = clusterState.s3Path()
+        val jarS3Path = s3Path.spark().resolve(localFile.name)
 
         // Upload using ObjectStore (handles retry logic and progress)
         val result = objectStore.uploadFile(localFile, jarS3Path, showProgress = true)

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/ClusterConfigWriter.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/ClusterConfigWriter.kt
@@ -43,11 +43,13 @@ object ClusterConfigWriter {
      * @param writer BufferedWriter to write environment file to
      * @param hosts Map of server types to their hosts
      * @param identityFile Path to the SSH identity file (for embedded SSH config generation)
+     * @param clusterName Name of the cluster for prompt customization
      */
     fun writeEnvironmentFile(
         writer: BufferedWriter,
         hosts: Map<ServerType, List<ClusterHost>>,
         identityFile: String,
+        clusterName: String,
     ) {
         // write the initial SSH aliases
         writer.appendLine("#!/bin/bash")
@@ -60,6 +62,12 @@ object ClusterConfigWriter {
             i++
         }
         writer.appendLine(")")
+
+        // Cluster metadata for prompt customization
+        writer.appendLine("CLUSTER_NAME=\"$clusterName\"")
+        writer.appendLine("DB_NODE_COUNT=${hosts[ServerType.Cassandra]?.size ?: 0}")
+        writer.appendLine("APP_NODE_COUNT=${hosts[ServerType.Stress]?.size ?: 0}")
+        writer.appendLine()
 
         i = 0
         hosts[ServerType.Cassandra]?.forEach { _ ->

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/ClusterState.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/ClusterState.kt
@@ -152,6 +152,8 @@ data class ClusterState(
     var emrCluster: EMRClusterState? = null,
     // Infrastructure resource IDs for cleanup
     var infrastructure: InfrastructureState? = null,
+    // S3 bucket for this environment (per-cluster bucket, created during 'up')
+    var s3Bucket: String? = null,
 ) {
     /**
      * Update hosts
@@ -228,18 +230,18 @@ data class ClusterState(
 }
 
 /**
- * Extension function to create a ClusterS3Path from ClusterState and User configuration.
- * Provides convenient access to cluster-namespaced S3 paths.
+ * Extension function to create a ClusterS3Path from ClusterState.
+ * Provides convenient access to S3 paths for this environment's bucket.
  *
  * Example:
  * ```
  * val manager = ClusterStateManager()
  * val state = manager.load()
- * val s3Path = state.s3Path(userConfig)
- * val jarPath = s3Path.sparkJars().resolve("myapp.jar")
+ * val s3Path = state.s3Path()
+ * val jarPath = s3Path.spark().resolve("myapp.jar")
  * ```
  *
- * @param user The user configuration containing s3Bucket
- * @return A ClusterS3Path rooted at this cluster's namespace
+ * @return A ClusterS3Path for this cluster's S3 bucket
+ * @throws IllegalStateException if s3Bucket is not configured
  */
-fun ClusterState.s3Path(user: User): ClusterS3Path = ClusterS3Path.from(this, user)
+fun ClusterState.s3Path(): ClusterS3Path = ClusterS3Path.from(this)

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/User.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/User.kt
@@ -41,7 +41,6 @@ data class User(
     var awsSecret: String,
     var axonOpsOrg: String = "",
     var axonOpsKey: String = "",
-    var s3Bucket: String = "",
 ) {
     companion object {
         val log = KotlinLogging.logger {}
@@ -186,22 +185,5 @@ data class User(
                 throw e
             }
         }
-
-        /**
-         * Generates a valid S3 bucket name if the user doesn't have one.
-         * Generated names follow the pattern: easy-db-lab-{uuid} (lowercase).
-         *
-         * NOTE: This method does NOT modify the User object. Callers must update
-         * the User object after successfully creating the S3 bucket.
-         *
-         * @param user The User object to check
-         * @return The bucket name (existing or newly generated)
-         */
-        fun generateBucketName(user: User): String =
-            if (user.s3Bucket.isBlank()) {
-                "easy-db-lab-${UUID.randomUUID()}".lowercase()
-            } else {
-                user.s3Bucket
-            }
     }
 }

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/kubernetes/ManifestApplier.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/kubernetes/ManifestApplier.kt
@@ -1,5 +1,8 @@
 package com.rustyrazorblade.easydblab.kubernetes
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import io.fabric8.kubernetes.client.KubernetesClient
 import io.github.oshai.kotlinlogging.KotlinLogging
 import java.io.ByteArrayInputStream
@@ -17,9 +20,11 @@ import java.io.File
  */
 object ManifestApplier {
     private val log = KotlinLogging.logger {}
+    private val yamlMapper = ObjectMapper(YAMLFactory()).registerKotlinModule()
 
     /**
      * Apply a manifest file to the cluster using server-side apply.
+     * Supports multi-document YAML files (documents separated by ---).
      *
      * @param client Kubernetes client
      * @param file Manifest file to apply
@@ -31,23 +36,59 @@ object ManifestApplier {
         file: File,
     ) {
         val yamlContent = file.readText()
-        val kind = extractKind(yamlContent)
-        val resourceName = extractName(yamlContent)
+        val documents = parseYamlDocuments(yamlContent)
 
-        log.info { "Applying $kind resource '$resourceName' from ${file.name}" }
-        log.debug { "YAML content:\n$yamlContent" }
+        log.info { "Processing ${file.name} with ${documents.size} document(s)" }
 
-        try {
-            applyYaml(client, yamlContent, kind)
-            log.info { "Successfully applied $kind '$resourceName'" }
-        } catch (e: Exception) {
-            log.error(e) { "Failed to apply $kind '$resourceName': ${e.message}" }
-            throw e
+        for ((index, document) in documents.withIndex()) {
+            val kind =
+                document["kind"] as? String
+                    ?: error("Document ${index + 1} in ${file.name} missing 'kind' field")
+
+            @Suppress("UNCHECKED_CAST")
+            val metadata = document["metadata"] as? Map<String, Any>
+            val resourceName = metadata?.get("name") as? String ?: "unknown"
+
+            val documentYaml = yamlMapper.writeValueAsString(document)
+
+            log.info { "Applying document ${index + 1}/${documents.size}: $kind '$resourceName' from ${file.name}" }
+            log.debug { "YAML content:\n$documentYaml" }
+
+            try {
+                applySingleDocument(client, documentYaml, kind)
+                log.info { "Successfully applied $kind '$resourceName'" }
+            } catch (e: Exception) {
+                log.error(e) { "Failed to apply $kind '$resourceName': ${e.message}" }
+                throw e
+            }
         }
     }
 
     /**
+     * Parse a YAML file that may contain multiple documents.
+     * Returns a list of parsed documents as Maps.
+     *
+     * @param yamlContent YAML content (may contain multiple documents separated by ---)
+     * @return List of parsed documents
+     */
+    @Suppress("UNCHECKED_CAST")
+    private fun parseYamlDocuments(yamlContent: String): List<Map<String, Any>> {
+        val factory = YAMLFactory()
+        val parser = factory.createParser(yamlContent)
+        val documents = mutableListOf<Map<String, Any>>()
+
+        while (parser.nextToken() != null) {
+            val doc = yamlMapper.readValue(parser, Map::class.java) as? Map<String, Any>
+            if (doc != null) {
+                documents.add(doc)
+            }
+        }
+        return documents
+    }
+
+    /**
      * Apply YAML content to the cluster using server-side apply.
+     * Supports multi-document YAML (documents separated by ---).
      *
      * @param client Kubernetes client
      * @param yamlContent YAML content to apply
@@ -57,85 +98,101 @@ object ManifestApplier {
         client: KubernetesClient,
         yamlContent: String,
     ) {
-        val kind = extractKind(yamlContent)
-        applyYaml(client, yamlContent, kind)
+        val documents = parseYamlDocuments(yamlContent)
+
+        for ((index, document) in documents.withIndex()) {
+            val kind =
+                document["kind"] as? String
+                    ?: error("Document ${index + 1} missing 'kind' field")
+
+            val documentYaml = yamlMapper.writeValueAsString(document)
+            applySingleDocument(client, documentYaml, kind)
+        }
     }
 
-    private fun applyYaml(
+    private fun applySingleDocument(
         client: KubernetesClient,
         yamlContent: String,
         kind: String,
     ) {
+        log.debug { "Loading $kind via typed loader" }
         ByteArrayInputStream(yamlContent.toByteArray()).use { stream ->
             when (kind) {
-                "Namespace" -> {
-                    log.debug { "Loading Namespace via typed loader" }
-                    client
-                        .namespaces()
-                        .load(stream)
-                        .forceConflicts()
-                        .serverSideApply()
-                }
-                "ConfigMap" -> {
-                    log.debug { "Loading ConfigMap via typed loader" }
-                    client
-                        .configMaps()
-                        .load(stream)
-                        .forceConflicts()
-                        .serverSideApply()
-                }
-                "Service" -> {
-                    log.debug { "Loading Service via typed loader" }
-                    client
-                        .services()
-                        .load(stream)
-                        .forceConflicts()
-                        .serverSideApply()
-                }
-                "DaemonSet" -> {
-                    log.debug { "Loading DaemonSet via typed loader" }
-                    client
-                        .apps()
-                        .daemonSets()
-                        .load(stream)
-                        .forceConflicts()
-                        .serverSideApply()
-                }
-                "Deployment" -> {
-                    log.debug { "Loading Deployment via typed loader" }
-                    client
-                        .apps()
-                        .deployments()
-                        .load(stream)
-                        .forceConflicts()
-                        .serverSideApply()
-                }
-                else -> throw IllegalStateException("Unsupported resource kind: $kind")
+                "Namespace" -> applyNamespace(client, stream)
+                "ConfigMap" -> applyConfigMap(client, stream)
+                "Service" -> applyService(client, stream)
+                "DaemonSet" -> applyDaemonSet(client, stream)
+                "Deployment" -> applyDeployment(client, stream)
+                "StatefulSet" -> applyStatefulSet(client, stream)
+                "Secret" -> applySecret(client, stream)
+                else -> error("Unsupported resource kind: $kind")
             }
         }
     }
 
-    /**
-     * Extract the kind field from a YAML manifest.
-     *
-     * @param yamlContent YAML content
-     * @return The resource kind (e.g., "Namespace", "ConfigMap")
-     * @throws IllegalStateException if kind cannot be determined
-     */
-    fun extractKind(yamlContent: String): String {
-        val kindRegex = Regex("""^kind:\s*(\w+)""", RegexOption.MULTILINE)
-        return kindRegex.find(yamlContent)?.groupValues?.get(1)
-            ?: throw IllegalStateException("Could not determine resource kind from YAML")
-    }
+    private fun applyNamespace(
+        client: KubernetesClient,
+        stream: ByteArrayInputStream,
+    ) = client
+        .namespaces()
+        .load(stream)
+        .forceConflicts()
+        .serverSideApply()
 
-    /**
-     * Extract the name field from a YAML manifest.
-     *
-     * @param yamlContent YAML content
-     * @return The resource name, or "unknown" if not found
-     */
-    fun extractName(yamlContent: String): String {
-        val nameRegex = Regex("""^\s*name:\s*(\S+)""", RegexOption.MULTILINE)
-        return nameRegex.find(yamlContent)?.groupValues?.get(1) ?: "unknown"
-    }
+    private fun applyConfigMap(
+        client: KubernetesClient,
+        stream: ByteArrayInputStream,
+    ) = client
+        .configMaps()
+        .load(stream)
+        .forceConflicts()
+        .serverSideApply()
+
+    private fun applyService(
+        client: KubernetesClient,
+        stream: ByteArrayInputStream,
+    ) = client
+        .services()
+        .load(stream)
+        .forceConflicts()
+        .serverSideApply()
+
+    private fun applyDaemonSet(
+        client: KubernetesClient,
+        stream: ByteArrayInputStream,
+    ) = client
+        .apps()
+        .daemonSets()
+        .load(stream)
+        .forceConflicts()
+        .serverSideApply()
+
+    private fun applyDeployment(
+        client: KubernetesClient,
+        stream: ByteArrayInputStream,
+    ) = client
+        .apps()
+        .deployments()
+        .load(stream)
+        .forceConflicts()
+        .serverSideApply()
+
+    private fun applyStatefulSet(
+        client: KubernetesClient,
+        stream: ByteArrayInputStream,
+    ) = client
+        .apps()
+        .statefulSets()
+        .load(stream)
+        .forceConflicts()
+        .serverSideApply()
+
+    private fun applySecret(
+        client: KubernetesClient,
+        stream: ByteArrayInputStream,
+    ) = client
+        .secrets()
+        .load(stream)
+        .forceConflicts()
+        .serverSideApply()
 }

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/output/OutputHandler.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/output/OutputHandler.kt
@@ -464,3 +464,57 @@ class FilteringChannelOutputHandler(
         }
     }
 }
+
+/**
+ * Display observability stack access information.
+ * Used by both K8Apply (after deployment) and Status (for reference).
+ */
+fun OutputHandler.displayObservabilityAccess(controlNodeIp: String) {
+    handleMessage("")
+    handleMessage("Observability:")
+    handleMessage("  Grafana:    http://$controlNodeIp:${Constants.K8s.GRAFANA_PORT}")
+    handleMessage("  Prometheus: http://$controlNodeIp:${Constants.K8s.PROMETHEUS_PORT}")
+    handleMessage("")
+    handleMessage("Grafana credentials: admin/admin")
+}
+
+/**
+ * Display ClickHouse access information.
+ * Used by both ClickHouseStatus (after start) and Status (for reference).
+ * @param dbNodeIp IP address of a db node where ClickHouse pods are scheduled
+ */
+fun OutputHandler.displayClickHouseAccess(dbNodeIp: String) {
+    handleMessage("")
+    handleMessage("ClickHouse:")
+    handleMessage("  Play UI:         http://$dbNodeIp:${Constants.ClickHouse.HTTP_PORT}/play")
+    handleMessage("  HTTP Interface:  http://$dbNodeIp:${Constants.ClickHouse.HTTP_PORT}")
+    handleMessage("  Native Protocol: $dbNodeIp:${Constants.ClickHouse.NATIVE_PORT}")
+}
+
+/**
+ * Display S3Manager access information.
+ * @param controlNodeIp IP address of the control node where S3Manager runs
+ * @param bucketName S3 bucket name to link directly to
+ */
+fun OutputHandler.displayS3ManagerAccess(
+    controlNodeIp: String,
+    bucketName: String,
+) {
+    handleMessage("")
+    handleMessage("S3 Manager:")
+    handleMessage("  Web UI: http://$controlNodeIp:${Constants.K8s.S3MANAGER_PORT}/buckets/$bucketName")
+}
+
+/**
+ * Display S3Manager access information for ClickHouse data directory.
+ * @param controlNodeIp IP address of the control node where S3Manager runs
+ * @param bucketName S3 bucket name
+ */
+fun OutputHandler.displayS3ManagerClickHouseAccess(
+    controlNodeIp: String,
+    bucketName: String,
+) {
+    handleMessage("")
+    handleMessage("S3 Manager:")
+    handleMessage("  ClickHouse Data: http://$controlNodeIp:${Constants.K8s.S3MANAGER_PORT}/buckets/$bucketName/clickhouse/")
+}

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/providers/aws/AWSModule.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/providers/aws/AWSModule.kt
@@ -147,7 +147,6 @@ val awsModule =
         single {
             AWSResourceSetupService(
                 get<AWS>(),
-                get(),
                 get<OutputHandler>(),
             )
         }
@@ -167,7 +166,6 @@ val awsModule =
                 get<OutputHandler>(),
                 get<ObjectStore>(),
                 get<ClusterStateManager>(),
-                get<User>(),
             )
         }
 

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/providers/aws/AWSPolicy.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/providers/aws/AWSPolicy.kt
@@ -135,24 +135,27 @@ sealed class AWSPolicy {
      */
     sealed class Inline : AWSPolicy() {
         /**
-         * S3 access policy granting full S3 access to a specific bucket.
+         * S3 access policy granting full S3 access to all easy-db-lab buckets.
+         * Uses wildcard pattern to support per-environment buckets.
          * Attached to IAM roles to allow EC2 instances to access cluster data.
-         *
-         * @param bucketName The S3 bucket name to grant access to
+         * Also includes s3:ListAllMyBuckets for S3Manager web UI.
          */
-        data class S3Access(
-            val bucketName: String,
-        ) : Inline() {
+        data object S3AccessWildcard : Inline() {
             override fun toJson() =
                 """{
             "Version": "2012-10-17",
             "Statement": [
                 {
                     "Effect": "Allow",
+                    "Action": "s3:ListAllMyBuckets",
+                    "Resource": "*"
+                },
+                {
+                    "Effect": "Allow",
                     "Action": "s3:*",
                     "Resource": [
-                        "arn:aws:s3:::$bucketName",
-                        "arn:aws:s3:::$bucketName/*"
+                        "arn:aws:s3:::easy-db-lab-*",
+                        "arn:aws:s3:::easy-db-lab-*/*"
                     ]
                 }
             ]

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/providers/aws/EMRSparkService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/providers/aws/EMRSparkService.kt
@@ -3,7 +3,6 @@ package com.rustyrazorblade.easydblab.providers.aws
 import com.rustyrazorblade.easydblab.Constants
 import com.rustyrazorblade.easydblab.configuration.ClusterStateManager
 import com.rustyrazorblade.easydblab.configuration.EMRClusterInfo
-import com.rustyrazorblade.easydblab.configuration.User
 import com.rustyrazorblade.easydblab.configuration.s3Path
 import com.rustyrazorblade.easydblab.output.OutputHandler
 import com.rustyrazorblade.easydblab.services.ObjectStore
@@ -50,7 +49,6 @@ class EMRSparkService(
     private val outputHandler: OutputHandler,
     private val objectStore: ObjectStore,
     private val clusterStateManager: ClusterStateManager,
-    private val userConfig: User,
 ) : SparkService {
     private val log = KotlinLogging.logger {}
 
@@ -243,7 +241,7 @@ class EMRSparkService(
         runCatching {
             // Build the S3 path for logs: {emrLogs}/{cluster-id}/steps/{step-id}/{logType}.gz
             val clusterState = clusterStateManager.load()
-            val s3Path = clusterState.s3Path(userConfig)
+            val s3Path = clusterState.s3Path()
             val logPath =
                 s3Path
                     .emrLogs()
@@ -277,7 +275,7 @@ class EMRSparkService(
     override fun downloadAllLogs(stepId: String): Result<Path> =
         runCatching {
             val clusterState = clusterStateManager.load()
-            val s3Path = clusterState.s3Path(userConfig)
+            val s3Path = clusterState.s3Path()
             val emrLogsPath = s3Path.emrLogs()
 
             // Save to logs/emr/<step-id>/
@@ -298,7 +296,7 @@ class EMRSparkService(
     ): Result<Path> =
         runCatching {
             val clusterState = clusterStateManager.load()
-            val s3Path = clusterState.s3Path(userConfig)
+            val s3Path = clusterState.s3Path()
 
             // Create local logs directory: ./logs/{cluster-id}/{step-id}/
             val localLogsDir = Paths.get("logs", clusterId, stepId)

--- a/src/main/resources/com/rustyrazorblade/easydblab/commands/cassandra-sidecar.yaml
+++ b/src/main/resources/com/rustyrazorblade/easydblab/commands/cassandra-sidecar.yaml
@@ -26,11 +26,11 @@ cassandra_instances:
     username: cassandra
     password: cassandra
     data_dirs:
-      - /mnt/cassandra/data/
-    commitlog_dir: /mnt/cassandra/commitlog
-    hints_dir: /mnt/cassandra/hints
-    saved_caches_dir: /mnt/cassandra/saved_caches
-    staging_dir: /mnt/cassandra/import
+      - /mnt/db1/cassandra/data/
+    commitlog_dir: /mnt/db1/cassandra/commitlog
+    hints_dir: /mnt/db1/cassandra/hints
+    saved_caches_dir: /mnt/db1/cassandra/saved_caches
+    staging_dir: /mnt/db1/cassandra/import
     jmx_host: 127.0.0.1
     jmx_port: 7199
     jmx_ssl_enabled: false

--- a/src/main/resources/com/rustyrazorblade/easydblab/commands/k8s/clickhouse/11-clickhouse-keeper-configmap.yaml
+++ b/src/main/resources/com/rustyrazorblade/easydblab/commands/k8s/clickhouse/11-clickhouse-keeper-configmap.yaml
@@ -1,0 +1,57 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: clickhouse-keeper-config
+  namespace: default
+  labels:
+    app.kubernetes.io/name: clickhouse-keeper
+data:
+  keeper_config.xml: |
+    <clickhouse>
+        <logger>
+            <level>information</level>
+            <console>true</console>
+        </logger>
+        <listen_host>0.0.0.0</listen_host>
+        <keeper_server>
+            <tcp_port>2181</tcp_port>
+            <server_id from_env="KEEPER_SERVER_ID"/>
+            <log_storage_path>/var/lib/clickhouse-keeper/log</log_storage_path>
+            <snapshot_storage_path>/var/lib/clickhouse-keeper/snapshots</snapshot_storage_path>
+            <coordination_settings>
+                <operation_timeout_ms>10000</operation_timeout_ms>
+                <session_timeout_ms>30000</session_timeout_ms>
+                <raft_logs_level>warning</raft_logs_level>
+            </coordination_settings>
+            <raft_configuration>
+                <server>
+                    <id>1</id>
+                    <hostname>clickhouse-keeper-0.clickhouse-keeper.default.svc.cluster.local</hostname>
+                    <port>9234</port>
+                </server>
+                <server>
+                    <id>2</id>
+                    <hostname>clickhouse-keeper-1.clickhouse-keeper.default.svc.cluster.local</hostname>
+                    <port>9234</port>
+                </server>
+                <server>
+                    <id>3</id>
+                    <hostname>clickhouse-keeper-2.clickhouse-keeper.default.svc.cluster.local</hostname>
+                    <port>9234</port>
+                </server>
+            </raft_configuration>
+            <http_control>
+                <port>9182</port>
+                <readiness>
+                    <endpoint>/ready</endpoint>
+                </readiness>
+            </http_control>
+        </keeper_server>
+        <prometheus>
+            <endpoint>/metrics</endpoint>
+            <port>9363</port>
+            <metrics>true</metrics>
+            <events>true</events>
+            <asynchronous_metrics>true</asynchronous_metrics>
+        </prometheus>
+    </clickhouse>

--- a/src/main/resources/com/rustyrazorblade/easydblab/commands/k8s/clickhouse/12-clickhouse-server-configmap.yaml
+++ b/src/main/resources/com/rustyrazorblade/easydblab/commands/k8s/clickhouse/12-clickhouse-server-configmap.yaml
@@ -1,0 +1,141 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: clickhouse-server-config
+  namespace: default
+  labels:
+    app.kubernetes.io/name: clickhouse-server
+data:
+  config.xml: |
+    <clickhouse>
+        <logger>
+            <level>information</level>
+            <console>true</console>
+        </logger>
+        <listen_host>0.0.0.0</listen_host>
+        <http_port>8123</http_port>
+        <tcp_port>9000</tcp_port>
+        <interserver_http_port>9009</interserver_http_port>
+
+        <path>/mnt/db1/clickhouse/</path>
+        <tmp_path>/mnt/db1/clickhouse/tmp/</tmp_path>
+        <user_files_path>/mnt/db1/clickhouse/user_files/</user_files_path>
+        <format_schema_path>/mnt/db1/clickhouse/format_schemas/</format_schema_path>
+
+        <!-- Storage Configuration -->
+        <!-- Available policies: 'local' (default), 's3_main' (S3 with local cache) -->
+        <storage_configuration>
+            <disks>
+                <default>
+                    <keep_free_space_bytes>1073741824</keep_free_space_bytes>
+                </default>
+                <s3_disk>
+                    <type>s3</type>
+                    <endpoint from_env="CLICKHOUSE_S3_ENDPOINT"/>
+                    <use_environment_credentials>true</use_environment_credentials>
+                    <metadata_path>/mnt/db1/clickhouse/disks/s3_disk/</metadata_path>
+                </s3_disk>
+                <s3_cache>
+                    <type>cache</type>
+                    <disk>s3_disk</disk>
+                    <path>/mnt/db1/clickhouse/disks/s3_cache/</path>
+                    <max_size>10Gi</max_size>
+                </s3_cache>
+            </disks>
+            <policies>
+                <local>
+                    <volumes>
+                        <main>
+                            <disk>default</disk>
+                        </main>
+                    </volumes>
+                </local>
+                <s3_main>
+                    <volumes>
+                        <main>
+                            <disk>s3_cache</disk>
+                        </main>
+                    </volumes>
+                </s3_main>
+            </policies>
+        </storage_configuration>
+
+        <zookeeper>
+            <node>
+                <host>clickhouse-keeper-0.clickhouse-keeper.default.svc.cluster.local</host>
+                <port>2181</port>
+            </node>
+            <node>
+                <host>clickhouse-keeper-1.clickhouse-keeper.default.svc.cluster.local</host>
+                <port>2181</port>
+            </node>
+            <node>
+                <host>clickhouse-keeper-2.clickhouse-keeper.default.svc.cluster.local</host>
+                <port>2181</port>
+            </node>
+        </zookeeper>
+
+        <macros>
+            <cluster>easy_db_lab</cluster>
+            <shard from_env="SHARD"/>
+            <replica from_env="REPLICA"/>
+        </macros>
+
+        <remote_servers>
+            <easy_db_lab>
+                <shard>
+                    <replica>
+                        <host>clickhouse-0.clickhouse.default.svc.cluster.local</host>
+                        <port>9000</port>
+                    </replica>
+                    <replica>
+                        <host>clickhouse-1.clickhouse.default.svc.cluster.local</host>
+                        <port>9000</port>
+                    </replica>
+                </shard>
+            </easy_db_lab>
+        </remote_servers>
+
+        <distributed_ddl>
+            <path>/clickhouse/task_queue/ddl</path>
+        </distributed_ddl>
+
+        <prometheus>
+            <endpoint>/metrics</endpoint>
+            <port>9363</port>
+            <metrics>true</metrics>
+            <events>true</events>
+            <asynchronous_metrics>true</asynchronous_metrics>
+        </prometheus>
+    </clickhouse>
+  users.xml: |
+    <clickhouse>
+        <users>
+            <default>
+                <password></password>
+                <networks>
+                    <ip>::/0</ip>
+                </networks>
+                <profile>default</profile>
+                <quota>default</quota>
+                <access_management>1</access_management>
+            </default>
+        </users>
+        <profiles>
+            <default>
+                <max_memory_usage>10000000000</max_memory_usage>
+            </default>
+        </profiles>
+        <quotas>
+            <default>
+                <interval>
+                    <duration>3600</duration>
+                    <queries>0</queries>
+                    <errors>0</errors>
+                    <result_rows>0</result_rows>
+                    <read_rows>0</read_rows>
+                    <execution_time>0</execution_time>
+                </interval>
+            </default>
+        </quotas>
+    </clickhouse>

--- a/src/main/resources/com/rustyrazorblade/easydblab/commands/k8s/clickhouse/14-grafana-dashboard-clickhouse.yaml
+++ b/src/main/resources/com/rustyrazorblade/easydblab/commands/k8s/clickhouse/14-grafana-dashboard-clickhouse.yaml
@@ -1,0 +1,396 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-clickhouse
+  namespace: default
+  labels:
+    grafana_dashboard: "1"
+data:
+  clickhouse-overview.json: |
+    {
+      "annotations": {
+        "list": []
+      },
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 0,
+      "id": null,
+      "links": [],
+      "liveNow": false,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 0
+          },
+          "id": 1,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "expr": "rate(ClickHouseProfileEvents_Query[1m])",
+              "legendFormat": "{{instance}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Queries per Second",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "bytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 0
+          },
+          "id": 2,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "expr": "ClickHouseMetrics_MemoryTracking",
+              "legendFormat": "{{instance}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Memory Usage",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 8
+          },
+          "id": 3,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "expr": "ClickHouseMetrics_TCPConnection",
+              "legendFormat": "{{instance}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Active Connections",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "bytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 8
+          },
+          "id": 4,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "expr": "rate(ClickHouseProfileEvents_ReadCompressedBytes[1m])",
+              "legendFormat": "Read - {{instance}}",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "expr": "rate(ClickHouseProfileEvents_WriteBufferFromFileDescriptorWriteBytes[1m])",
+              "legendFormat": "Write - {{instance}}",
+              "refId": "B"
+            }
+          ],
+          "title": "Disk I/O Rate",
+          "type": "timeseries"
+        }
+      ],
+      "refresh": "5s",
+      "schemaVersion": 38,
+      "style": "dark",
+      "tags": ["clickhouse"],
+      "templating": {
+        "list": []
+      },
+      "time": {
+        "from": "now-1h",
+        "to": "now"
+      },
+      "timepicker": {},
+      "timezone": "",
+      "title": "ClickHouse Overview",
+      "uid": "clickhouse-overview",
+      "version": 1,
+      "weekStart": ""
+    }

--- a/src/main/resources/com/rustyrazorblade/easydblab/commands/k8s/clickhouse/20-clickhouse-keeper-service.yaml
+++ b/src/main/resources/com/rustyrazorblade/easydblab/commands/k8s/clickhouse/20-clickhouse-keeper-service.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: clickhouse-keeper
+  namespace: default
+  labels:
+    app.kubernetes.io/name: clickhouse-keeper
+spec:
+  type: ClusterIP
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+    - name: client
+      port: 2181
+      targetPort: 2181
+      protocol: TCP
+    - name: raft
+      port: 9234
+      targetPort: 9234
+      protocol: TCP
+    - name: metrics
+      port: 9363
+      targetPort: 9363
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: clickhouse-keeper

--- a/src/main/resources/com/rustyrazorblade/easydblab/commands/k8s/clickhouse/21-clickhouse-server-service.yaml
+++ b/src/main/resources/com/rustyrazorblade/easydblab/commands/k8s/clickhouse/21-clickhouse-server-service.yaml
@@ -1,0 +1,52 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: clickhouse
+  namespace: default
+  labels:
+    app.kubernetes.io/name: clickhouse-server
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: http
+      port: 8123
+      targetPort: 8123
+      protocol: TCP
+    - name: native
+      port: 9000
+      targetPort: 9000
+      protocol: TCP
+    - name: interserver
+      port: 9009
+      targetPort: 9009
+      protocol: TCP
+    - name: metrics
+      port: 9363
+      targetPort: 9363
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: clickhouse-server
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: clickhouse-client
+  namespace: default
+  labels:
+    app.kubernetes.io/name: clickhouse-server
+    app.kubernetes.io/component: client
+spec:
+  type: NodePort
+  ports:
+    - name: http
+      port: 8123
+      targetPort: 8123
+      protocol: TCP
+    - name: native
+      port: 9000
+      targetPort: 9000
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: clickhouse-server

--- a/src/main/resources/com/rustyrazorblade/easydblab/commands/k8s/clickhouse/30-clickhouse-keeper-statefulset.yaml
+++ b/src/main/resources/com/rustyrazorblade/easydblab/commands/k8s/clickhouse/30-clickhouse-keeper-statefulset.yaml
@@ -1,0 +1,99 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: clickhouse-keeper
+  namespace: default
+  labels:
+    app.kubernetes.io/name: clickhouse-keeper
+spec:
+  serviceName: clickhouse-keeper
+  replicas: 3
+  podManagementPolicy: Parallel
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: clickhouse-keeper
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: clickhouse-keeper
+    spec:
+      nodeSelector:
+        type: db
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: clickhouse-keeper
+              topologyKey: kubernetes.io/hostname
+      initContainers:
+        - name: init-data-dir
+          image: busybox:1.36
+          command:
+            - /bin/sh
+            - -c
+            - |
+              mkdir -p /var/lib/clickhouse-keeper/log
+              mkdir -p /var/lib/clickhouse-keeper/snapshots
+              chown -R 101:101 /var/lib/clickhouse-keeper
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/clickhouse-keeper
+      containers:
+        - name: clickhouse-keeper
+          image: clickhouse/clickhouse-keeper:latest
+          securityContext:
+            runAsUser: 101
+            runAsGroup: 101
+          ports:
+            - containerPort: 2181
+              name: client
+            - containerPort: 9234
+              name: raft
+            - containerPort: 9363
+              name: metrics
+            - containerPort: 9182
+              name: http-control
+          env:
+            - name: KEEPER_SERVER_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          command:
+            - /bin/bash
+            - -c
+            - |
+              export KEEPER_SERVER_ID=$((${HOSTNAME##*-} + 1))
+              exec clickhouse-keeper --config-file=/etc/clickhouse-keeper/keeper_config.xml
+          resources:
+            limits:
+              memory: 512Mi
+            requests:
+              memory: 256Mi
+              cpu: 100m
+          volumeMounts:
+            - name: config
+              mountPath: /etc/clickhouse-keeper
+              readOnly: true
+            - name: data
+              mountPath: /var/lib/clickhouse-keeper
+          livenessProbe:
+            httpGet:
+              path: /ready
+              port: 9182
+            initialDelaySeconds: 30
+            periodSeconds: 15
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 9182
+            initialDelaySeconds: 10
+            periodSeconds: 10
+      volumes:
+        - name: config
+          configMap:
+            name: clickhouse-keeper-config
+        - name: data
+          hostPath:
+            path: /mnt/db1/clickhouse/keeper
+            type: DirectoryOrCreate

--- a/src/main/resources/com/rustyrazorblade/easydblab/commands/k8s/clickhouse/31-clickhouse-server-statefulset.yaml
+++ b/src/main/resources/com/rustyrazorblade/easydblab/commands/k8s/clickhouse/31-clickhouse-server-statefulset.yaml
@@ -1,0 +1,131 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: clickhouse
+  namespace: default
+  labels:
+    app.kubernetes.io/name: clickhouse-server
+spec:
+  serviceName: clickhouse
+  replicas: 2
+  podManagementPolicy: Parallel
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: clickhouse-server
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: clickhouse-server
+    spec:
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      nodeSelector:
+        type: db
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: clickhouse-server
+              topologyKey: kubernetes.io/hostname
+      initContainers:
+        - name: wait-for-keeper
+          image: busybox:1.36
+          command:
+            - /bin/sh
+            - -c
+            - |
+              echo "Waiting for ClickHouse Keeper to be ready..."
+              until nc -z clickhouse-keeper-0.clickhouse-keeper.default.svc.cluster.local 2181; do
+                echo "Keeper not ready, sleeping..."
+                sleep 5
+              done
+              echo "Keeper is ready!"
+        - name: init-data-dir
+          image: busybox:1.36
+          command:
+            - /bin/sh
+            - -c
+            - |
+              mkdir -p /mnt/db1/clickhouse
+              mkdir -p /mnt/db1/clickhouse/tmp
+              mkdir -p /mnt/db1/clickhouse/user_files
+              mkdir -p /mnt/db1/clickhouse/format_schemas
+              mkdir -p /mnt/db1/clickhouse/disks/s3_disk
+              mkdir -p /mnt/db1/clickhouse/disks/s3_cache
+              chown -R 101:101 /mnt/db1/clickhouse
+          volumeMounts:
+            - name: data
+              mountPath: /mnt/db1/clickhouse
+      containers:
+        - name: clickhouse
+          image: clickhouse/clickhouse-server:latest
+          securityContext:
+            runAsUser: 101
+            runAsGroup: 101
+          ports:
+            - containerPort: 8123
+              hostPort: 8123
+              name: http
+            - containerPort: 9000
+              hostPort: 9000
+              name: native
+            - containerPort: 9009
+              name: interserver
+            - containerPort: 9363
+              name: metrics
+          env:
+            - name: SHARD
+              value: "1"
+            - name: REPLICA
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          envFrom:
+            - secretRef:
+                name: clickhouse-s3-credentials
+                optional: true
+          resources:
+            limits:
+              memory: 4Gi
+            requests:
+              memory: 2Gi
+              cpu: 500m
+          volumeMounts:
+            - name: config
+              mountPath: /etc/clickhouse-server/config.d
+              readOnly: true
+            - name: users
+              mountPath: /etc/clickhouse-server/users.d
+              readOnly: true
+            - name: data
+              mountPath: /mnt/db1/clickhouse
+          livenessProbe:
+            httpGet:
+              path: /ping
+              port: 8123
+            initialDelaySeconds: 30
+            periodSeconds: 15
+          readinessProbe:
+            httpGet:
+              path: /ping
+              port: 8123
+            initialDelaySeconds: 10
+            periodSeconds: 10
+      volumes:
+        - name: config
+          configMap:
+            name: clickhouse-server-config
+            items:
+              - key: config.xml
+                path: config.xml
+        - name: users
+          configMap:
+            name: clickhouse-server-config
+            items:
+              - key: users.xml
+                path: users.xml
+        - name: data
+          hostPath:
+            path: /mnt/db1/clickhouse
+            type: DirectoryOrCreate

--- a/src/main/resources/com/rustyrazorblade/easydblab/commands/k8s/core/10-otel-configmap-control.yaml
+++ b/src/main/resources/com/rustyrazorblade/easydblab/commands/k8s/core/10-otel-configmap-control.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: otel-collector-config-control
-  namespace: observability
+  namespace: default
   labels:
     app.kubernetes.io/name: otel-collector
     app.kubernetes.io/component: aggregator

--- a/src/main/resources/com/rustyrazorblade/easydblab/commands/k8s/core/11-otel-configmap-workers.yaml
+++ b/src/main/resources/com/rustyrazorblade/easydblab/commands/k8s/core/11-otel-configmap-workers.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: otel-collector-config-workers
-  namespace: observability
+  namespace: default
   labels:
     app.kubernetes.io/name: otel-collector
     app.kubernetes.io/component: forwarder
@@ -21,7 +21,7 @@ data:
           processes:
       filelog:
         include:
-          - /mnt/cassandra/logs/*.log
+          - /mnt/db1/otel/logs/*.log
         start_at: end
         operators:
           - type: regex_parser

--- a/src/main/resources/com/rustyrazorblade/easydblab/commands/k8s/core/12-prometheus-configmap.yaml
+++ b/src/main/resources/com/rustyrazorblade/easydblab/commands/k8s/core/12-prometheus-configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: prometheus-config
-  namespace: observability
+  namespace: default
   labels:
     app.kubernetes.io/name: prometheus
 data:

--- a/src/main/resources/com/rustyrazorblade/easydblab/commands/k8s/core/13-grafana-datasource-configmap.yaml
+++ b/src/main/resources/com/rustyrazorblade/easydblab/commands/k8s/core/13-grafana-datasource-configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: grafana-datasources
-  namespace: observability
+  namespace: default
   labels:
     app.kubernetes.io/name: grafana
 data:
@@ -14,4 +14,13 @@ data:
         access: proxy
         url: http://localhost:9090
         isDefault: true
+        editable: false
+      - name: ClickHouse
+        type: grafana-clickhouse-datasource
+        access: proxy
+        jsonData:
+          defaultDatabase: default
+          port: 9000
+          protocol: native
+          host: cassandra0
         editable: false

--- a/src/main/resources/com/rustyrazorblade/easydblab/commands/k8s/core/14-grafana-dashboards-configmap.yaml
+++ b/src/main/resources/com/rustyrazorblade/easydblab/commands/k8s/core/14-grafana-dashboards-configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: grafana-dashboards-config
-  namespace: observability
+  namespace: default
   labels:
     app.kubernetes.io/name: grafana
 data:

--- a/src/main/resources/com/rustyrazorblade/easydblab/commands/k8s/core/15-grafana-dashboard-system.yaml
+++ b/src/main/resources/com/rustyrazorblade/easydblab/commands/k8s/core/15-grafana-dashboard-system.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: grafana-dashboard-system
-  namespace: observability
+  namespace: default
   labels:
     app.kubernetes.io/name: grafana
     grafana_dashboard: "1"

--- a/src/main/resources/com/rustyrazorblade/easydblab/commands/k8s/core/20-otel-service.yaml
+++ b/src/main/resources/com/rustyrazorblade/easydblab/commands/k8s/core/20-otel-service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: otel-collector
-  namespace: observability
+  namespace: default
   labels:
     app.kubernetes.io/name: otel-collector
     app.kubernetes.io/component: aggregator

--- a/src/main/resources/com/rustyrazorblade/easydblab/commands/k8s/core/30-otel-daemonset-control.yaml
+++ b/src/main/resources/com/rustyrazorblade/easydblab/commands/k8s/core/30-otel-daemonset-control.yaml
@@ -1,56 +1,61 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: otel-collector-workers
-  namespace: observability
+  name: otel-collector-control
+  namespace: default
   labels:
     app.kubernetes.io/name: otel-collector
-    app.kubernetes.io/component: forwarder
+    app.kubernetes.io/component: aggregator
 spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: otel-collector
-      app.kubernetes.io/component: forwarder
+      app.kubernetes.io/component: aggregator
   template:
     metadata:
       labels:
         app.kubernetes.io/name: otel-collector
-        app.kubernetes.io/component: forwarder
+        app.kubernetes.io/component: aggregator
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                  - key: node-role.kubernetes.io/master
-                    operator: DoesNotExist
+      nodeSelector:
+        node-role.kubernetes.io/master: "true"
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+          effect: NoSchedule
       containers:
         - name: otel-collector
           image: otel/opentelemetry-collector-contrib:latest
           args:
             - --config=/etc/otel-collector-config.yaml
           ports:
+            - containerPort: 4317
+              hostPort: 4317
+              protocol: TCP
+            - containerPort: 4318
+              hostPort: 4318
+              protocol: TCP
+            - containerPort: 8889
+              hostPort: 8889
+              protocol: TCP
             - containerPort: 13133
               hostPort: 13133
               protocol: TCP
           env:
             - name: GOMEMLIMIT
-              value: "256MiB"
+              value: "512MiB"
           resources:
             limits:
-              memory: 256Mi
+              memory: 512Mi
             requests:
-              memory: 128Mi
-              cpu: 50m
+              memory: 256Mi
+              cpu: 100m
           volumeMounts:
             - name: config
               mountPath: /etc/otel-collector-config.yaml
               subPath: otel-collector-config.yaml
-              readOnly: true
-            - name: cassandra-logs
-              mountPath: /mnt/cassandra/logs
               readOnly: true
           livenessProbe:
             httpGet:
@@ -67,8 +72,4 @@ spec:
       volumes:
         - name: config
           configMap:
-            name: otel-collector-config-workers
-        - name: cassandra-logs
-          hostPath:
-            path: /mnt/cassandra/logs
-            type: DirectoryOrCreate
+            name: otel-collector-config-control

--- a/src/main/resources/com/rustyrazorblade/easydblab/commands/k8s/core/31-otel-daemonset-workers.yaml
+++ b/src/main/resources/com/rustyrazorblade/easydblab/commands/k8s/core/31-otel-daemonset-workers.yaml
@@ -1,61 +1,56 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: otel-collector-control
-  namespace: observability
+  name: otel-collector-workers
+  namespace: default
   labels:
     app.kubernetes.io/name: otel-collector
-    app.kubernetes.io/component: aggregator
+    app.kubernetes.io/component: forwarder
 spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: otel-collector
-      app.kubernetes.io/component: aggregator
+      app.kubernetes.io/component: forwarder
   template:
     metadata:
       labels:
         app.kubernetes.io/name: otel-collector
-        app.kubernetes.io/component: aggregator
+        app.kubernetes.io/component: forwarder
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
-      nodeSelector:
-        node-role.kubernetes.io/master: "true"
-      tolerations:
-        - key: node-role.kubernetes.io/master
-          operator: Exists
-          effect: NoSchedule
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/master
+                    operator: DoesNotExist
       containers:
         - name: otel-collector
           image: otel/opentelemetry-collector-contrib:latest
           args:
             - --config=/etc/otel-collector-config.yaml
           ports:
-            - containerPort: 4317
-              hostPort: 4317
-              protocol: TCP
-            - containerPort: 4318
-              hostPort: 4318
-              protocol: TCP
-            - containerPort: 8889
-              hostPort: 8889
-              protocol: TCP
             - containerPort: 13133
               hostPort: 13133
               protocol: TCP
           env:
             - name: GOMEMLIMIT
-              value: "512MiB"
+              value: "256MiB"
           resources:
             limits:
-              memory: 512Mi
-            requests:
               memory: 256Mi
-              cpu: 100m
+            requests:
+              memory: 128Mi
+              cpu: 50m
           volumeMounts:
             - name: config
               mountPath: /etc/otel-collector-config.yaml
               subPath: otel-collector-config.yaml
+              readOnly: true
+            - name: otel-logs
+              mountPath: /mnt/db1/otel/logs
               readOnly: true
           livenessProbe:
             httpGet:
@@ -72,4 +67,8 @@ spec:
       volumes:
         - name: config
           configMap:
-            name: otel-collector-config-control
+            name: otel-collector-config-workers
+        - name: otel-logs
+          hostPath:
+            path: /mnt/db1/otel/logs
+            type: DirectoryOrCreate

--- a/src/main/resources/com/rustyrazorblade/easydblab/commands/k8s/core/40-prometheus-deployment.yaml
+++ b/src/main/resources/com/rustyrazorblade/easydblab/commands/k8s/core/40-prometheus-deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: prometheus
-  namespace: observability
+  namespace: default
   labels:
     app.kubernetes.io/name: prometheus
 spec:

--- a/src/main/resources/com/rustyrazorblade/easydblab/commands/k8s/core/41-grafana-deployment.yaml
+++ b/src/main/resources/com/rustyrazorblade/easydblab/commands/k8s/core/41-grafana-deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: grafana
-  namespace: observability
+  namespace: default
   labels:
     app.kubernetes.io/name: grafana
 spec:
@@ -34,6 +34,8 @@ spec:
               hostPort: 3000
               protocol: TCP
           env:
+            - name: GF_INSTALL_PLUGINS
+              value: grafana-clickhouse-datasource
             - name: GF_SECURITY_ADMIN_USER
               value: admin
             - name: GF_SECURITY_ADMIN_PASSWORD

--- a/src/main/resources/com/rustyrazorblade/easydblab/commands/k8s/core/42-registry-deployment.yaml
+++ b/src/main/resources/com/rustyrazorblade/easydblab/commands/k8s/core/42-registry-deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: registry
-  namespace: observability
+  namespace: default
   labels:
     app.kubernetes.io/name: registry
 spec:

--- a/src/main/resources/com/rustyrazorblade/easydblab/commands/k8s/core/43-s3manager-deployment.yaml
+++ b/src/main/resources/com/rustyrazorblade/easydblab/commands/k8s/core/43-s3manager-deployment.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: s3manager
+  namespace: default
+  labels:
+    app.kubernetes.io/name: s3manager
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: s3manager
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: s3manager
+    spec:
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      nodeSelector:
+        node-role.kubernetes.io/master: "true"
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+          effect: NoSchedule
+      containers:
+        - name: s3manager
+          image: cloudlena/s3manager:latest
+          ports:
+            - containerPort: 8080
+              hostPort: 8080
+              protocol: TCP
+          env:
+            - name: USE_IAM
+              value: "true"
+            - name: PORT
+              value: "8080"
+          resources:
+            limits:
+              memory: 256Mi
+            requests:
+              memory: 64Mi
+              cpu: 50m
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 15
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10

--- a/src/main/resources/com/rustyrazorblade/easydblab/commands/k8s/core/namespace.yaml
+++ b/src/main/resources/com/rustyrazorblade/easydblab/commands/k8s/core/namespace.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: observability
-  labels:
-    app.kubernetes.io/name: observability
-    app.kubernetes.io/part-of: easy-db-lab

--- a/src/main/resources/com/rustyrazorblade/easydblab/iam-policy-iam-s3.json
+++ b/src/main/resources/com/rustyrazorblade/easydblab/iam-policy-iam-s3.json
@@ -19,6 +19,14 @@
       "Resource": "*"
     },
     {
+      "Sid": "S3ListAllBuckets",
+      "Effect": "Allow",
+      "Action": [
+        "s3:ListAllMyBuckets"
+      ],
+      "Resource": "*"
+    },
+    {
       "Sid": "S3Permissions",
       "Effect": "Allow",
       "Action": [

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/TestContextFactory.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/TestContextFactory.kt
@@ -38,7 +38,6 @@ object TestContextFactory {
                 awsSecret = "test",
                 axonOpsOrg = "",
                 axonOpsKey = "",
-                s3Bucket = "",
             )
 
         val context =

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/TestModules.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/TestModules.kt
@@ -54,7 +54,12 @@ object TestModules {
      */
     fun testContextModule(tempDir: File): Module {
         val testContext = TestContextFactory.createTestContext(tempDir)
-        val contextFactory = ContextFactory(testContext.easyDbLabUserDirectory)
+        // Use the testContext's workingDirectory to ensure tests don't affect the real project
+        val contextFactory =
+            ContextFactory(
+                baseDirectory = testContext.easyDbLabUserDirectory,
+                workingDirectory = testContext.workingDirectory,
+            )
         return module {
             // Include all context module definitions
             includes(contextModule(contextFactory))

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/commands/UpTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/commands/UpTest.kt
@@ -1,6 +1,7 @@
 package com.rustyrazorblade.easydblab.commands
 
 import com.rustyrazorblade.easydblab.BaseKoinTest
+import com.rustyrazorblade.easydblab.TestContextFactory
 import com.rustyrazorblade.easydblab.configuration.ClusterHost
 import com.rustyrazorblade.easydblab.configuration.ClusterState
 import com.rustyrazorblade.easydblab.configuration.ClusterStateManager
@@ -8,9 +9,9 @@ import com.rustyrazorblade.easydblab.configuration.InitConfig
 import com.rustyrazorblade.easydblab.configuration.ServerType
 import com.rustyrazorblade.easydblab.configuration.User
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
 import org.koin.dsl.module
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
@@ -23,31 +24,14 @@ import java.io.File
  * with all required environment variables for stress testing.
  */
 class UpTest : BaseKoinTest() {
+    @TempDir
+    lateinit var workingDir: File
+
     private lateinit var environmentFile: File
-    private lateinit var clusterStateFile: File
 
     @BeforeEach
     fun setupTestEnvironmentFile() {
-        environmentFile = File("environment.sh")
-        clusterStateFile = File("state.json")
-
-        // Ensure files don't exist before test
-        if (environmentFile.exists()) {
-            environmentFile.delete()
-        }
-        if (clusterStateFile.exists()) {
-            clusterStateFile.delete()
-        }
-    }
-
-    @AfterEach
-    fun cleanupTestEnvironmentFile() {
-        if (environmentFile.exists()) {
-            environmentFile.delete()
-        }
-        if (clusterStateFile.exists()) {
-            clusterStateFile.delete()
-        }
+        environmentFile = File(workingDir, "environment.sh")
     }
 
     @Test
@@ -91,8 +75,11 @@ class UpTest : BaseKoinTest() {
         org.koin.core.context
             .loadKoinModules(customModules)
 
-        // Create Up command instance
-        val upCommand = Up(context)
+        // Create test context with working directory
+        val testContext = TestContextFactory.createTestContext(tempDir, workingDir)
+
+        // Create Up command instance with test context
+        val upCommand = Up(testContext)
 
         // Initialize workingState via reflection (normally done in execute())
         val workingStateField =
@@ -167,8 +154,11 @@ class UpTest : BaseKoinTest() {
         org.koin.core.context
             .loadKoinModules(customModules)
 
-        // Create Up command instance
-        val upCommand = Up(context)
+        // Create test context with working directory
+        val testContext = TestContextFactory.createTestContext(tempDir, workingDir)
+
+        // Create Up command instance with test context
+        val upCommand = Up(testContext)
 
         // Initialize workingState via reflection (normally done in execute())
         val workingStateField =
@@ -236,8 +226,11 @@ class UpTest : BaseKoinTest() {
         org.koin.core.context
             .loadKoinModules(customModules)
 
-        // Create Up command instance
-        val upCommand = Up(context)
+        // Create test context with working directory
+        val testContext = TestContextFactory.createTestContext(tempDir, workingDir)
+
+        // Create Up command instance with test context
+        val upCommand = Up(testContext)
 
         // Initialize workingState via reflection (normally done in execute())
         val workingStateField =

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/commands/clickhouse/ClickHouseStartTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/commands/clickhouse/ClickHouseStartTest.kt
@@ -1,0 +1,395 @@
+package com.rustyrazorblade.easydblab.commands.clickhouse
+
+import com.rustyrazorblade.easydblab.BaseKoinTest
+import com.rustyrazorblade.easydblab.Constants
+import com.rustyrazorblade.easydblab.configuration.ClusterHost
+import com.rustyrazorblade.easydblab.configuration.ClusterState
+import com.rustyrazorblade.easydblab.configuration.ClusterStateManager
+import com.rustyrazorblade.easydblab.configuration.ServerType
+import com.rustyrazorblade.easydblab.services.K8sService
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.koin.core.module.Module
+import org.koin.dsl.module
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argThat
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+/**
+ * Test suite for ClickHouseStart command following TDD principles.
+ *
+ * These tests verify ClickHouse cluster deployment including
+ * manifest application, storage configuration, and K8sService integration.
+ */
+class ClickHouseStartTest : BaseKoinTest() {
+    private lateinit var mockK8sService: K8sService
+    private lateinit var mockClusterStateManager: ClusterStateManager
+
+    private val testControlHost =
+        ClusterHost(
+            publicIp = "54.123.45.67",
+            privateIp = "10.0.1.5",
+            alias = "control0",
+            availabilityZone = "us-west-2a",
+            instanceId = "i-test123",
+        )
+
+    private val testDbHost =
+        ClusterHost(
+            publicIp = "54.123.45.68",
+            privateIp = "10.0.1.6",
+            alias = "cassandra0",
+            availabilityZone = "us-west-2a",
+            instanceId = "i-test124",
+        )
+
+    private val testDbHost2 =
+        ClusterHost(
+            publicIp = "54.123.45.69",
+            privateIp = "10.0.1.7",
+            alias = "cassandra1",
+            availabilityZone = "us-west-2b",
+            instanceId = "i-test125",
+        )
+
+    private val testDbHost3 =
+        ClusterHost(
+            publicIp = "54.123.45.70",
+            privateIp = "10.0.1.8",
+            alias = "cassandra2",
+            availabilityZone = "us-west-2c",
+            instanceId = "i-test126",
+        )
+
+    override fun additionalTestModules(): List<Module> =
+        listOf(
+            module {
+                single {
+                    mock<K8sService>().also {
+                        mockK8sService = it
+                    }
+                }
+
+                single {
+                    mock<ClusterStateManager>().also {
+                        mockClusterStateManager = it
+                    }
+                }
+            },
+        )
+
+    @BeforeEach
+    fun setupMocks() {
+        mockK8sService = getKoin().get()
+        mockClusterStateManager = getKoin().get()
+
+        // Default mock for scaleStatefulSet - used by most tests
+        whenever(mockK8sService.scaleStatefulSet(any(), any(), any(), any())).thenReturn(Result.success(Unit))
+    }
+
+    @Test
+    fun `execute should fail when no control nodes exist`() {
+        // Given - cluster state with no control nodes
+        val emptyState =
+            ClusterState(
+                name = "test-cluster",
+                versions = mutableMapOf(),
+                hosts = mutableMapOf(),
+            )
+
+        whenever(mockClusterStateManager.load()).thenReturn(emptyState)
+
+        val command = ClickHouseStart(context)
+
+        // When/Then
+        assertThatThrownBy { command.execute() }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("No control nodes found")
+    }
+
+    @Test
+    fun `execute should apply manifests and create S3 secret when bucket configured`() {
+        // Given - cluster state with control node, db nodes, and S3 bucket
+        val stateWithControlAndDb =
+            ClusterState(
+                name = "test-cluster",
+                versions = mutableMapOf(),
+                hosts =
+                    mutableMapOf(
+                        ServerType.Control to listOf(testControlHost),
+                        ServerType.Cassandra to listOf(testDbHost, testDbHost2, testDbHost3),
+                    ),
+                s3Bucket = "test-bucket",
+            )
+
+        whenever(mockClusterStateManager.load()).thenReturn(stateWithControlAndDb)
+        whenever(mockK8sService.applyManifestFromResources(any(), any())).thenReturn(Result.success(Unit))
+        whenever(
+            mockK8sService.createClickHouseS3Secret(
+                any(),
+                eq(Constants.ClickHouse.NAMESPACE),
+                eq("us-west-2"),
+                eq("test-bucket"),
+            ),
+        ).thenReturn(Result.success(Unit))
+        whenever(mockK8sService.waitForPodsReady(any(), any(), eq(Constants.ClickHouse.NAMESPACE)))
+            .thenReturn(Result.success(Unit))
+
+        val command = ClickHouseStart(context)
+
+        // When
+        command.execute()
+
+        // Then - verify 7 manifests are applied
+        verify(mockK8sService, times(7)).applyManifestFromResources(eq(testControlHost), any())
+
+        // Verify the unified configmap is applied
+        verify(mockK8sService).applyManifestFromResources(
+            eq(testControlHost),
+            argThat { contains("12-clickhouse-server-configmap.yaml") },
+        )
+
+        // Verify S3 secret is created when bucket is configured
+        verify(mockK8sService).createClickHouseS3Secret(
+            eq(testControlHost),
+            eq(Constants.ClickHouse.NAMESPACE),
+            eq("us-west-2"),
+            eq("test-bucket"),
+        )
+
+        verify(mockK8sService).waitForPodsReady(eq(testControlHost), any(), eq(Constants.ClickHouse.NAMESPACE))
+    }
+
+    @Test
+    fun `execute should skip S3 secret creation when bucket not configured`() {
+        // Given - cluster state without S3 bucket
+        val stateWithControlAndDb =
+            ClusterState(
+                name = "test-cluster",
+                versions = mutableMapOf(),
+                hosts =
+                    mutableMapOf(
+                        ServerType.Control to listOf(testControlHost),
+                        ServerType.Cassandra to listOf(testDbHost, testDbHost2, testDbHost3),
+                    ),
+                s3Bucket = null, // No bucket configured
+            )
+
+        whenever(mockClusterStateManager.load()).thenReturn(stateWithControlAndDb)
+        whenever(mockK8sService.applyManifestFromResources(any(), any())).thenReturn(Result.success(Unit))
+        whenever(mockK8sService.waitForPodsReady(any(), any(), eq(Constants.ClickHouse.NAMESPACE)))
+            .thenReturn(Result.success(Unit))
+
+        val command = ClickHouseStart(context)
+
+        // When
+        command.execute()
+
+        // Then - S3 secret should not be created
+        verify(mockK8sService, never()).createClickHouseS3Secret(any(), any(), any(), any())
+
+        // But manifests should still be applied
+        verify(mockK8sService, times(7)).applyManifestFromResources(eq(testControlHost), any())
+    }
+
+    @Test
+    fun `execute should skip waiting when skipWait is true`() {
+        // Given - cluster state with control node, db nodes, and S3 bucket
+        val stateWithControlAndDb =
+            ClusterState(
+                name = "test-cluster",
+                versions = mutableMapOf(),
+                hosts =
+                    mutableMapOf(
+                        ServerType.Control to listOf(testControlHost),
+                        ServerType.Cassandra to listOf(testDbHost, testDbHost2, testDbHost3),
+                    ),
+                s3Bucket = "test-bucket",
+            )
+
+        whenever(mockClusterStateManager.load()).thenReturn(stateWithControlAndDb)
+        whenever(mockK8sService.applyManifestFromResources(any(), any())).thenReturn(Result.success(Unit))
+        whenever(
+            mockK8sService.createClickHouseS3Secret(
+                any(),
+                eq(Constants.ClickHouse.NAMESPACE),
+                eq("us-west-2"),
+                eq("test-bucket"),
+            ),
+        ).thenReturn(Result.success(Unit))
+
+        val command = ClickHouseStart(context)
+        command.skipWait = true
+
+        // When
+        command.execute()
+
+        // Then
+        verify(mockK8sService, times(7)).applyManifestFromResources(eq(testControlHost), any())
+        verify(mockK8sService, never()).waitForPodsReady(any(), any(), any())
+    }
+
+    @Test
+    fun `execute should fail when applyManifestFromResources fails`() {
+        // Given - cluster state with control node, db nodes, and S3 bucket
+        val stateWithControlAndDb =
+            ClusterState(
+                name = "test-cluster",
+                versions = mutableMapOf(),
+                hosts =
+                    mutableMapOf(
+                        ServerType.Control to listOf(testControlHost),
+                        ServerType.Cassandra to listOf(testDbHost, testDbHost2, testDbHost3),
+                    ),
+                s3Bucket = "test-bucket",
+            )
+
+        whenever(mockClusterStateManager.load()).thenReturn(stateWithControlAndDb)
+        whenever(
+            mockK8sService.createClickHouseS3Secret(
+                any(),
+                eq(Constants.ClickHouse.NAMESPACE),
+                eq("us-west-2"),
+                eq("test-bucket"),
+            ),
+        ).thenReturn(Result.success(Unit))
+        whenever(mockK8sService.applyManifestFromResources(any(), any()))
+            .thenReturn(Result.failure(RuntimeException("kubectl apply failed")))
+
+        val command = ClickHouseStart(context)
+
+        // When/Then
+        assertThatThrownBy { command.execute() }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("kubectl apply failed")
+    }
+
+    @Test
+    fun `execute should use custom timeout value`() {
+        // Given - cluster state with control node, db nodes, and S3 bucket
+        val stateWithControlAndDb =
+            ClusterState(
+                name = "test-cluster",
+                versions = mutableMapOf(),
+                hosts =
+                    mutableMapOf(
+                        ServerType.Control to listOf(testControlHost),
+                        ServerType.Cassandra to listOf(testDbHost, testDbHost2, testDbHost3),
+                    ),
+                s3Bucket = "test-bucket",
+            )
+
+        whenever(mockClusterStateManager.load()).thenReturn(stateWithControlAndDb)
+        whenever(mockK8sService.applyManifestFromResources(any(), any())).thenReturn(Result.success(Unit))
+        whenever(
+            mockK8sService.createClickHouseS3Secret(
+                any(),
+                eq(Constants.ClickHouse.NAMESPACE),
+                eq("us-west-2"),
+                eq("test-bucket"),
+            ),
+        ).thenReturn(Result.success(Unit))
+        whenever(mockK8sService.waitForPodsReady(any(), eq(600), eq(Constants.ClickHouse.NAMESPACE)))
+            .thenReturn(Result.success(Unit))
+
+        val command = ClickHouseStart(context)
+        command.timeoutSeconds = 600
+
+        // When
+        command.execute()
+
+        // Then
+        verify(mockK8sService).waitForPodsReady(any(), eq(600), eq(Constants.ClickHouse.NAMESPACE))
+    }
+
+    @Test
+    fun `execute should fail when no db nodes exist`() {
+        // Given - cluster state with control node but no db nodes
+        val stateWithControlOnly =
+            ClusterState(
+                name = "test-cluster",
+                versions = mutableMapOf(),
+                hosts =
+                    mutableMapOf(
+                        ServerType.Control to listOf(testControlHost),
+                    ),
+                s3Bucket = "test-bucket",
+            )
+
+        whenever(mockClusterStateManager.load()).thenReturn(stateWithControlOnly)
+        whenever(mockK8sService.applyManifestFromResources(any(), any())).thenReturn(Result.success(Unit))
+        whenever(mockK8sService.waitForPodsReady(any(), any(), eq(Constants.ClickHouse.NAMESPACE)))
+            .thenReturn(Result.success(Unit))
+
+        val command = ClickHouseStart(context)
+
+        // When/Then
+        assertThatThrownBy { command.execute() }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("No db nodes found")
+    }
+
+    @Test
+    fun `execute should fail when fewer than 3 db nodes exist`() {
+        // Given - cluster state with control node but only 2 db nodes (less than minimum required)
+        val stateWithInsufficientNodes =
+            ClusterState(
+                name = "test-cluster",
+                versions = mutableMapOf(),
+                hosts =
+                    mutableMapOf(
+                        ServerType.Control to listOf(testControlHost),
+                        ServerType.Cassandra to listOf(testDbHost, testDbHost2),
+                    ),
+                s3Bucket = "test-bucket",
+            )
+
+        whenever(mockClusterStateManager.load()).thenReturn(stateWithInsufficientNodes)
+
+        val command = ClickHouseStart(context)
+
+        // When/Then
+        assertThatThrownBy { command.execute() }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("requires at least")
+            .hasMessageContaining("3 nodes")
+    }
+
+    @Test
+    fun `execute should warn when S3 secret creation fails but continue`() {
+        // Given - cluster state with control node, db nodes, and S3 bucket
+        val stateWithControlAndDb =
+            ClusterState(
+                name = "test-cluster",
+                versions = mutableMapOf(),
+                hosts =
+                    mutableMapOf(
+                        ServerType.Control to listOf(testControlHost),
+                        ServerType.Cassandra to listOf(testDbHost, testDbHost2, testDbHost3),
+                    ),
+                s3Bucket = "test-bucket",
+            )
+
+        whenever(mockClusterStateManager.load()).thenReturn(stateWithControlAndDb)
+        whenever(mockK8sService.applyManifestFromResources(any(), any())).thenReturn(Result.success(Unit))
+        whenever(mockK8sService.createClickHouseS3Secret(any(), any(), any(), any()))
+            .thenReturn(Result.failure(RuntimeException("Failed to create secret")))
+        whenever(mockK8sService.waitForPodsReady(any(), any(), eq(Constants.ClickHouse.NAMESPACE)))
+            .thenReturn(Result.success(Unit))
+
+        val command = ClickHouseStart(context)
+
+        // When - should not throw, just warn
+        command.execute()
+
+        // Then - manifests should still be applied despite S3 secret failure
+        verify(mockK8sService, times(7)).applyManifestFromResources(eq(testControlHost), any())
+        verify(mockK8sService).waitForPodsReady(eq(testControlHost), any(), eq(Constants.ClickHouse.NAMESPACE))
+    }
+}

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/commands/clickhouse/ClickHouseStatusTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/commands/clickhouse/ClickHouseStatusTest.kt
@@ -1,0 +1,206 @@
+package com.rustyrazorblade.easydblab.commands.clickhouse
+
+import com.rustyrazorblade.easydblab.BaseKoinTest
+import com.rustyrazorblade.easydblab.Constants
+import com.rustyrazorblade.easydblab.configuration.ClusterHost
+import com.rustyrazorblade.easydblab.configuration.ClusterState
+import com.rustyrazorblade.easydblab.configuration.ClusterStateManager
+import com.rustyrazorblade.easydblab.configuration.ServerType
+import com.rustyrazorblade.easydblab.services.K8sService
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.koin.core.module.Module
+import org.koin.dsl.module
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+/**
+ * Test suite for ClickHouseStatus command following TDD principles.
+ *
+ * These tests verify ClickHouse cluster status retrieval including
+ * namespace status queries and K8sService integration.
+ */
+class ClickHouseStatusTest : BaseKoinTest() {
+    private lateinit var mockK8sService: K8sService
+    private lateinit var mockClusterStateManager: ClusterStateManager
+
+    private val testControlHost =
+        ClusterHost(
+            publicIp = "54.123.45.67",
+            privateIp = "10.0.1.5",
+            alias = "control0",
+            availabilityZone = "us-west-2a",
+            instanceId = "i-test123",
+        )
+
+    private val testDbHost =
+        ClusterHost(
+            publicIp = "54.123.45.68",
+            privateIp = "10.0.1.6",
+            alias = "cassandra0",
+            availabilityZone = "us-west-2a",
+            instanceId = "i-test124",
+        )
+
+    override fun additionalTestModules(): List<Module> =
+        listOf(
+            module {
+                single {
+                    mock<K8sService>().also {
+                        mockK8sService = it
+                    }
+                }
+
+                single {
+                    mock<ClusterStateManager>().also {
+                        mockClusterStateManager = it
+                    }
+                }
+            },
+        )
+
+    @BeforeEach
+    fun setupMocks() {
+        mockK8sService = getKoin().get()
+        mockClusterStateManager = getKoin().get()
+    }
+
+    @Test
+    fun `execute should fail when no control nodes exist`() {
+        // Given - cluster state with no control nodes
+        val emptyState =
+            ClusterState(
+                name = "test-cluster",
+                versions = mutableMapOf(),
+                hosts = mutableMapOf(),
+            )
+
+        whenever(mockClusterStateManager.load()).thenReturn(emptyState)
+
+        val command = ClickHouseStatus(context)
+
+        // When/Then
+        assertThatThrownBy { command.execute() }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("No control nodes found")
+    }
+
+    @Test
+    fun `execute should get namespace status successfully`() {
+        // Given - cluster state with control node and db nodes
+        val stateWithControlAndDb =
+            ClusterState(
+                name = "test-cluster",
+                versions = mutableMapOf(),
+                hosts =
+                    mutableMapOf(
+                        ServerType.Control to listOf(testControlHost),
+                        ServerType.Cassandra to listOf(testDbHost),
+                    ),
+            )
+
+        val statusOutput =
+            """
+            NAME                              READY   STATUS    RESTARTS   AGE
+            clickhouse-keeper-0               1/1     Running   0          5m
+            clickhouse-keeper-1               1/1     Running   0          5m
+            clickhouse-keeper-2               1/1     Running   0          5m
+            clickhouse-server-0               1/1     Running   0          5m
+            clickhouse-server-1               1/1     Running   0          5m
+            """.trimIndent()
+
+        whenever(mockClusterStateManager.load()).thenReturn(stateWithControlAndDb)
+        whenever(mockK8sService.getNamespaceStatus(any(), eq(Constants.ClickHouse.NAMESPACE)))
+            .thenReturn(Result.success(statusOutput))
+
+        val command = ClickHouseStatus(context)
+
+        // When
+        command.execute()
+
+        // Then
+        verify(mockK8sService).getNamespaceStatus(eq(testControlHost), eq(Constants.ClickHouse.NAMESPACE))
+    }
+
+    @Test
+    fun `execute should fail when getNamespaceStatus fails`() {
+        // Given - cluster state with control node and db nodes
+        val stateWithControlAndDb =
+            ClusterState(
+                name = "test-cluster",
+                versions = mutableMapOf(),
+                hosts =
+                    mutableMapOf(
+                        ServerType.Control to listOf(testControlHost),
+                        ServerType.Cassandra to listOf(testDbHost),
+                    ),
+            )
+
+        whenever(mockClusterStateManager.load()).thenReturn(stateWithControlAndDb)
+        whenever(mockK8sService.getNamespaceStatus(any(), eq(Constants.ClickHouse.NAMESPACE)))
+            .thenReturn(Result.failure(RuntimeException("Namespace not found")))
+
+        val command = ClickHouseStatus(context)
+
+        // When/Then
+        assertThatThrownBy { command.execute() }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("Namespace not found")
+    }
+
+    @Test
+    fun `execute should use correct ClickHouse namespace`() {
+        // Given - cluster state with control node and db nodes
+        val stateWithControlAndDb =
+            ClusterState(
+                name = "test-cluster",
+                versions = mutableMapOf(),
+                hosts =
+                    mutableMapOf(
+                        ServerType.Control to listOf(testControlHost),
+                        ServerType.Cassandra to listOf(testDbHost),
+                    ),
+            )
+
+        whenever(mockClusterStateManager.load()).thenReturn(stateWithControlAndDb)
+        whenever(mockK8sService.getNamespaceStatus(any(), eq("default")))
+            .thenReturn(Result.success("Running"))
+
+        val command = ClickHouseStatus(context)
+
+        // When
+        command.execute()
+
+        // Then - verify the default namespace is used
+        verify(mockK8sService).getNamespaceStatus(any(), eq("default"))
+    }
+
+    @Test
+    fun `execute should fail when no db nodes exist`() {
+        // Given - cluster state with control node but no db nodes
+        val stateWithControlOnly =
+            ClusterState(
+                name = "test-cluster",
+                versions = mutableMapOf(),
+                hosts =
+                    mutableMapOf(
+                        ServerType.Control to listOf(testControlHost),
+                    ),
+            )
+
+        whenever(mockClusterStateManager.load()).thenReturn(stateWithControlOnly)
+        whenever(mockK8sService.getNamespaceStatus(any(), eq(Constants.ClickHouse.NAMESPACE)))
+            .thenReturn(Result.success("Running"))
+
+        val command = ClickHouseStatus(context)
+
+        // When/Then
+        assertThatThrownBy { command.execute() }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("No db nodes found")
+    }
+}

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/commands/clickhouse/ClickHouseStopTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/commands/clickhouse/ClickHouseStopTest.kt
@@ -1,0 +1,225 @@
+package com.rustyrazorblade.easydblab.commands.clickhouse
+
+import com.rustyrazorblade.easydblab.BaseKoinTest
+import com.rustyrazorblade.easydblab.Constants
+import com.rustyrazorblade.easydblab.configuration.ClusterHost
+import com.rustyrazorblade.easydblab.configuration.ClusterState
+import com.rustyrazorblade.easydblab.configuration.ClusterStateManager
+import com.rustyrazorblade.easydblab.configuration.ServerType
+import com.rustyrazorblade.easydblab.services.K8sService
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.koin.core.module.Module
+import org.koin.dsl.module
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+/**
+ * Test suite for ClickHouseStop command following TDD principles.
+ *
+ * These tests verify ClickHouse cluster stop and removal including
+ * label-based resource deletion and safety confirmation.
+ */
+class ClickHouseStopTest : BaseKoinTest() {
+    private lateinit var mockK8sService: K8sService
+    private lateinit var mockClusterStateManager: ClusterStateManager
+
+    private val testControlHost =
+        ClusterHost(
+            publicIp = "54.123.45.67",
+            privateIp = "10.0.1.5",
+            alias = "control0",
+            availabilityZone = "us-west-2a",
+            instanceId = "i-test123",
+        )
+
+    override fun additionalTestModules(): List<Module> =
+        listOf(
+            module {
+                single {
+                    mock<K8sService>().also {
+                        mockK8sService = it
+                    }
+                }
+
+                single {
+                    mock<ClusterStateManager>().also {
+                        mockClusterStateManager = it
+                    }
+                }
+            },
+        )
+
+    @BeforeEach
+    fun setupMocks() {
+        mockK8sService = getKoin().get()
+        mockClusterStateManager = getKoin().get()
+    }
+
+    @Test
+    fun `command has correct default options`() {
+        val command = ClickHouseStop(context)
+
+        assertThat(command.force).isFalse()
+    }
+
+    @Test
+    fun `execute should fail when no control nodes exist`() {
+        // Given - cluster state with no control nodes
+        val emptyState =
+            ClusterState(
+                name = "test-cluster",
+                versions = mutableMapOf(),
+                hosts = mutableMapOf(),
+            )
+
+        whenever(mockClusterStateManager.load()).thenReturn(emptyState)
+
+        val command = ClickHouseStop(context)
+        command.force = true
+
+        // When/Then
+        assertThatThrownBy { command.execute() }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("No control nodes found")
+    }
+
+    @Test
+    fun `execute without force flag should not delete resources`() {
+        // Given - cluster state with control node
+        val stateWithControl =
+            ClusterState(
+                name = "test-cluster",
+                versions = mutableMapOf(),
+                hosts =
+                    mutableMapOf(
+                        ServerType.Control to listOf(testControlHost),
+                    ),
+            )
+
+        whenever(mockClusterStateManager.load()).thenReturn(stateWithControl)
+
+        val command = ClickHouseStop(context)
+        command.force = false
+
+        // When
+        command.execute()
+
+        // Then - deleteResourcesByLabel should NOT be called without --force
+        verify(mockK8sService, never()).deleteResourcesByLabel(any(), any(), any(), any())
+    }
+
+    @Test
+    fun `execute with force flag should delete resources by label`() {
+        // Given - cluster state with control node
+        val stateWithControl =
+            ClusterState(
+                name = "test-cluster",
+                versions = mutableMapOf(),
+                hosts =
+                    mutableMapOf(
+                        ServerType.Control to listOf(testControlHost),
+                    ),
+            )
+
+        whenever(mockClusterStateManager.load()).thenReturn(stateWithControl)
+        whenever(
+            mockK8sService.deleteResourcesByLabel(
+                any(),
+                eq(Constants.ClickHouse.NAMESPACE),
+                eq("app.kubernetes.io/name"),
+                eq(listOf("clickhouse-server", "clickhouse-keeper")),
+            ),
+        ).thenReturn(Result.success(Unit))
+
+        val command = ClickHouseStop(context)
+        command.force = true
+
+        // When
+        command.execute()
+
+        // Then
+        verify(mockK8sService).deleteResourcesByLabel(
+            eq(testControlHost),
+            eq(Constants.ClickHouse.NAMESPACE),
+            eq("app.kubernetes.io/name"),
+            eq(listOf("clickhouse-server", "clickhouse-keeper")),
+        )
+    }
+
+    @Test
+    fun `execute should fail when deleteResourcesByLabel fails`() {
+        // Given - cluster state with control node
+        val stateWithControl =
+            ClusterState(
+                name = "test-cluster",
+                versions = mutableMapOf(),
+                hosts =
+                    mutableMapOf(
+                        ServerType.Control to listOf(testControlHost),
+                    ),
+            )
+
+        whenever(mockClusterStateManager.load()).thenReturn(stateWithControl)
+        whenever(
+            mockK8sService.deleteResourcesByLabel(
+                any(),
+                eq(Constants.ClickHouse.NAMESPACE),
+                eq("app.kubernetes.io/name"),
+                eq(listOf("clickhouse-server", "clickhouse-keeper")),
+            ),
+        ).thenReturn(Result.failure(RuntimeException("Resource deletion failed")))
+
+        val command = ClickHouseStop(context)
+        command.force = true
+
+        // When/Then
+        assertThatThrownBy { command.execute() }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("Resource deletion failed")
+    }
+
+    @Test
+    fun `execute should use correct ClickHouse label values for deletion`() {
+        // Given - cluster state with control node
+        val stateWithControl =
+            ClusterState(
+                name = "test-cluster",
+                versions = mutableMapOf(),
+                hosts =
+                    mutableMapOf(
+                        ServerType.Control to listOf(testControlHost),
+                    ),
+            )
+
+        whenever(mockClusterStateManager.load()).thenReturn(stateWithControl)
+        whenever(
+            mockK8sService.deleteResourcesByLabel(
+                any(),
+                any(),
+                any(),
+                any(),
+            ),
+        ).thenReturn(Result.success(Unit))
+
+        val command = ClickHouseStop(context)
+        command.force = true
+
+        // When
+        command.execute()
+
+        // Then - verify the correct label values are used
+        verify(mockK8sService).deleteResourcesByLabel(
+            any(),
+            eq("default"),
+            eq("app.kubernetes.io/name"),
+            eq(listOf("clickhouse-server", "clickhouse-keeper")),
+        )
+    }
+}

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/configuration/ClusterStateTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/configuration/ClusterStateTest.kt
@@ -1,6 +1,7 @@
 package com.rustyrazorblade.easydblab.configuration
 
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.io.File
@@ -643,24 +644,26 @@ class ClusterStateTest {
             ClusterState(
                 name = "test-cluster",
                 versions = mutableMapOf(),
+                s3Bucket = "easy-db-lab-test-abc12345",
             )
 
-        val user =
-            User(
-                email = "test@example.com",
-                region = "us-west-2",
-                keyName = "test-key",
-                sshKeyPath = "/path/to/key",
-                awsProfile = "",
-                awsAccessKey = "",
-                awsSecret = "",
-                s3Bucket = "my-test-bucket",
+        val s3Path = state.s3Path()
+
+        assertThat(s3Path.bucket).isEqualTo("easy-db-lab-test-abc12345")
+        assertThat(s3Path.toString()).isEqualTo("s3://easy-db-lab-test-abc12345")
+    }
+
+    @Test
+    fun `s3Path extension function should throw when s3Bucket not configured`() {
+        val state =
+            ClusterState(
+                name = "test-cluster",
+                versions = mutableMapOf(),
+                s3Bucket = null,
             )
 
-        val s3Path = state.s3Path(user)
-
-        assertThat(s3Path.bucket).isEqualTo("my-test-bucket")
-        assertThat(s3Path.toString()).contains(state.clusterId)
-        assertThat(s3Path.toString()).startsWith("s3://my-test-bucket/clusters/")
+        assertThatThrownBy { state.s3Path() }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("S3 bucket not configured")
     }
 }

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/kubernetes/ManifestApplierTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/kubernetes/ManifestApplierTest.kt
@@ -1,0 +1,149 @@
+package com.rustyrazorblade.easydblab.kubernetes
+
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+
+/**
+ * Test suite for ManifestApplier utility.
+ *
+ * These tests verify YAML parsing and error handling for Kubernetes manifests,
+ * including multi-document YAML file support.
+ *
+ * Note: Full integration testing of fabric8 client operations requires a running
+ * K8s cluster or complex mock setup. These tests focus on validation logic.
+ */
+class ManifestApplierTest {
+    @TempDir
+    lateinit var tempDir: Path
+
+    @Test
+    fun `applyManifest should throw when kind is missing`() {
+        val yaml =
+            """
+            apiVersion: v1
+            metadata:
+              name: test
+            """.trimIndent()
+
+        val file = tempDir.resolve("invalid.yaml").toFile()
+        file.writeText(yaml)
+
+        // Pass null client - we expect it to fail on kind validation before reaching client
+        assertThatThrownBy {
+            ManifestApplier.applyManifest(
+                createNullClient(),
+                file,
+            )
+        }.isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("missing 'kind' field")
+    }
+
+    @Test
+    fun `applyManifest should throw for unsupported kind`() {
+        val yaml =
+            """
+            apiVersion: v1
+            kind: UnsupportedResource
+            metadata:
+              name: test
+            """.trimIndent()
+
+        val file = tempDir.resolve("unsupported.yaml").toFile()
+        file.writeText(yaml)
+
+        assertThatThrownBy {
+            ManifestApplier.applyManifest(
+                createNullClient(),
+                file,
+            )
+        }.isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("Unsupported resource kind")
+    }
+
+    @Test
+    fun `applyManifest should handle empty file gracefully`() {
+        val yaml = ""
+
+        val file = tempDir.resolve("empty.yaml").toFile()
+        file.writeText(yaml)
+
+        // Empty file should not throw - just does nothing
+        ManifestApplier.applyManifest(createNullClient(), file)
+    }
+
+    @Test
+    fun `applyManifest should throw for multi-doc when second document has missing kind`() {
+        // Test that the second document's missing kind is detected
+        // Note: This will fail on the first doc attempting to apply, but if we use
+        // a YAML with both docs missing kind, we can verify the parsing works
+        val yaml =
+            """
+            ---
+            apiVersion: v1
+            metadata:
+              name: invalid-doc-one
+            ---
+            apiVersion: v1
+            metadata:
+              name: invalid-doc-two
+            """.trimIndent()
+
+        val file = tempDir.resolve("multi-invalid.yaml").toFile()
+        file.writeText(yaml)
+
+        // First document is missing kind, should fail immediately
+        assertThatThrownBy {
+            ManifestApplier.applyManifest(
+                createNullClient(),
+                file,
+            )
+        }.isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("missing 'kind' field")
+    }
+
+    @Test
+    fun `applyYaml should throw when kind is missing`() {
+        val yaml =
+            """
+            apiVersion: v1
+            metadata:
+              name: test
+            """.trimIndent()
+
+        assertThatThrownBy { ManifestApplier.applyYaml(createNullClient(), yaml) }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("missing 'kind' field")
+    }
+
+    @Test
+    fun `applyYaml should throw for unsupported kind`() {
+        val yaml =
+            """
+            apiVersion: v1
+            kind: CustomResourceDefinition
+            metadata:
+              name: test
+            """.trimIndent()
+
+        assertThatThrownBy { ManifestApplier.applyYaml(createNullClient(), yaml) }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("Unsupported resource kind")
+    }
+
+    /**
+     * Creates a mock-like client that throws NPE when accessed.
+     * This allows testing validation logic that runs before client operations.
+     */
+    @Suppress("UNCHECKED_CAST")
+    private fun createNullClient(): io.fabric8.kubernetes.client.KubernetesClient {
+        // Use a proxy that throws NPE for any method call
+        return java.lang.reflect.Proxy.newProxyInstance(
+            io.fabric8.kubernetes.client.KubernetesClient::class.java.classLoader,
+            arrayOf(io.fabric8.kubernetes.client.KubernetesClient::class.java),
+        ) { _, _, _ ->
+            throw NullPointerException("Client method should not be called for validation tests")
+        } as io.fabric8.kubernetes.client.KubernetesClient
+    }
+}

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/providers/AWSTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/providers/AWSTest.kt
@@ -151,7 +151,6 @@ internal class AWSTest :
     @Test
     fun createRoleWithS3PolicySuccess() {
         val roleName = "easy-db-lab-test-role"
-        val bucketName = "easy-db-lab-test-bucket"
 
         // Setup mock responses
         val mockRole =
@@ -211,7 +210,7 @@ internal class AWSTest :
             .thenReturn(listPoliciesResponse)
 
         // Execute the method
-        val result = aws.createRoleWithS3Policy(roleName, bucketName)
+        val result = aws.createRoleWithS3Policy(roleName)
 
         // Verify the expected calls were made
         verify(mockIamClient).createRole(any<CreateRoleRequest>())
@@ -228,7 +227,6 @@ internal class AWSTest :
     @Test
     fun createRoleWithS3PolicyRoleAlreadyExists() {
         val roleName = "easy-db-lab-existing-role"
-        val bucketName = "easy-db-lab-test-bucket"
 
         val mockRole =
             Role
@@ -288,7 +286,7 @@ internal class AWSTest :
             .thenReturn(listPoliciesResponse)
 
         // Execute the method - should not throw exception
-        val result = aws.createRoleWithS3Policy(roleName, bucketName)
+        val result = aws.createRoleWithS3Policy(roleName)
 
         // Verify the createRole was attempted
         verify(mockIamClient).createRole(any<CreateRoleRequest>())
@@ -301,17 +299,15 @@ internal class AWSTest :
 
     @Test
     fun createRoleWithS3PolicyInvalidRoleName() {
-        val bucketName = "easy-db-lab-test-bucket"
-
         // Test with invalid characters
         assertThrows<IllegalArgumentException> {
-            aws.createRoleWithS3Policy("invalid role name with spaces", bucketName)
+            aws.createRoleWithS3Policy("invalid role name with spaces")
         }
 
         // Test with too long name (> 64 chars)
         val longName = "a".repeat(65)
         assertThrows<IllegalArgumentException> {
-            aws.createRoleWithS3Policy(longName, bucketName)
+            aws.createRoleWithS3Policy(longName)
         }
     }
 

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/providers/aws/EC2InstanceServiceTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/providers/aws/EC2InstanceServiceTest.kt
@@ -369,6 +369,21 @@ internal class EC2InstanceServiceTest {
         assertThat(capturedRequests[1].subnetId()).isEqualTo("subnet-b")
     }
 
+    @Test
+    fun `waitForInstanceStatusOk should return immediately for empty list`() {
+        // Should not throw and should not call the EC2 client
+        ec2InstanceService.waitForInstanceStatusOk(emptyList())
+
+        // Verify no calls were made to the EC2 client (waiter is never created for empty list)
+        // Note: The waiter uses its own client internally, so we verify no status calls were made
+        verify(
+            mockEc2Client,
+            times(0),
+        ).describeInstanceStatus(
+            any<software.amazon.awssdk.services.ec2.model.DescribeInstanceStatusRequest>(),
+        )
+    }
+
     private fun createInstance(
         instanceId: String,
         serverType: String,

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/providers/aws/S3ObjectStoreTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/providers/aws/S3ObjectStoreTest.kt
@@ -56,7 +56,7 @@ class S3ObjectStoreTest : BaseKoinTest() {
         // Given
         val testFile = tempDir.resolve("test.jar").toFile()
         testFile.writeText("test content")
-        val s3Path = ClusterS3Path.from("test-bucket", "cluster-123").sparkJars().resolve("test.jar")
+        val s3Path = ClusterS3Path.root("test-bucket").spark().resolve("test.jar")
 
         // Initialize ObjectStore (triggers mock creation)
         objectStore = get()
@@ -77,7 +77,7 @@ class S3ObjectStoreTest : BaseKoinTest() {
     fun `uploadFile throws exception when file does not exist`() {
         // Given
         val nonexistentFile = File("/nonexistent/file.jar")
-        val s3Path = ClusterS3Path.from("test-bucket", "cluster-123").sparkJars().resolve("test.jar")
+        val s3Path = ClusterS3Path.root("test-bucket").spark().resolve("test.jar")
 
         // When/Then
         objectStore = get()
@@ -92,7 +92,7 @@ class S3ObjectStoreTest : BaseKoinTest() {
         @TempDir tempDir: Path,
     ) {
         // Given
-        val s3Path = ClusterS3Path.from("test-bucket", "cluster-123").sparkJars().resolve("test.jar")
+        val s3Path = ClusterS3Path.root("test-bucket").spark().resolve("test.jar")
         val localPath = tempDir.resolve("downloaded.jar")
         val testContent = "test content".toByteArray()
 
@@ -119,7 +119,7 @@ class S3ObjectStoreTest : BaseKoinTest() {
     @Test
     fun `fileExists returns true when file exists in S3`() {
         // Given
-        val s3Path = ClusterS3Path.from("test-bucket", "cluster-123").sparkJars().resolve("test.jar")
+        val s3Path = ClusterS3Path.root("test-bucket").spark().resolve("test.jar")
 
         // Initialize ObjectStore (triggers mock creation)
         objectStore = get()
@@ -143,7 +143,7 @@ class S3ObjectStoreTest : BaseKoinTest() {
     @Test
     fun `fileExists returns false when file does not exist in S3`() {
         // Given
-        val s3Path = ClusterS3Path.from("test-bucket", "cluster-123").sparkJars().resolve("test.jar")
+        val s3Path = ClusterS3Path.root("test-bucket").spark().resolve("test.jar")
 
         // Initialize ObjectStore (triggers mock creation)
         objectStore = get()
@@ -161,7 +161,7 @@ class S3ObjectStoreTest : BaseKoinTest() {
     @Test
     fun `getFileInfo returns metadata when file exists`() {
         // Given
-        val s3Path = ClusterS3Path.from("test-bucket", "cluster-123").sparkJars().resolve("test.jar")
+        val s3Path = ClusterS3Path.root("test-bucket").spark().resolve("test.jar")
         val lastModified = Instant.now()
 
         // Initialize ObjectStore (triggers mock creation)
@@ -189,7 +189,7 @@ class S3ObjectStoreTest : BaseKoinTest() {
     @Test
     fun `getFileInfo returns null when file does not exist`() {
         // Given
-        val s3Path = ClusterS3Path.from("test-bucket", "cluster-123").sparkJars().resolve("test.jar")
+        val s3Path = ClusterS3Path.root("test-bucket").spark().resolve("test.jar")
 
         // Initialize ObjectStore (triggers mock creation)
         objectStore = get()
@@ -207,7 +207,7 @@ class S3ObjectStoreTest : BaseKoinTest() {
     @Test
     fun `listFiles returns files under prefix`() {
         // Given
-        val s3Path = ClusterS3Path.from("test-bucket", "cluster-123").sparkJars()
+        val s3Path = ClusterS3Path.root("test-bucket").spark()
         val lastModified = Instant.now()
 
         // Initialize ObjectStore (triggers mock creation)
@@ -216,7 +216,7 @@ class S3ObjectStoreTest : BaseKoinTest() {
         val s3Object1 =
             S3Object
                 .builder()
-                .key("clusters/cluster-123/spark-jars/app1.jar")
+                .key("spark/app1.jar")
                 .size(1024L)
                 .lastModified(lastModified)
                 .build()
@@ -224,7 +224,7 @@ class S3ObjectStoreTest : BaseKoinTest() {
         val s3Object2 =
             S3Object
                 .builder()
-                .key("clusters/cluster-123/spark-jars/app2.jar")
+                .key("spark/app2.jar")
                 .size(2048L)
                 .lastModified(lastModified)
                 .build()
@@ -252,7 +252,7 @@ class S3ObjectStoreTest : BaseKoinTest() {
     @Test
     fun `deleteFile removes file from S3`() {
         // Given
-        val s3Path = ClusterS3Path.from("test-bucket", "cluster-123").sparkJars().resolve("test.jar")
+        val s3Path = ClusterS3Path.root("test-bucket").spark().resolve("test.jar")
 
         // Initialize ObjectStore (triggers mock creation)
         objectStore = get()
@@ -272,7 +272,7 @@ class S3ObjectStoreTest : BaseKoinTest() {
     @Test
     fun `listFiles returns empty list when no files exist`() {
         // Given
-        val s3Path = ClusterS3Path.from("test-bucket", "cluster-123").sparkJars()
+        val s3Path = ClusterS3Path.root("test-bucket").spark()
 
         // Initialize ObjectStore (triggers mock creation)
         objectStore = get()
@@ -298,7 +298,7 @@ class S3ObjectStoreTest : BaseKoinTest() {
     @Test
     fun `listFiles returns empty list when contents is null`() {
         // Given
-        val s3Path = ClusterS3Path.from("test-bucket", "cluster-123").sparkJars()
+        val s3Path = ClusterS3Path.root("test-bucket").spark()
 
         // Initialize ObjectStore (triggers mock creation)
         objectStore = get()
@@ -329,7 +329,7 @@ class S3ObjectStoreTest : BaseKoinTest() {
         // Given
         val testFile = tempDir.resolve("test.jar").toFile()
         testFile.writeText("test content")
-        val s3Path = ClusterS3Path.from("test-bucket", "cluster-123").sparkJars().resolve("test.jar")
+        val s3Path = ClusterS3Path.root("test-bucket").spark().resolve("test.jar")
 
         objectStore = get()
 
@@ -353,7 +353,7 @@ class S3ObjectStoreTest : BaseKoinTest() {
         @TempDir tempDir: Path,
     ) {
         // Given
-        val s3Path = ClusterS3Path.from("test-bucket", "cluster-123").sparkJars().resolve("test.jar")
+        val s3Path = ClusterS3Path.root("test-bucket").spark().resolve("test.jar")
         val localPath = tempDir.resolve("downloaded.jar")
 
         objectStore = get()
@@ -376,7 +376,7 @@ class S3ObjectStoreTest : BaseKoinTest() {
     @Test
     fun `fileExists throws exception on S3 server error`() {
         // Given
-        val s3Path = ClusterS3Path.from("test-bucket", "cluster-123").sparkJars().resolve("test.jar")
+        val s3Path = ClusterS3Path.root("test-bucket").spark().resolve("test.jar")
 
         objectStore = get()
 
@@ -398,7 +398,7 @@ class S3ObjectStoreTest : BaseKoinTest() {
     @Test
     fun `getFileInfo throws exception on S3 server error`() {
         // Given
-        val s3Path = ClusterS3Path.from("test-bucket", "cluster-123").sparkJars().resolve("test.jar")
+        val s3Path = ClusterS3Path.root("test-bucket").spark().resolve("test.jar")
 
         objectStore = get()
 
@@ -420,7 +420,7 @@ class S3ObjectStoreTest : BaseKoinTest() {
     @Test
     fun `deleteFile throws exception on S3 error`() {
         // Given
-        val s3Path = ClusterS3Path.from("test-bucket", "cluster-123").sparkJars().resolve("test.jar")
+        val s3Path = ClusterS3Path.root("test-bucket").spark().resolve("test.jar")
 
         objectStore = get()
 

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/services/AWSResourceSetupServiceTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/services/AWSResourceSetupServiceTest.kt
@@ -3,7 +3,6 @@ package com.rustyrazorblade.easydblab.services
 import com.rustyrazorblade.easydblab.BaseKoinTest
 import com.rustyrazorblade.easydblab.Constants
 import com.rustyrazorblade.easydblab.configuration.User
-import com.rustyrazorblade.easydblab.configuration.UserConfigProvider
 import com.rustyrazorblade.easydblab.output.OutputHandler
 import com.rustyrazorblade.easydblab.providers.aws.AWS
 import org.assertj.core.api.Assertions.assertThat
@@ -12,8 +11,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.koin.core.component.KoinComponent
 import org.mockito.kotlin.any
-import org.mockito.kotlin.argumentCaptor
-import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
@@ -23,14 +20,14 @@ import software.amazon.awssdk.services.iam.model.IamException
 /**
  * Tests for AWSResourceSetupService.
  *
- * Validates AWS resource setup orchestration including:
- * - Early return when resources already exist and valid
- * - Full setup workflow when resources missing
+ * Validates AWS IAM resource setup orchestration including:
+ * - Early return when IAM resources already exist and valid
+ * - Full IAM setup workflow when resources missing
  * - Repair workflow when validation fails
  * - Error handling for various failure scenarios
  *
- * Note: These tests use mocks for all dependencies including AWS service
- * to isolate and verify the orchestration logic at the service layer.
+ * Note: S3 bucket creation is now handled per-environment in the Up command,
+ * not in this service. This service only handles IAM role setup with wildcard S3 policy.
  */
 internal class AWSResourceSetupServiceTest :
     BaseKoinTest(),
@@ -40,19 +37,18 @@ internal class AWSResourceSetupServiceTest :
 
     // Mock dependencies - fully mocked AWS for service-level orchestration testing
     private val mockAws: AWS = mock()
-    private val mockUserConfigProvider: UserConfigProvider = mock()
     private val mockOutputHandler: OutputHandler = mock()
 
     @BeforeEach
     fun setupTest() {
-        // Create service with mocked dependencies
-        service = AWSResourceSetupService(mockAws, mockUserConfigProvider, mockOutputHandler)
+        // Create service with mocked dependencies (no more userConfigProvider)
+        service = AWSResourceSetupService(mockAws, mockOutputHandler)
     }
 
     @Test
-    fun `ensureAWSResources should skip setup when resources exist and valid`() {
-        // Given: User config with existing S3 bucket
-        val userConfig = createUserConfig(s3Bucket = "test-bucket")
+    fun `ensureAWSResources should skip setup when IAM resources exist and valid`() {
+        // Given: IAM resources already configured
+        val userConfig = createUserConfig()
 
         // Mock validation to return valid
         val validValidation =
@@ -72,69 +68,21 @@ internal class AWSResourceSetupServiceTest :
         // Then: Should validate but not create any resources
         verify(mockAws).validateRoleSetup(Constants.AWS.Roles.EC2_INSTANCE_ROLE)
         verify(mockAws, never()).checkPermissions()
-        verify(mockAws, never()).createS3Bucket(any())
-        verify(mockAws, never()).createRoleWithS3Policy(any(), any())
+        verify(mockAws, never()).createRoleWithS3Policy(any())
     }
 
     @Test
-    fun `ensureAWSResources should create resources when S3 bucket missing`() {
-        // Given: User config without S3 bucket
-        val userConfig = createUserConfig(s3Bucket = "")
-
-        // Mock successful operations
-        org.mockito.kotlin
-            .doNothing()
-            .whenever(mockAws)
-            .checkPermissions()
-        whenever(mockAws.createS3Bucket(any())).thenReturn("test-bucket")
-        whenever(mockAws.createRoleWithS3Policy(any(), any())).thenReturn(Constants.AWS.Roles.EC2_INSTANCE_ROLE)
-        whenever(mockAws.createServiceRole()).thenReturn(Constants.AWS.Roles.EMR_SERVICE_ROLE)
-        whenever(mockAws.createEMREC2Role()).thenReturn(Constants.AWS.Roles.EMR_EC2_ROLE)
-        org.mockito.kotlin
-            .doNothing()
-            .whenever(mockAws)
-            .putS3BucketPolicy(any())
-
-        val validValidation =
-            AWS.RoleValidationResult(
-                isValid = true,
-                instanceProfileExists = true,
-                roleAttached = true,
-                hasPolicies = true,
-                errorMessage = "",
-            )
-        whenever(mockAws.validateRoleSetup(Constants.AWS.Roles.EC2_INSTANCE_ROLE))
-            .thenReturn(validValidation)
-
-        // When
-        service.ensureAWSResources(userConfig)
-
-        // Then: Should execute full setup workflow
-        verify(mockAws).checkPermissions()
-        verify(mockAws).createS3Bucket(any())
-        verify(mockAws).createRoleWithS3Policy(eq(Constants.AWS.Roles.EC2_INSTANCE_ROLE), any())
-        verify(mockAws).createServiceRole()
-        verify(mockAws).createEMREC2Role()
-        verify(mockAws).putS3BucketPolicy(any())
-        verify(mockAws).validateRoleSetup(Constants.AWS.Roles.EC2_INSTANCE_ROLE)
-        verify(mockUserConfigProvider).saveUserConfig(userConfig)
-
-        // Verify S3 bucket was saved to config
-        assertThat(userConfig.s3Bucket).isNotEmpty()
-    }
-
-    @Test
-    fun `ensureAWSResources should repair resources when validation fails initially`() {
-        // Given: User config with S3 bucket but failed validation
-        val userConfig = createUserConfig(s3Bucket = "test-bucket")
+    fun `ensureAWSResources should create IAM resources when validation fails`() {
+        // Given: IAM resources not configured (validation fails initially)
+        val userConfig = createUserConfig()
 
         val invalidValidation =
             AWS.RoleValidationResult(
                 isValid = false,
                 instanceProfileExists = false,
                 roleAttached = false,
-                hasPolicies = true,
-                errorMessage = "Instance profile does not exist",
+                hasPolicies = false,
+                errorMessage = "Resources not found",
             )
         val validValidation =
             AWS.RoleValidationResult(
@@ -145,7 +93,7 @@ internal class AWSResourceSetupServiceTest :
                 errorMessage = "",
             )
 
-        // First call returns invalid, subsequent calls return valid
+        // First call returns invalid, second call (after creation) returns valid
         whenever(mockAws.validateRoleSetup(Constants.AWS.Roles.EC2_INSTANCE_ROLE))
             .thenReturn(invalidValidation, validValidation)
 
@@ -154,28 +102,80 @@ internal class AWSResourceSetupServiceTest :
             .doNothing()
             .whenever(mockAws)
             .checkPermissions()
-        whenever(mockAws.createS3Bucket(any())).thenReturn("test-bucket")
-        whenever(mockAws.createRoleWithS3Policy(any(), any())).thenReturn(Constants.AWS.Roles.EC2_INSTANCE_ROLE)
+        whenever(mockAws.createRoleWithS3Policy(any())).thenReturn(Constants.AWS.Roles.EC2_INSTANCE_ROLE)
         whenever(mockAws.createServiceRole()).thenReturn(Constants.AWS.Roles.EMR_SERVICE_ROLE)
         whenever(mockAws.createEMREC2Role()).thenReturn(Constants.AWS.Roles.EMR_EC2_ROLE)
-        org.mockito.kotlin
-            .doNothing()
-            .whenever(mockAws)
-            .putS3BucketPolicy(any())
 
         // When
         service.ensureAWSResources(userConfig)
 
-        // Then: Should output repair warning and execute full setup
-        verify(mockOutputHandler).handleMessage("Warning: IAM role configuration incomplete or invalid. Will attempt to repair.")
+        // Then: Should execute full IAM setup workflow
         verify(mockAws).checkPermissions()
-        verify(mockAws).createRoleWithS3Policy(eq(Constants.AWS.Roles.EC2_INSTANCE_ROLE), eq("test-bucket"))
+        verify(mockAws).createRoleWithS3Policy(Constants.AWS.Roles.EC2_INSTANCE_ROLE)
+        verify(mockAws).createServiceRole()
+        verify(mockAws).createEMREC2Role()
+        // Should NOT create S3 bucket or apply bucket policy (that's done in Up command now)
+        verify(mockAws, never()).createS3Bucket(any())
+        verify(mockAws, never()).putS3BucketPolicy(any())
+    }
+
+    @Test
+    fun `ensureAWSResources should output repair warning when validation initially fails`() {
+        // Given: IAM resources partially configured
+        val userConfig = createUserConfig()
+
+        val invalidValidation =
+            AWS.RoleValidationResult(
+                isValid = false,
+                instanceProfileExists = true,
+                roleAttached = false,
+                hasPolicies = true,
+                errorMessage = "Role not attached to instance profile",
+            )
+        val validValidation =
+            AWS.RoleValidationResult(
+                isValid = true,
+                instanceProfileExists = true,
+                roleAttached = true,
+                hasPolicies = true,
+                errorMessage = "",
+            )
+
+        // First call returns invalid, second returns valid
+        whenever(mockAws.validateRoleSetup(Constants.AWS.Roles.EC2_INSTANCE_ROLE))
+            .thenReturn(invalidValidation, validValidation)
+
+        // Mock successful operations
+        org.mockito.kotlin
+            .doNothing()
+            .whenever(mockAws)
+            .checkPermissions()
+        whenever(mockAws.createRoleWithS3Policy(any())).thenReturn(Constants.AWS.Roles.EC2_INSTANCE_ROLE)
+        whenever(mockAws.createServiceRole()).thenReturn(Constants.AWS.Roles.EMR_SERVICE_ROLE)
+        whenever(mockAws.createEMREC2Role()).thenReturn(Constants.AWS.Roles.EMR_EC2_ROLE)
+
+        // When
+        service.ensureAWSResources(userConfig)
+
+        // Then: Should output repair warning
+        verify(mockOutputHandler).handleMessage("Warning: IAM role configuration incomplete or invalid. Will attempt to repair.")
     }
 
     @Test
     fun `ensureAWSResources should validate credentials before setup`() {
-        // Given: User config without S3 bucket
-        val userConfig = createUserConfig(s3Bucket = "")
+        // Given: IAM resources not configured
+        val userConfig = createUserConfig()
+
+        val invalidValidation =
+            AWS.RoleValidationResult(
+                isValid = false,
+                instanceProfileExists = false,
+                roleAttached = false,
+                hasPolicies = false,
+                errorMessage = "Resources not found",
+            )
+        whenever(mockAws.validateRoleSetup(Constants.AWS.Roles.EC2_INSTANCE_ROLE))
+            .thenReturn(invalidValidation)
 
         // Mock credential validation failure
         val exception = IamException.builder().message("Access denied").build()
@@ -188,30 +188,24 @@ internal class AWSResourceSetupServiceTest :
 
         // Should call checkPermissions but not proceed to resource creation
         verify(mockAws).checkPermissions()
-        verify(mockAws, never()).createS3Bucket(any())
+        verify(mockAws, never()).createRoleWithS3Policy(any())
         // Verify user-facing error message was displayed
         verify(mockOutputHandler).handleMessage(org.mockito.kotlin.argThat { contains("AWS PERMISSION ERROR") })
     }
 
     @Test
     fun `ensureAWSResources should create all 3 IAM roles`() {
-        // Given: User config without S3 bucket
-        val userConfig = createUserConfig(s3Bucket = "")
+        // Given: IAM resources not configured
+        val userConfig = createUserConfig()
 
-        // Mock successful operations
-        org.mockito.kotlin
-            .doNothing()
-            .whenever(mockAws)
-            .checkPermissions()
-        whenever(mockAws.createS3Bucket(any())).thenReturn("test-bucket")
-        whenever(mockAws.createRoleWithS3Policy(any(), any())).thenReturn(Constants.AWS.Roles.EC2_INSTANCE_ROLE)
-        whenever(mockAws.createServiceRole()).thenReturn(Constants.AWS.Roles.EMR_SERVICE_ROLE)
-        whenever(mockAws.createEMREC2Role()).thenReturn(Constants.AWS.Roles.EMR_EC2_ROLE)
-        org.mockito.kotlin
-            .doNothing()
-            .whenever(mockAws)
-            .putS3BucketPolicy(any())
-
+        val invalidValidation =
+            AWS.RoleValidationResult(
+                isValid = false,
+                instanceProfileExists = false,
+                roleAttached = false,
+                hasPolicies = false,
+                errorMessage = "Resources not found",
+            )
         val validValidation =
             AWS.RoleValidationResult(
                 isValid = true,
@@ -221,117 +215,30 @@ internal class AWSResourceSetupServiceTest :
                 errorMessage = "",
             )
         whenever(mockAws.validateRoleSetup(Constants.AWS.Roles.EC2_INSTANCE_ROLE))
-            .thenReturn(validValidation)
+            .thenReturn(invalidValidation, validValidation)
+
+        // Mock successful operations
+        org.mockito.kotlin
+            .doNothing()
+            .whenever(mockAws)
+            .checkPermissions()
+        whenever(mockAws.createRoleWithS3Policy(any())).thenReturn(Constants.AWS.Roles.EC2_INSTANCE_ROLE)
+        whenever(mockAws.createServiceRole()).thenReturn(Constants.AWS.Roles.EMR_SERVICE_ROLE)
+        whenever(mockAws.createEMREC2Role()).thenReturn(Constants.AWS.Roles.EMR_EC2_ROLE)
 
         // When
         service.ensureAWSResources(userConfig)
 
         // Then: Should create all 3 roles
-        verify(mockAws).createRoleWithS3Policy(eq(Constants.AWS.Roles.EC2_INSTANCE_ROLE), any())
+        verify(mockAws).createRoleWithS3Policy(Constants.AWS.Roles.EC2_INSTANCE_ROLE)
         verify(mockAws).createServiceRole()
         verify(mockAws).createEMREC2Role()
     }
 
     @Test
-    fun `ensureAWSResources should apply S3 bucket policy after role creation`() {
-        // Given: User config without S3 bucket
-        val userConfig = createUserConfig(s3Bucket = "")
-
-        // Capture the generated bucket name
-        val bucketNameCaptor = argumentCaptor<String>()
-
-        // Mock successful operations - let createS3Bucket return whatever is passed
-        org.mockito.kotlin
-            .doNothing()
-            .whenever(mockAws)
-            .checkPermissions()
-        whenever(mockAws.createS3Bucket(bucketNameCaptor.capture())).thenAnswer { bucketNameCaptor.firstValue }
-        whenever(mockAws.createRoleWithS3Policy(any(), any())).thenReturn(Constants.AWS.Roles.EC2_INSTANCE_ROLE)
-        whenever(mockAws.createServiceRole()).thenReturn(Constants.AWS.Roles.EMR_SERVICE_ROLE)
-        whenever(mockAws.createEMREC2Role()).thenReturn(Constants.AWS.Roles.EMR_EC2_ROLE)
-        org.mockito.kotlin
-            .doNothing()
-            .whenever(mockAws)
-            .putS3BucketPolicy(any())
-
-        val validValidation =
-            AWS.RoleValidationResult(
-                isValid = true,
-                instanceProfileExists = true,
-                roleAttached = true,
-                hasPolicies = true,
-                errorMessage = "",
-            )
-        whenever(mockAws.validateRoleSetup(Constants.AWS.Roles.EC2_INSTANCE_ROLE))
-            .thenReturn(validValidation)
-
-        // When
-        service.ensureAWSResources(userConfig)
-
-        // Then: Should apply S3 bucket policy with the same bucket name that was created
-        val createdBucketName = bucketNameCaptor.firstValue
-        assertThat(createdBucketName).startsWith("easy-db-lab-")
-        verify(mockAws).putS3BucketPolicy(createdBucketName)
-    }
-
-    @Test
-    fun `ensureAWSResources should save config after successful validation`() {
-        // Given: User config without S3 bucket
-        val userConfig = createUserConfig(s3Bucket = "")
-        val bucketName = "test-bucket"
-
-        // Mock successful operations
-        org.mockito.kotlin
-            .doNothing()
-            .whenever(mockAws)
-            .checkPermissions()
-        whenever(mockAws.createS3Bucket(any())).thenReturn(bucketName)
-        whenever(mockAws.createRoleWithS3Policy(any(), any())).thenReturn(Constants.AWS.Roles.EC2_INSTANCE_ROLE)
-        whenever(mockAws.createServiceRole()).thenReturn(Constants.AWS.Roles.EMR_SERVICE_ROLE)
-        whenever(mockAws.createEMREC2Role()).thenReturn(Constants.AWS.Roles.EMR_EC2_ROLE)
-        org.mockito.kotlin
-            .doNothing()
-            .whenever(mockAws)
-            .putS3BucketPolicy(any())
-
-        val validValidation =
-            AWS.RoleValidationResult(
-                isValid = true,
-                instanceProfileExists = true,
-                roleAttached = true,
-                hasPolicies = true,
-                errorMessage = "",
-            )
-        whenever(mockAws.validateRoleSetup(Constants.AWS.Roles.EC2_INSTANCE_ROLE))
-            .thenReturn(validValidation)
-
-        // When
-        service.ensureAWSResources(userConfig)
-
-        // Then: Should save config with updated S3 bucket
-        verify(mockUserConfigProvider).saveUserConfig(userConfig)
-        // Bucket name is generated with UUID, verify it was set and returned
-        assertThat(userConfig.s3Bucket).isNotEmpty().startsWith("easy-db-lab-")
-    }
-
-    @Test
     fun `ensureAWSResources should throw when final validation fails`() {
-        // Given: User config without S3 bucket
-        val userConfig = createUserConfig(s3Bucket = "")
-
-        // Mock successful operations but final validation fails
-        org.mockito.kotlin
-            .doNothing()
-            .whenever(mockAws)
-            .checkPermissions()
-        whenever(mockAws.createS3Bucket(any())).thenReturn("test-bucket")
-        whenever(mockAws.createRoleWithS3Policy(any(), any())).thenReturn(Constants.AWS.Roles.EC2_INSTANCE_ROLE)
-        whenever(mockAws.createServiceRole()).thenReturn(Constants.AWS.Roles.EMR_SERVICE_ROLE)
-        whenever(mockAws.createEMREC2Role()).thenReturn(Constants.AWS.Roles.EMR_EC2_ROLE)
-        org.mockito.kotlin
-            .doNothing()
-            .whenever(mockAws)
-            .putS3BucketPolicy(any())
+        // Given: IAM resources not configured and validation keeps failing
+        val userConfig = createUserConfig()
 
         val invalidValidation =
             AWS.RoleValidationResult(
@@ -341,8 +248,19 @@ internal class AWSResourceSetupServiceTest :
                 hasPolicies = true,
                 errorMessage = "Role not attached to instance profile",
             )
+
+        // Both calls return invalid
         whenever(mockAws.validateRoleSetup(Constants.AWS.Roles.EC2_INSTANCE_ROLE))
             .thenReturn(invalidValidation)
+
+        // Mock successful operations
+        org.mockito.kotlin
+            .doNothing()
+            .whenever(mockAws)
+            .checkPermissions()
+        whenever(mockAws.createRoleWithS3Policy(any())).thenReturn(Constants.AWS.Roles.EC2_INSTANCE_ROLE)
+        whenever(mockAws.createServiceRole()).thenReturn(Constants.AWS.Roles.EMR_SERVICE_ROLE)
+        whenever(mockAws.createEMREC2Role()).thenReturn(Constants.AWS.Roles.EMR_EC2_ROLE)
 
         // When/Then: Should throw IllegalStateException
         val exception =
@@ -352,29 +270,36 @@ internal class AWSResourceSetupServiceTest :
 
         assertThat(exception.message).contains("AWS resource setup completed but final validation failed")
         assertThat(exception.message).contains("Role not attached to instance profile")
-
-        // Should not save config on validation failure
-        verify(mockUserConfigProvider, never()).saveUserConfig(any())
     }
 
     @Test
     fun `ensureAWSResources should handle IAM permission errors`() {
-        // Given: User config without S3 bucket
-        val userConfig = createUserConfig(s3Bucket = "")
+        // Given: IAM resources not configured
+        val userConfig = createUserConfig()
+
+        val invalidValidation =
+            AWS.RoleValidationResult(
+                isValid = false,
+                instanceProfileExists = false,
+                roleAttached = false,
+                hasPolicies = false,
+                errorMessage = "Resources not found",
+            )
+        whenever(mockAws.validateRoleSetup(Constants.AWS.Roles.EC2_INSTANCE_ROLE))
+            .thenReturn(invalidValidation)
 
         // Mock successful credential check but IAM permission error during role creation
         org.mockito.kotlin
             .doNothing()
             .whenever(mockAws)
             .checkPermissions()
-        whenever(mockAws.createS3Bucket(any())).thenReturn("test-bucket")
 
         val iamException =
             IamException
                 .builder()
                 .message("User is not authorized to perform: iam:CreateRole")
                 .build()
-        whenever(mockAws.createRoleWithS3Policy(any(), any())).thenThrow(iamException)
+        whenever(mockAws.createRoleWithS3Policy(any())).thenThrow(iamException)
 
         // When/Then: Should throw IamException
         assertThrows<IamException> {
@@ -385,35 +310,8 @@ internal class AWSResourceSetupServiceTest :
         verify(mockOutputHandler).handleError(any<String>(), any())
     }
 
-    @Test
-    fun `ensureAWSResources should handle S3 bucket creation failure`() {
-        // Given: User config without S3 bucket
-        val userConfig = createUserConfig(s3Bucket = "")
-
-        // Mock successful credential check but S3 creation failure
-        org.mockito.kotlin
-            .doNothing()
-            .whenever(mockAws)
-            .checkPermissions()
-
-        val s3Exception =
-            software.amazon.awssdk.services.s3.model.S3Exception
-                .builder()
-                .message("Access denied")
-                .build()
-        whenever(mockAws.createS3Bucket(any())).thenThrow(s3Exception)
-
-        // When/Then: Should throw exception
-        assertThrows<software.amazon.awssdk.services.s3.model.S3Exception> {
-            service.ensureAWSResources(userConfig)
-        }
-
-        // Should not proceed to role creation
-        verify(mockAws, never()).createRoleWithS3Policy(any(), any())
-    }
-
-    // Helper method to create test user config
-    private fun createUserConfig(s3Bucket: String = ""): User =
+    // Helper method to create test user config (no more s3Bucket field)
+    private fun createUserConfig(): User =
         User(
             email = "test@example.com",
             region = "us-west-2",
@@ -422,6 +320,5 @@ internal class AWSResourceSetupServiceTest :
             awsProfile = "default",
             awsAccessKey = "",
             awsSecret = "",
-            s3Bucket = s3Bucket,
         )
 }

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/services/EMRSparkServiceTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/services/EMRSparkServiceTest.kt
@@ -5,7 +5,6 @@ import com.rustyrazorblade.easydblab.configuration.ClusterState
 import com.rustyrazorblade.easydblab.configuration.ClusterStateManager
 import com.rustyrazorblade.easydblab.configuration.EMRClusterInfo
 import com.rustyrazorblade.easydblab.configuration.EMRClusterState
-import com.rustyrazorblade.easydblab.configuration.User
 import com.rustyrazorblade.easydblab.providers.aws.EMRSparkService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -38,7 +37,6 @@ class EMRSparkServiceTest : BaseKoinTest() {
     private lateinit var mockEmrClient: EmrClient
     private lateinit var mockObjectStore: ObjectStore
     private lateinit var mockClusterStateManager: ClusterStateManager
-    private lateinit var mockUserConfig: User
     private lateinit var sparkService: SparkService
 
     private val testClusterId = "j-ABC123DEF456"
@@ -68,8 +66,7 @@ class EMRSparkServiceTest : BaseKoinTest() {
                 single<EmrClient> { mockEmrClient }
                 single<ObjectStore> { mockObjectStore }
                 single<ClusterStateManager> { mockClusterStateManager }
-                single<User> { mockUserConfig }
-                factory<SparkService> { EMRSparkService(get(), get(), get(), get(), get()) }
+                factory<SparkService> { EMRSparkService(get(), get(), get(), get()) }
             },
         )
 
@@ -78,7 +75,6 @@ class EMRSparkServiceTest : BaseKoinTest() {
         mockEmrClient = mock()
         mockObjectStore = mock()
         mockClusterStateManager = mock()
-        mockUserConfig = mock()
         sparkService = getKoin().get()
     }
 


### PR DESCRIPTION
## Summary
- Add ClickHouse cluster deployment on K3s with Keeper for coordination
- Add `clickhouse start`, `clickhouse stop`, and `clickhouse status` commands
- Refactor K8s manifest loading to use numeric prefixes for ordering
- Add resumable test steps to end-to-end-test script

### ClickHouse Features
- 3-node ClickHouse Keeper cluster for coordination
- 3-node ClickHouse server cluster with ReplicatedMergeTree support
- HTTP interface exposed on port 8123 via NodePort
- Native protocol on port 9000
- Grafana dashboard for ClickHouse metrics

### End-to-End Test Improvements
- Extract test commands into discrete step functions
- Add step registry with `run_from_step()` runner for resumability
- New menu: retry from failed step (1), shell (2), teardown (3), delete (4), keep (5)
- Add `rerun` command to shell session for rebuild + resume workflow
- Track current step for informative failure messages