### PR TITLE
Move cassandra commands under cassandra subcommand

### DIFF
--- a/src/main/kotlin/com/rustyrazorblade/easydblab/CommandLineParser.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/CommandLineParser.kt
@@ -10,31 +10,31 @@ import com.rustyrazorblade.easydblab.commands.BuildImage
 import com.rustyrazorblade.easydblab.commands.Clean
 import com.rustyrazorblade.easydblab.commands.ConfigureAWS
 import com.rustyrazorblade.easydblab.commands.ConfigureAxonOps
-import com.rustyrazorblade.easydblab.commands.Down
-import com.rustyrazorblade.easydblab.commands.DownloadConfig
 import com.rustyrazorblade.easydblab.commands.Exec
 import com.rustyrazorblade.easydblab.commands.Hosts
 import com.rustyrazorblade.easydblab.commands.Init
 import com.rustyrazorblade.easydblab.commands.Ip
-import com.rustyrazorblade.easydblab.commands.ListVersions
 import com.rustyrazorblade.easydblab.commands.PicoCommand
 import com.rustyrazorblade.easydblab.commands.PruneAMIs
 import com.rustyrazorblade.easydblab.commands.Repl
-import com.rustyrazorblade.easydblab.commands.Restart
 import com.rustyrazorblade.easydblab.commands.Server
 import com.rustyrazorblade.easydblab.commands.SetupInstance
 import com.rustyrazorblade.easydblab.commands.SetupProfile
 import com.rustyrazorblade.easydblab.commands.ShowIamPolicies
-import com.rustyrazorblade.easydblab.commands.Start
 import com.rustyrazorblade.easydblab.commands.Status
-import com.rustyrazorblade.easydblab.commands.Stop
-import com.rustyrazorblade.easydblab.commands.Up
-import com.rustyrazorblade.easydblab.commands.UpdateConfig
 import com.rustyrazorblade.easydblab.commands.UploadAuthorizedKeys
-import com.rustyrazorblade.easydblab.commands.UseCassandra
 import com.rustyrazorblade.easydblab.commands.Version
-import com.rustyrazorblade.easydblab.commands.WriteConfig
 import com.rustyrazorblade.easydblab.commands.cassandra.Cassandra
+import com.rustyrazorblade.easydblab.commands.cassandra.Down
+import com.rustyrazorblade.easydblab.commands.cassandra.DownloadConfig
+import com.rustyrazorblade.easydblab.commands.cassandra.ListVersions
+import com.rustyrazorblade.easydblab.commands.cassandra.Restart
+import com.rustyrazorblade.easydblab.commands.cassandra.Start
+import com.rustyrazorblade.easydblab.commands.cassandra.Stop
+import com.rustyrazorblade.easydblab.commands.cassandra.Up
+import com.rustyrazorblade.easydblab.commands.cassandra.UpdateConfig
+import com.rustyrazorblade.easydblab.commands.cassandra.UseCassandra
+import com.rustyrazorblade.easydblab.commands.cassandra.WriteConfig
 import com.rustyrazorblade.easydblab.commands.cassandra.stress.Stress
 import com.rustyrazorblade.easydblab.commands.cassandra.stress.StressFields
 import com.rustyrazorblade.easydblab.commands.cassandra.stress.StressInfo
