### PR TITLE
Fix user tag propagation and separate init from infrastructure provis…

### DIFF
--- a/bin/end-to-end-test
+++ b/bin/end-to-end-test
@@ -163,6 +163,53 @@ step_verify_k3s() {
     kubectl wait --for=condition=Ready nodes --all --timeout=120s
 }
 
+step_verify_vpc_tags() {
+    echo "=== Verifying VPC tags ==="
+
+    # Extract VPC ID from state.json
+    local vpc_id=$(jq -r '.vpcId' state.json)
+    if [ -z "$vpc_id" ] || [ "$vpc_id" = "null" ]; then
+        echo "ERROR: VPC ID not found in state.json"
+        return 1
+    fi
+
+    echo "VPC ID: $vpc_id"
+
+    # Get VPC tags using AWS CLI
+    local tags=$(aws ec2 describe-vpcs --vpc-ids "$vpc_id" --query 'Vpcs[0].Tags' --output json)
+    echo "VPC Tags: $tags"
+
+    # Verify easy_cass_lab system tag is present
+    local easy_cass_lab_tag=$(echo "$tags" | jq -r '.[] | select(.Key == "easy_cass_lab") | .Value')
+    if [ "$easy_cass_lab_tag" = "1" ]; then
+        echo "  easy_cass_lab tag: OK (value: $easy_cass_lab_tag)"
+    else
+        echo "ERROR: easy_cass_lab tag not found or incorrect"
+        return 1
+    fi
+
+    # Verify ClusterId system tag is present
+    local cluster_id_tag=$(echo "$tags" | jq -r '.[] | select(.Key == "ClusterId") | .Value')
+    if [ -n "$cluster_id_tag" ] && [ "$cluster_id_tag" != "null" ]; then
+        echo "  ClusterId tag: OK (value: $cluster_id_tag)"
+    else
+        echo "ERROR: ClusterId tag not found"
+        return 1
+    fi
+
+    # Verify user-supplied 'created' tag is present (from init --tag "created=$timestamp")
+    local created_tag=$(echo "$tags" | jq -r '.[] | select(.Key == "created") | .Value')
+    if [ -n "$created_tag" ] && [ "$created_tag" != "null" ]; then
+        echo "  created tag: OK (value: $created_tag)"
+    else
+        echo "ERROR: User-supplied 'created' tag not found on VPC"
+        echo "This tag was specified via 'init --tag created=...' and should be propagated to the VPC"
+        return 1
+    fi
+
+    echo "=== VPC tag verification passed ==="
+}
+
 step_list_hosts() {
     echo "=== Listing cluster hosts ==="
     easy-db-lab hosts
@@ -767,6 +814,7 @@ STEPS_WORKDIR=(
     "step_setup_kubectl:Setup kubectl"
     "step_wait_k3s_ready:Wait for K3s"
     "step_verify_k3s:Verify K3s cluster"
+    "step_verify_vpc_tags:Verify VPC tags"
     "step_registry_push_pull:Test registry push/pull"
     "step_list_hosts:List hosts"
     "step_verify_s3_backup:Verify S3 backup"

--- a/docs/user-guide/kubernetes.md
+++ b/docs/user-guide/kubernetes.md
@@ -7,8 +7,8 @@ easy-db-lab uses K3s to provide a lightweight Kubernetes cluster for deploying s
 K3s is automatically installed on all nodes during provisioning:
 
 - **Control node**: Runs the K3s server (Kubernetes control plane)
-- **Cassandra nodes**: Run as K3s agents with label `role=cassandra`
-- **Stress nodes**: Run as K3s agents with label `role=stress`
+- **Cassandra nodes**: Run as K3s agents with label `type=db`
+- **Stress nodes**: Run as K3s agents with label `type=app`
 
 ## Accessing the Cluster
 
@@ -128,8 +128,8 @@ Nodes are automatically labeled for workload scheduling:
 
 | Node Type | Labels |
 |-----------|--------|
-| Cassandra | `role=cassandra`, `type=db` |
-| Stress | `role=stress`, `type=app` |
+| Cassandra | `type=db` |
+| Stress | `type=app` |
 | Control | (no labels) |
 
 ### Using Node Selectors
@@ -143,7 +143,7 @@ metadata:
   name: stress-worker
 spec:
   nodeSelector:
-    role: stress
+    type: app
   containers:
   - name: worker
     image: my-stress-tool:latest

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/CommandLineParser.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/CommandLineParser.kt
@@ -19,6 +19,7 @@ import com.rustyrazorblade.easydblab.commands.SetupInstance
 import com.rustyrazorblade.easydblab.commands.SetupProfile
 import com.rustyrazorblade.easydblab.commands.ShowIamPolicies
 import com.rustyrazorblade.easydblab.commands.Status
+import com.rustyrazorblade.easydblab.commands.Up
 import com.rustyrazorblade.easydblab.commands.UploadAuthorizedKeys
 import com.rustyrazorblade.easydblab.commands.Version
 import com.rustyrazorblade.easydblab.commands.aws.Aws
@@ -30,7 +31,6 @@ import com.rustyrazorblade.easydblab.commands.cassandra.ListVersions
 import com.rustyrazorblade.easydblab.commands.cassandra.Restart
 import com.rustyrazorblade.easydblab.commands.cassandra.Start
 import com.rustyrazorblade.easydblab.commands.cassandra.Stop
-import com.rustyrazorblade.easydblab.commands.cassandra.Up
 import com.rustyrazorblade.easydblab.commands.cassandra.UpdateConfig
 import com.rustyrazorblade.easydblab.commands.cassandra.UseCassandra
 import com.rustyrazorblade.easydblab.commands.cassandra.WriteConfig
@@ -234,7 +234,6 @@ class CommandLineParser(
         cassandraCommandLine.addSubcommand("stress", stressCommandLine)
 
         // Cassandra cluster management commands (also available at top level for backwards compatibility)
-        cassandraCommandLine.addSubcommand("up", Up(context))
         cassandraCommandLine.addSubcommand("down", Down(context))
         cassandraCommandLine.addSubcommand("start", Start(context))
         cassandraCommandLine.addSubcommand("stop", Stop(context))

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/providers/aws/AwsInfrastructureService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/providers/aws/AwsInfrastructureService.kt
@@ -59,7 +59,7 @@ class AwsInfrastructureService(
                         subnetConfig.availabilityZone,
                     )
                 // Ensure routing is configured for each subnet
-                vpcService.ensureRouteTable(vpcId, subnetId, igwId)
+                vpcService.ensureRouteTable(vpcId, subnetId, igwId, config.tags)
                 subnetId
             }
 
@@ -122,7 +122,7 @@ class AwsInfrastructureService(
                     subnetConfig.cidr,
                     config.tags,
                 )
-            vpcService.ensureRouteTable(existingVpcId, subnetId, igwId)
+            vpcService.ensureRouteTable(existingVpcId, subnetId, igwId, config.tags)
             val sgId =
                 vpcService.findOrCreateSecurityGroup(
                     existingVpcId,
@@ -211,7 +211,7 @@ class AwsInfrastructureService(
 
         // Ensure route tables are configured for each subnet
         subnetIds.forEach { subnetId ->
-            vpcService.ensureRouteTable(config.vpcId, subnetId, igwId)
+            vpcService.ensureRouteTable(config.vpcId, subnetId, igwId, baseTags)
         }
 
         // Create security group

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/providers/aws/EC2VpcService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/providers/aws/EC2VpcService.kt
@@ -214,6 +214,7 @@ class EC2VpcService(
         vpcId: VpcId,
         subnetId: SubnetId,
         igwId: InternetGatewayId,
+        tags: Map<String, String>,
     ) {
         // Get the main route table for the VPC
         val describeRequest =
@@ -239,6 +240,12 @@ class EC2VpcService(
         }
 
         val routeTableId = routeTables[0].routeTableId()
+
+        // Apply tags to the route table if provided
+        if (tags.isNotEmpty()) {
+            createTags(routeTableId, tags)
+            log.info { "Applied tags to route table: $routeTableId" }
+        }
 
         // Check if default route already exists
         val existingRoute =

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/providers/aws/VpcService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/providers/aws/VpcService.kt
@@ -78,15 +78,18 @@ interface VpcService {
     /**
      * Ensures the route table for the subnet has a default route to the internet gateway.
      * Uses the VPC's main route table and associates it with the subnet.
+     * Also applies tags to the route table for resource tracking.
      *
      * @param vpcId The VPC ID
      * @param subnetId The subnet ID to associate with the route table
      * @param igwId The internet gateway ID to route traffic to
+     * @param tags Tags to apply to the route table (optional)
      */
     fun ensureRouteTable(
         vpcId: VpcId,
         subnetId: SubnetId,
         igwId: InternetGatewayId,
+        tags: Map<String, String> = emptyMap(),
     )
 
     /**

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/K3sClusterService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/K3sClusterService.kt
@@ -326,8 +326,8 @@ class DefaultK3sClusterService(
 
     override fun getNodeLabels(serverType: ServerType): Map<String, String> =
         when (serverType) {
-            ServerType.Cassandra -> mapOf("role" to "cassandra", "type" to "db")
-            ServerType.Stress -> mapOf("role" to "stress", "type" to "app")
+            ServerType.Cassandra -> mapOf("type" to "db")
+            ServerType.Stress -> mapOf("type" to "app")
             ServerType.Control -> emptyMap()
         }
 }

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/providers/aws/AwsInfrastructureServiceTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/providers/aws/AwsInfrastructureServiceTest.kt
@@ -86,7 +86,7 @@ internal class AwsInfrastructureServiceTest {
         inOrder.verify(mockVpcService).findOrCreateSubnet(any(), any(), any(), any(), anyOrNull())
 
         // Route table must be configured after VPC, subnet, and IGW exist
-        inOrder.verify(mockVpcService).ensureRouteTable(any(), any(), any())
+        inOrder.verify(mockVpcService).ensureRouteTable(any(), any(), any(), any())
 
         // Security group must be created after VPC
         inOrder.verify(mockVpcService).findOrCreateSecurityGroup(any(), any(), any(), any())
@@ -109,6 +109,7 @@ internal class AwsInfrastructureServiceTest {
             eq("vpc-12345"),
             eq("subnet-12345"),
             eq("igw-12345"),
+            eq(mapOf("easy_cass_lab" to "1")),
         )
     }
 
@@ -356,9 +357,14 @@ internal class AwsInfrastructureServiceTest {
 
         awsInfraService.setupVpcNetworking(config) { "192.168.1.1" }
 
+        val expectedTags =
+            mapOf(
+                "easy_cass_lab" to "1",
+                "ClusterId" to "cluster-123",
+            )
         val inOrder = inOrder(mockVpcService)
-        inOrder.verify(mockVpcService).ensureRouteTable("vpc-existing", "subnet-1", "igw-12345")
-        inOrder.verify(mockVpcService).ensureRouteTable("vpc-existing", "subnet-2", "igw-12345")
+        inOrder.verify(mockVpcService).ensureRouteTable("vpc-existing", "subnet-1", "igw-12345", expectedTags)
+        inOrder.verify(mockVpcService).ensureRouteTable("vpc-existing", "subnet-2", "igw-12345", expectedTags)
     }
 
     @Test

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/services/K3sAgentServiceTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/services/K3sAgentServiceTest.kt
@@ -98,7 +98,7 @@ class K3sAgentServiceTest : BaseKoinTest() {
         // Given
         val serverUrl = "https://10.0.1.5:6443"
         val token = "K10abcdef1234567890::server:1234567890abcdef"
-        val labels = mapOf("role" to "cassandra", "type" to "db")
+        val labels = mapOf("type" to "db")
         val successResponse = Response(text = "", stderr = "")
 
         whenever(mockRemoteOps.executeRemotely(eq(testHost), any(), any(), any()))

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/services/K3sClusterServiceTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/services/K3sClusterServiceTest.kt
@@ -145,7 +145,7 @@ class K3sClusterServiceTest {
                 any(),
                 eq("https://10.0.1.1:6443"),
                 eq("test-token-12345"),
-                eq(mapOf("role" to "cassandra", "type" to "db")),
+                eq(mapOf("type" to "db")),
             )
         }
 
@@ -170,7 +170,7 @@ class K3sClusterServiceTest {
                 any(),
                 eq("https://10.0.1.1:6443"),
                 eq("test-token-12345"),
-                eq(mapOf("role" to "stress", "type" to "app")),
+                eq(mapOf("type" to "app")),
             )
         }
 
@@ -376,14 +376,14 @@ class K3sClusterServiceTest {
         fun `should return cassandra labels for Cassandra type`() {
             val labels = service.getNodeLabels(ServerType.Cassandra)
 
-            assertThat(labels).isEqualTo(mapOf("role" to "cassandra", "type" to "db"))
+            assertThat(labels).isEqualTo(mapOf("type" to "db"))
         }
 
         @Test
         fun `should return stress labels for Stress type`() {
             val labels = service.getNodeLabels(ServerType.Stress)
 
-            assertThat(labels).isEqualTo(mapOf("role" to "stress", "type" to "app"))
+            assertThat(labels).isEqualTo(mapOf("type" to "app"))
         }
 
         @Test


### PR DESCRIPTION
…ioning

- Propagate user tags (from init --tag) to S3 buckets, VPCs, and route tables
- Move VPC creation from init to up command - init now only sets up local configuration, all AWS infrastructure is provisioned during up
- Move Up.kt from commands/cassandra/ to commands/ as a top-level command
- Remove deprecated 'role' K8s node label, keep only 'type=db' and 'type=app'
- Add VPC tag verification step to end-to-end tests
- Update K8s documentation to reference type labels instead of role