### PR TITLE
feat: add k9s to base image

### DIFF
--- a/packer/base/base.pkr.hcl
+++ b/packer/base/base.pkr.hcl
@@ -124,6 +124,11 @@ build {
     script = "install/install_k3s.sh"
   }
 
+  # install k9s (Kubernetes TUI)
+  provisioner "shell" {
+    script = "install/install_k9s.sh"
+  }
+
   # install k3s startup scripts
   provisioner "file" {
     source      = "install/start_k3s_server.sh"

--- a/packer/base/install/install_k9s.sh
+++ b/packer/base/install/install_k9s.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -ex
+
+echo "=== Running: install_k9s.sh ==="
+
+# Get the architecture using uname
+cpu_arch=$(uname -m)
+
+# Set ARCH based on the CPU architecture
+if [[ "$cpu_arch" == "x86_64" ]]; then
+    ARCH="amd64"
+elif [[ "$cpu_arch" == "aarch64" ]]; then
+    ARCH="arm64"
+else
+    echo "Unsupported architecture: $cpu_arch"
+    exit 1
+fi
+
+echo "ARCH is set to: $ARCH"
+
+K9S_VERSION="v0.32.7"
+RELEASE="k9s_Linux_${ARCH}.tar.gz"
+
+echo "Downloading k9s ${K9S_VERSION} for ${ARCH}..."
+wget "https://github.com/derailed/k9s/releases/download/${K9S_VERSION}/${RELEASE}" || { echo "ERROR: k9s download failed" >&2; exit 1; }
+
+tar -xzvf "${RELEASE}"
+sudo mv k9s /usr/local/bin/
+rm -f "${RELEASE}" LICENSE README.md
+
+# Verify installation
+k9s version || { echo "ERROR: k9s installation verification failed" >&2; exit 1; }
+
+echo "✓ install_k9s.sh completed successfully"


### PR DESCRIPTION
## Summary

- Add k9s v0.32.7 (Kubernetes TUI) to the base AMI
- Installation script supports both amd64 and arm64 architectures
- k9s provides a terminal-based UI for managing k3s clusters

## Changes

- New file: `packer/base/install/install_k9s.sh` - Architecture-aware installation script
- Modified: `packer/base/base.pkr.hcl` - Added provisioner to run the install script

## Testing

Tested locally using Docker-based packer test infrastructure:
```
./test-script.sh base/install/install_k9s.sh
```

Closes #385