@@ -208,7 +208,7 @@ class CommandLineParser(
         clickHouseCommandLine.addSubcommand("stop", ClickHouseStop(context))
         commandLine.addSubcommand("clickhouse", clickHouseCommandLine)
 
-        // Register Cassandra parent command with nested stress commands
+        // Register Cassandra parent command with nested stress commands and cluster operations
         // Cassandra is a parent command for Cassandra tooling operations
         val cassandraCommandLine = CommandLine(Cassandra())
 
@@ -222,6 +222,18 @@ class CommandLineParser(
         stressCommandLine.addSubcommand("fields", StressFields(context))
         stressCommandLine.addSubcommand("info", StressInfo(context))
         cassandraCommandLine.addSubcommand("stress", stressCommandLine)
+
+        // Cassandra cluster management commands (also available at top level for backwards compatibility)
+        cassandraCommandLine.addSubcommand("up", Up(context))
+        cassandraCommandLine.addSubcommand("down", Down(context))
+        cassandraCommandLine.addSubcommand("start", Start(context))
+        cassandraCommandLine.addSubcommand("stop", Stop(context))
+        cassandraCommandLine.addSubcommand("restart", Restart(context))
+        cassandraCommandLine.addSubcommand("list", ListVersions(context))
+        cassandraCommandLine.addSubcommand("use", UseCassandra(context))
+        cassandraCommandLine.addSubcommand("download-config", DownloadConfig(context))
+        cassandraCommandLine.addSubcommand("write-config", WriteConfig(context))
+        cassandraCommandLine.addSubcommand("update-config", UpdateConfig(context))
 
         commandLine.addSubcommand("cassandra", cassandraCommandLine)
 

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Init.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Init.kt
@@ -6,6 +6,7 @@ import com.rustyrazorblade.easydblab.Constants
 import com.rustyrazorblade.easydblab.Context
 import com.rustyrazorblade.easydblab.annotations.McpCommand
 import com.rustyrazorblade.easydblab.annotations.RequireProfileSetup
+import com.rustyrazorblade.easydblab.commands.cassandra.Up
 import com.rustyrazorblade.easydblab.commands.converters.PicoAZConverter
 import com.rustyrazorblade.easydblab.commands.mixins.OpenSearchInitMixin
 import com.rustyrazorblade.easydblab.commands.mixins.SparkInitMixin

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/Cassandra.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/Cassandra.kt
@@ -1,20 +1,30 @@
 package com.rustyrazorblade.easydblab.commands.cassandra
 
 import picocli.CommandLine.Command
+import picocli.CommandLine.Model.CommandSpec
+import picocli.CommandLine.Spec
 
 /**
  * Parent command for Cassandra-related operations.
  *
- * This command groups subcommands for Cassandra tooling including
- * stress testing with cassandra-easy-stress.
+ * This command groups subcommands for Cassandra cluster management and tooling including:
+ * - Cluster lifecycle: up, down, start, stop, restart
+ * - Configuration: use, list, download-config, write-config, update-config
+ * - Stress testing: stress (with nested subcommands)
+ *
+ * Note: Sub-commands are registered manually in CommandLineParser to inject
+ * the Context dependency that PicoCommands require.
  */
 @Command(
     name = "cassandra",
-    description = ["Cassandra tooling operations"],
-    subcommands = [],
+    description = ["Cassandra cluster management and tooling operations"],
+    mixinStandardHelpOptions = true,
 )
 class Cassandra : Runnable {
+    @Spec
+    lateinit var spec: CommandSpec
+
     override fun run() {
-        println("Use a subcommand. Run 'easy-db-lab cassandra --help' for available commands.")
+        spec.commandLine().usage(System.out)
     }
 }

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/DownloadConfig.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/DownloadConfig.kt
@@ -1,7 +1,8 @@
-package com.rustyrazorblade.easydblab.commands
+package com.rustyrazorblade.easydblab.commands.cassandra
 
 import com.rustyrazorblade.easydblab.Context
 import com.rustyrazorblade.easydblab.annotations.RequireProfileSetup
+import com.rustyrazorblade.easydblab.commands.PicoBaseCommand
 import com.rustyrazorblade.easydblab.commands.mixins.HostsMixin
 import com.rustyrazorblade.easydblab.configuration.ServerType
 import com.rustyrazorblade.easydblab.configuration.getHosts

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/ListVersions.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/ListVersions.kt
@@ -1,8 +1,9 @@
-package com.rustyrazorblade.easydblab.commands
+package com.rustyrazorblade.easydblab.commands.cassandra
 
 import com.rustyrazorblade.easydblab.Context
 import com.rustyrazorblade.easydblab.annotations.McpCommand
 import com.rustyrazorblade.easydblab.annotations.RequireProfileSetup
+import com.rustyrazorblade.easydblab.commands.PicoBaseCommand
 import com.rustyrazorblade.easydblab.configuration.ServerType
 import com.rustyrazorblade.easydblab.configuration.getHosts
 import picocli.CommandLine.Command

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/Restart.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/Restart.kt
@@ -1,8 +1,9 @@
-package com.rustyrazorblade.easydblab.commands
+package com.rustyrazorblade.easydblab.commands.cassandra
 
 import com.rustyrazorblade.easydblab.Context
 import com.rustyrazorblade.easydblab.annotations.McpCommand
 import com.rustyrazorblade.easydblab.annotations.RequireProfileSetup
+import com.rustyrazorblade.easydblab.commands.PicoBaseCommand
 import com.rustyrazorblade.easydblab.commands.mixins.HostsMixin
 import com.rustyrazorblade.easydblab.configuration.ServerType
 import com.rustyrazorblade.easydblab.configuration.toHost

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/Start.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/Start.kt
@@ -1,10 +1,11 @@
-package com.rustyrazorblade.easydblab.commands
+package com.rustyrazorblade.easydblab.commands.cassandra
 
 import com.github.ajalt.mordant.TermColors
 import com.rustyrazorblade.easydblab.Context
 import com.rustyrazorblade.easydblab.annotations.McpCommand
 import com.rustyrazorblade.easydblab.annotations.RequireProfileSetup
 import com.rustyrazorblade.easydblab.annotations.RequireSSHKey
+import com.rustyrazorblade.easydblab.commands.PicoBaseCommand
 import com.rustyrazorblade.easydblab.commands.mixins.HostsMixin
 import com.rustyrazorblade.easydblab.configuration.ServerType
 import com.rustyrazorblade.easydblab.configuration.User

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/Stop.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/Stop.kt
@@ -1,8 +1,9 @@
-package com.rustyrazorblade.easydblab.commands
+package com.rustyrazorblade.easydblab.commands.cassandra
 
 import com.rustyrazorblade.easydblab.Context
 import com.rustyrazorblade.easydblab.annotations.RequireProfileSetup
 import com.rustyrazorblade.easydblab.annotations.RequireSSHKey
+import com.rustyrazorblade.easydblab.commands.PicoBaseCommand
 import com.rustyrazorblade.easydblab.commands.mixins.HostsMixin
 import com.rustyrazorblade.easydblab.configuration.ServerType
 import com.rustyrazorblade.easydblab.configuration.toHost

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/Up.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/Up.kt
@@ -1,10 +1,13 @@
-package com.rustyrazorblade.easydblab.commands
+package com.rustyrazorblade.easydblab.commands.cassandra
 
 import com.github.ajalt.mordant.TermColors
 import com.rustyrazorblade.easydblab.Constants
 import com.rustyrazorblade.easydblab.Context
 import com.rustyrazorblade.easydblab.annotations.McpCommand
 import com.rustyrazorblade.easydblab.annotations.RequireProfileSetup
+import com.rustyrazorblade.easydblab.commands.ConfigureAxonOps
+import com.rustyrazorblade.easydblab.commands.PicoBaseCommand
+import com.rustyrazorblade.easydblab.commands.SetupInstance
 import com.rustyrazorblade.easydblab.commands.k8.K8Apply
 import com.rustyrazorblade.easydblab.commands.mixins.HostsMixin
 import com.rustyrazorblade.easydblab.configuration.ClusterState
@@ -16,6 +19,7 @@ import com.rustyrazorblade.easydblab.configuration.toHost
 import com.rustyrazorblade.easydblab.providers.aws.AMIResolver
 import com.rustyrazorblade.easydblab.providers.aws.AWS
 import com.rustyrazorblade.easydblab.providers.aws.AwsInfrastructureService
+import com.rustyrazorblade.easydblab.providers.aws.DiscoveredInstance
 import com.rustyrazorblade.easydblab.providers.aws.EC2InstanceService
 import com.rustyrazorblade.easydblab.providers.aws.InstanceSpecFactory
 import com.rustyrazorblade.easydblab.providers.aws.RetryUtil
@@ -49,7 +53,7 @@ import java.time.Duration
  * After provisioning, it configures K3s on all nodes and applies Kubernetes manifests.
  * State is persisted incrementally as each resource type completes.
  *
- * @see Init for cluster initialization (must be run first)
+ * @see com.rustyrazorblade.easydblab.commands.Init for cluster initialization (must be run first)
  * @see Down for tearing down infrastructure
  */
 @McpCommand
@@ -305,9 +309,7 @@ class Up(
         outputHandler.handleMessage("Cluster state updated: ${result.hosts.values.flatten().size} hosts tracked")
     }
 
-    private fun logExistingInstances(
-        existingInstances: Map<ServerType, List<com.rustyrazorblade.easydblab.providers.aws.DiscoveredInstance>>,
-    ) {
+    private fun logExistingInstances(existingInstances: Map<ServerType, List<DiscoveredInstance>>) {
         if (existingInstances.values.flatten().isNotEmpty()) {
             val cassandra = existingInstances[ServerType.Cassandra]?.size ?: 0
             val stress = existingInstances[ServerType.Stress]?.size ?: 0

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/UpdateConfig.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/UpdateConfig.kt
@@ -1,4 +1,4 @@
-package com.rustyrazorblade.easydblab.commands
+package com.rustyrazorblade.easydblab.commands.cassandra
 
 import com.fasterxml.jackson.databind.node.ArrayNode
 import com.fasterxml.jackson.databind.node.ObjectNode
@@ -7,6 +7,7 @@ import com.rustyrazorblade.easydblab.Context
 import com.rustyrazorblade.easydblab.annotations.McpCommand
 import com.rustyrazorblade.easydblab.annotations.RequireProfileSetup
 import com.rustyrazorblade.easydblab.annotations.RequireSSHKey
+import com.rustyrazorblade.easydblab.commands.PicoBaseCommand
 import com.rustyrazorblade.easydblab.commands.mixins.HostsMixin
 import com.rustyrazorblade.easydblab.configuration.Host
 import com.rustyrazorblade.easydblab.configuration.ServerType

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/UseCassandra.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/UseCassandra.kt
@@ -1,10 +1,11 @@
-package com.rustyrazorblade.easydblab.commands
+package com.rustyrazorblade.easydblab.commands.cassandra
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.github.ajalt.mordant.TermColors
 import com.rustyrazorblade.easydblab.Context
 import com.rustyrazorblade.easydblab.annotations.McpCommand
 import com.rustyrazorblade.easydblab.annotations.RequireProfileSetup
+import com.rustyrazorblade.easydblab.commands.PicoBaseCommand
 import com.rustyrazorblade.easydblab.commands.mixins.HostsMixin
 import com.rustyrazorblade.easydblab.configuration.ServerType
 import com.rustyrazorblade.easydblab.configuration.getHosts

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/WriteConfig.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/WriteConfig.kt
@@ -1,7 +1,8 @@
-package com.rustyrazorblade.easydblab.commands
+package com.rustyrazorblade.easydblab.commands.cassandra
 
 import com.rustyrazorblade.easydblab.Context
 import com.rustyrazorblade.easydblab.annotations.RequireProfileSetup
+import com.rustyrazorblade.easydblab.commands.PicoCommand
 import com.rustyrazorblade.easydblab.configuration.ClusterStateManager
 import com.rustyrazorblade.easydblab.configuration.ServerType
 import com.rustyrazorblade.easydblab.configuration.getHosts


### PR DESCRIPTION
## Summary
- Reorganize CLI structure to group Cassandra-related commands under the `cassandra` parent command
- Commands remain accessible at top level for backwards compatibility
- Both `easy-db-lab cassandra up` and `easy-db-lab up` now work

## Changes
- Move 10 command files to `commands/cassandra/` directory
- Register commands as subcommands of `cassandra` in CommandLineParser
- Update `Cassandra.kt` parent command to show help when run without subcommand

## Command Mapping

| Legacy (still works) | New (recommended) |
|---------------------|-------------------|
| `easy-db-lab up` | `easy-db-lab cassandra up` |
| `easy-db-lab down` | `easy-db-lab cassandra down` |
| `easy-db-lab start` | `easy-db-lab cassandra start` |
| `easy-db-lab stop` | `easy-db-lab cassandra stop` |
| `easy-db-lab restart` | `easy-db-lab cassandra restart` |
| `easy-db-lab list` | `easy-db-lab cassandra list` |
| `easy-db-lab use` | `easy-db-lab cassandra use` |
| `easy-db-lab download-config` | `easy-db-lab cassandra download-config` |
| `easy-db-lab write-config` | `easy-db-lab cassandra write-config` |
| `easy-db-lab update-config` | `easy-db-lab cassandra update-config` |

Closes #399