### PR TITLE
Add --vpc-id option to reconstruct state from existing VPC

### DIFF
--- a/src/main/kotlin/com/rustyrazorblade/easydblab/Constants.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/Constants.kt
@@ -154,6 +154,12 @@ object Constants {
         }
     }
 
+    // S3 configuration
+    object S3 {
+        /** Prefix for all easy-db-lab S3 buckets */
+        const val BUCKET_PREFIX = "easy-db-lab-"
+    }
+
     // Monitoring
     object Monitoring {
         const val PROMETHEUS_JOB_CASSANDRA = "cassandra"

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/aws/Aws.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/aws/Aws.kt
@@ -1,0 +1,28 @@
+package com.rustyrazorblade.easydblab.commands.aws
+
+import picocli.CommandLine.Command
+import picocli.CommandLine.Model.CommandSpec
+import picocli.CommandLine.Spec
+
+/**
+ * Parent command for AWS-related operations.
+ *
+ * This command groups subcommands for AWS resource discovery and management:
+ * - vpcs: List easy-db-lab VPCs
+ *
+ * Note: Sub-commands are registered manually in CommandLineParser to inject
+ * the Context dependency that PicoCommands require.
+ */
+@Command(
+    name = "aws",
+    description = ["AWS resource discovery and management operations"],
+    mixinStandardHelpOptions = true,
+)
+class Aws : Runnable {
+    @Spec
+    lateinit var spec: CommandSpec
+
+    override fun run() {
+        spec.commandLine().usage(System.out)
+    }
+}

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/aws/Vpcs.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/aws/Vpcs.kt
@@ -1,0 +1,40 @@
+package com.rustyrazorblade.easydblab.commands.aws
+
+import com.rustyrazorblade.easydblab.Constants
+import com.rustyrazorblade.easydblab.Context
+import com.rustyrazorblade.easydblab.commands.PicoBaseCommand
+import com.rustyrazorblade.easydblab.providers.aws.VpcService
+import org.koin.core.component.inject
+import picocli.CommandLine.Command
+
+/**
+ * Lists all easy-db-lab VPCs in the current AWS region.
+ *
+ * Displays one VPC per line with: name, vpc-id, cluster-id
+ */
+@Command(
+    name = "vpcs",
+    description = ["List all easy-db-lab VPCs"],
+    mixinStandardHelpOptions = true,
+)
+class Vpcs(
+    context: Context,
+) : PicoBaseCommand(context) {
+    private val vpcService: VpcService by inject()
+
+    override fun execute() {
+        val vpcIds = vpcService.findVpcsByTag(Constants.Vpc.TAG_KEY, Constants.Vpc.TAG_VALUE)
+
+        if (vpcIds.isEmpty()) {
+            outputHandler.handleMessage("No easy-db-lab VPCs found")
+            return
+        }
+
+        for (vpcId in vpcIds) {
+            val tags = vpcService.getVpcTags(vpcId)
+            val name = tags["Name"] ?: "(unnamed)"
+            val clusterId = tags["ClusterId"] ?: "(no cluster id)"
+            outputHandler.handleMessage("$name $vpcId $clusterId")
+        }
+    }
+}

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/Up.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/Up.kt
@@ -135,6 +135,7 @@ class Up(
     /**
      * Creates the S3 bucket for this environment if it doesn't already exist.
      * Each environment gets its own dedicated bucket for isolation.
+     * The bucket is tagged with the ClusterId to enable state reconstruction.
      */
     private fun createS3BucketIfNeeded(initConfig: InitConfig) {
         if (!workingState.s3Bucket.isNullOrBlank()) {
@@ -148,6 +149,7 @@ class Up(
         outputHandler.handleMessage("Creating S3 bucket: $bucketName")
         aws.createS3Bucket(bucketName)
         aws.putS3BucketPolicy(bucketName)
+        aws.tagS3Bucket(bucketName, mapOf("ClusterId" to workingState.clusterId))
 
         workingState.s3Bucket = bucketName
         clusterStateManager.save(workingState)

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/providers/aws/EC2VpcService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/providers/aws/EC2VpcService.kt
@@ -534,6 +534,23 @@ class EC2VpcService(
         return vpc.tags().firstOrNull { it.key() == "Name" }?.value()
     }
 
+    override fun getVpcTags(vpcId: VpcId): Map<String, String> {
+        log.debug { "Getting tags for VPC: $vpcId" }
+
+        val describeRequest =
+            DescribeVpcsRequest
+                .builder()
+                .vpcIds(vpcId)
+                .build()
+
+        val vpcs = RetryUtil.withAwsRetry("get-vpc-tags") { ec2Client.describeVpcs(describeRequest).vpcs() }
+        val vpc =
+            vpcs.firstOrNull()
+                ?: error("VPC $vpcId not found")
+
+        return vpc.tags().associate { it.key() to it.value() }
+    }
+
     override fun findInstancesInVpc(vpcId: VpcId): List<InstanceId> {
         log.info { "Finding EC2 instances in VPC: $vpcId" }
 

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/providers/aws/VpcService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/providers/aws/VpcService.kt
@@ -137,6 +137,15 @@ interface VpcService {
     fun getVpcName(vpcId: VpcId): String?
 
     /**
+     * Gets all tags on a VPC.
+     *
+     * @param vpcId The VPC ID
+     * @return Map of tag key-value pairs on the VPC
+     * @throws IllegalStateException if the VPC does not exist
+     */
+    fun getVpcTags(vpcId: VpcId): Map<String, String>
+
+    /**
      * Finds all EC2 instances in a VPC.
      *
      * @param vpcId The VPC ID to search in

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/ServicesModule.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/ServicesModule.kt
@@ -6,6 +6,7 @@ import com.rustyrazorblade.easydblab.providers.aws.AWS
 import com.rustyrazorblade.easydblab.providers.aws.EC2InstanceService
 import com.rustyrazorblade.easydblab.providers.aws.EMRService
 import com.rustyrazorblade.easydblab.providers.aws.OpenSearchService
+import com.rustyrazorblade.easydblab.providers.aws.VpcService
 import org.koin.core.module.dsl.factoryOf
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.bind
@@ -49,6 +50,15 @@ val servicesModule =
                 get<K3sService>(),
                 get<K3sAgentService>(),
                 get<OutputHandler>(),
+            )
+        }
+
+        // State reconstruction service for recovering state from AWS resources
+        single<StateReconstructionService> {
+            DefaultStateReconstructionService(
+                get<VpcService>(),
+                get<EC2InstanceService>(),
+                get<AWS>(),
             )
         }
     }

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/StateReconstructionService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/StateReconstructionService.kt
@@ -1,0 +1,107 @@
+package com.rustyrazorblade.easydblab.services
+
+import com.rustyrazorblade.easydblab.configuration.ClusterState
+import com.rustyrazorblade.easydblab.configuration.InfrastructureState
+import com.rustyrazorblade.easydblab.configuration.InfrastructureStatus
+import com.rustyrazorblade.easydblab.providers.aws.AWS
+import com.rustyrazorblade.easydblab.providers.aws.EC2InstanceService
+import com.rustyrazorblade.easydblab.providers.aws.VpcId
+import com.rustyrazorblade.easydblab.providers.aws.VpcService
+import io.github.oshai.kotlinlogging.KotlinLogging
+
+/**
+ * Service for reconstructing cluster state from AWS resources.
+ *
+ * When a user has an existing easy-db-lab VPC but lost their local state.json,
+ * this service discovers resources in AWS and rebuilds the state file.
+ */
+interface StateReconstructionService {
+    /**
+     * Reconstructs ClusterState from resources associated with a VPC.
+     *
+     * The VPC must have a "ClusterId" tag (applied during init) which is used
+     * to discover associated EC2 instances and S3 bucket.
+     *
+     * @param vpcId The VPC ID to reconstruct state from
+     * @return A ClusterState populated with discovered resources
+     * @throws IllegalStateException if VPC is missing the ClusterId tag
+     */
+    fun reconstructFromVpc(vpcId: VpcId): ClusterState
+}
+
+/**
+ * Default implementation of StateReconstructionService.
+ *
+ * Reconstruction process:
+ * 1. Get VPC tags to extract ClusterId and Name
+ * 2. Use ClusterId to discover EC2 instances via existing findInstancesByClusterId
+ * 3. Use ClusterId to find the S3 bucket by tag
+ * 4. Discover infrastructure resources (subnets, security groups, internet gateway)
+ * 5. Build and return ClusterState
+ */
+class DefaultStateReconstructionService(
+    private val vpcService: VpcService,
+    private val ec2InstanceService: EC2InstanceService,
+    private val aws: AWS,
+) : StateReconstructionService {
+    companion object {
+        private val log = KotlinLogging.logger {}
+        private const val DEFAULT_CLUSTER_NAME = "recovered-cluster"
+        private const val CLUSTER_ID_TAG_KEY = "ClusterId"
+    }
+
+    override fun reconstructFromVpc(vpcId: VpcId): ClusterState {
+        log.info { "Reconstructing cluster state from VPC: $vpcId" }
+
+        // 1. Get VPC tags to extract ClusterId and Name
+        val vpcTags = vpcService.getVpcTags(vpcId)
+        val clusterId =
+            vpcTags[CLUSTER_ID_TAG_KEY]
+                ?: error("VPC $vpcId is missing the ClusterId tag. This VPC was not created by easy-db-lab.")
+        val clusterName = vpcTags["Name"] ?: DEFAULT_CLUSTER_NAME
+
+        log.info { "Found ClusterId: $clusterId, Name: $clusterName" }
+
+        // 2. Discover instances using existing method
+        val instancesByType = ec2InstanceService.findInstancesByClusterId(clusterId)
+        val hosts =
+            instancesByType.mapValues { (_, instances) ->
+                instances.map { it.toClusterHost() }
+            }
+        log.info { "Discovered ${hosts.values.sumOf { it.size }} instances" }
+
+        // 3. Discover infrastructure
+        val subnetIds = vpcService.findSubnetsInVpc(vpcId)
+        val securityGroupIds = vpcService.findSecurityGroupsInVpc(vpcId)
+        val igwId = vpcService.findInternetGatewayByVpc(vpcId)
+
+        val infrastructure =
+            InfrastructureState(
+                vpcId = vpcId,
+                subnetIds = subnetIds,
+                securityGroupId = securityGroupIds.firstOrNull(),
+                internetGatewayId = igwId,
+            )
+        log.info { "Discovered infrastructure: ${subnetIds.size} subnets, ${securityGroupIds.size} security groups" }
+
+        // 4. Discover S3 bucket by ClusterId tag
+        val s3Bucket = aws.findS3BucketByTag(CLUSTER_ID_TAG_KEY, clusterId)
+        if (s3Bucket != null) {
+            log.info { "Found S3 bucket: $s3Bucket" }
+        } else {
+            log.warn { "No S3 bucket found with ClusterId=$clusterId tag" }
+        }
+
+        // 5. Build ClusterState
+        return ClusterState(
+            name = clusterName,
+            clusterId = clusterId,
+            vpcId = vpcId,
+            hosts = hosts,
+            infrastructure = infrastructure,
+            s3Bucket = s3Bucket,
+            infrastructureStatus = InfrastructureStatus.UP,
+            versions = null,
+        )
+    }
+}

--- a/src/main/resources/com/rustyrazorblade/easydblab/iam-policy-iam-s3.json
+++ b/src/main/resources/com/rustyrazorblade/easydblab/iam-policy-iam-s3.json
@@ -39,7 +39,9 @@
         "s3:PutBucketVersioning",
         "s3:GetBucketVersioning",
         "s3:PutBucketPolicy",
-        "s3:GetBucketPolicy"
+        "s3:GetBucketPolicy",
+        "s3:PutBucketTagging",
+        "s3:GetBucketTagging"
       ],
       "Resource": [
         "arn:aws:s3:::easy-db-lab-*",

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/services/StateReconstructionServiceTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/services/StateReconstructionServiceTest.kt
@@ -1,0 +1,183 @@
+package com.rustyrazorblade.easydblab.services
+
+import com.rustyrazorblade.easydblab.configuration.ServerType
+import com.rustyrazorblade.easydblab.providers.aws.AWS
+import com.rustyrazorblade.easydblab.providers.aws.DiscoveredInstance
+import com.rustyrazorblade.easydblab.providers.aws.EC2InstanceService
+import com.rustyrazorblade.easydblab.providers.aws.VpcService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+/**
+ * Tests for StateReconstructionService.
+ *
+ * This service reconstructs ClusterState from AWS resources when the local state.json
+ * is missing but the VPC and resources still exist in AWS.
+ */
+internal class StateReconstructionServiceTest {
+    private val mockVpcService: VpcService = mock()
+    private val mockEc2InstanceService: EC2InstanceService = mock()
+    private val mockAws: AWS = mock()
+
+    private val service = DefaultStateReconstructionService(mockVpcService, mockEc2InstanceService, mockAws)
+
+    @Test
+    fun `reconstructFromVpc should return ClusterState with discovered instances`() {
+        val vpcId = "vpc-12345"
+        val clusterId = "abc123-full-uuid"
+        val clusterName = "my-cluster"
+
+        // Setup VPC tags
+        val vpcTags =
+            mapOf(
+                "Name" to clusterName,
+                "ClusterId" to clusterId,
+            )
+        whenever(mockVpcService.getVpcTags(vpcId)).thenReturn(vpcTags)
+
+        // Setup discovered instances
+        val cassandraInstance =
+            DiscoveredInstance(
+                instanceId = "i-cassandra1",
+                publicIp = "1.2.3.4",
+                privateIp = "10.0.1.10",
+                alias = "db0",
+                availabilityZone = "us-west-2a",
+                serverType = ServerType.Cassandra,
+                state = "running",
+            )
+        val controlInstance =
+            DiscoveredInstance(
+                instanceId = "i-control1",
+                publicIp = "1.2.3.5",
+                privateIp = "10.0.1.11",
+                alias = "control0",
+                availabilityZone = "us-west-2a",
+                serverType = ServerType.Control,
+                state = "running",
+            )
+
+        val instancesByType =
+            mapOf(
+                ServerType.Cassandra to listOf(cassandraInstance),
+                ServerType.Control to listOf(controlInstance),
+            )
+        whenever(mockEc2InstanceService.findInstancesByClusterId(clusterId)).thenReturn(instancesByType)
+
+        // Setup infrastructure discovery
+        whenever(mockVpcService.findSubnetsInVpc(vpcId)).thenReturn(listOf("subnet-1", "subnet-2"))
+        whenever(mockVpcService.findSecurityGroupsInVpc(vpcId)).thenReturn(listOf("sg-12345"))
+        whenever(mockVpcService.findInternetGatewayByVpc(vpcId)).thenReturn("igw-12345")
+
+        // Setup S3 bucket discovery
+        whenever(mockAws.findS3BucketByTag("ClusterId", clusterId)).thenReturn("easy-db-lab-my-cluster-abc12345")
+
+        // Execute
+        val result = service.reconstructFromVpc(vpcId)
+
+        // Verify
+        assertThat(result.name).isEqualTo(clusterName)
+        assertThat(result.clusterId).isEqualTo(clusterId)
+        assertThat(result.vpcId).isEqualTo(vpcId)
+        assertThat(result.s3Bucket).isEqualTo("easy-db-lab-my-cluster-abc12345")
+
+        // Verify hosts
+        assertThat(result.hosts).containsKey(ServerType.Cassandra)
+        assertThat(result.hosts).containsKey(ServerType.Control)
+        assertThat(result.hosts[ServerType.Cassandra]).hasSize(1)
+        assertThat(result.hosts[ServerType.Cassandra]?.first()?.alias).isEqualTo("db0")
+        assertThat(result.hosts[ServerType.Control]?.first()?.alias).isEqualTo("control0")
+
+        // Verify infrastructure
+        assertThat(result.infrastructure).isNotNull
+        assertThat(result.infrastructure?.vpcId).isEqualTo(vpcId)
+        assertThat(result.infrastructure?.subnetIds).containsExactly("subnet-1", "subnet-2")
+        assertThat(result.infrastructure?.securityGroupId).isEqualTo("sg-12345")
+        assertThat(result.infrastructure?.internetGatewayId).isEqualTo("igw-12345")
+    }
+
+    @Test
+    fun `reconstructFromVpc should throw when VPC has no ClusterId tag`() {
+        val vpcId = "vpc-no-clusterid"
+
+        // Setup VPC tags without ClusterId
+        val vpcTags =
+            mapOf(
+                "Name" to "my-cluster",
+            )
+        whenever(mockVpcService.getVpcTags(vpcId)).thenReturn(vpcTags)
+
+        // Execute & Verify
+        val exception =
+            assertThrows<IllegalStateException> {
+                service.reconstructFromVpc(vpcId)
+            }
+        assertThat(exception.message).contains("ClusterId")
+    }
+
+    @Test
+    fun `reconstructFromVpc should use default name when Name tag is missing`() {
+        val vpcId = "vpc-12345"
+        val clusterId = "abc123-full-uuid"
+
+        // Setup VPC tags without Name
+        val vpcTags =
+            mapOf(
+                "ClusterId" to clusterId,
+            )
+        whenever(mockVpcService.getVpcTags(vpcId)).thenReturn(vpcTags)
+
+        // Setup empty instances
+        whenever(mockEc2InstanceService.findInstancesByClusterId(clusterId))
+            .thenReturn(emptyMap())
+
+        // Setup infrastructure discovery
+        whenever(mockVpcService.findSubnetsInVpc(vpcId)).thenReturn(emptyList())
+        whenever(mockVpcService.findSecurityGroupsInVpc(vpcId)).thenReturn(emptyList())
+        whenever(mockVpcService.findInternetGatewayByVpc(vpcId)).thenReturn(null)
+
+        // Setup S3 bucket discovery - not found
+        whenever(mockAws.findS3BucketByTag("ClusterId", clusterId)).thenReturn(null)
+
+        // Execute
+        val result = service.reconstructFromVpc(vpcId)
+
+        // Verify default name is used
+        assertThat(result.name).isEqualTo("recovered-cluster")
+    }
+
+    @Test
+    fun `reconstructFromVpc should handle missing S3 bucket gracefully`() {
+        val vpcId = "vpc-12345"
+        val clusterId = "abc123-full-uuid"
+
+        // Setup VPC tags
+        val vpcTags =
+            mapOf(
+                "Name" to "my-cluster",
+                "ClusterId" to clusterId,
+            )
+        whenever(mockVpcService.getVpcTags(vpcId)).thenReturn(vpcTags)
+
+        // Setup empty instances
+        whenever(mockEc2InstanceService.findInstancesByClusterId(clusterId))
+            .thenReturn(emptyMap())
+
+        // Setup infrastructure discovery
+        whenever(mockVpcService.findSubnetsInVpc(vpcId)).thenReturn(emptyList())
+        whenever(mockVpcService.findSecurityGroupsInVpc(vpcId)).thenReturn(emptyList())
+        whenever(mockVpcService.findInternetGatewayByVpc(vpcId)).thenReturn(null)
+
+        // Setup S3 bucket discovery - not found
+        whenever(mockAws.findS3BucketByTag("ClusterId", clusterId)).thenReturn(null)
+
+        // Execute
+        val result = service.reconstructFromVpc(vpcId)
+
+        // Verify S3 bucket is null
+        assertThat(result.s3Bucket).isNull()
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `--vpc-id` top-level CLI option to reconstruct `state.json` from AWS resources when the local state file is missing but the VPC still exists
- Tags S3 buckets with `ClusterId` on creation to enable discovery during state reconstruction
- Creates `StateReconstructionService` that discovers instances, infrastructure, and S3 bucket from VPC tags

Closes #405

## Usage
```bash
# Recover state from an existing VPC
easy-db-lab --vpc-id vpc-0b38790... status

# Force overwrite existing state.json
easy-db-lab --vpc-id vpc-0b38790... --force status
```

## Changes
- `AWS.kt`: Add `tagS3Bucket()` and `findS3BucketByTag()` methods
- `Up.kt`: Tag S3 bucket with ClusterId during creation
- `VpcService.kt`/`EC2VpcService.kt`: Add `getVpcTags()` method
- `StateReconstructionService.kt`: New service to rebuild ClusterState from AWS resources
- `CommandLineParser.kt`: Add `--vpc-id` and `--force` options with execution strategy hook