### PR TITLE
Upgrade MCP SDK to 0.8.1 with namespacing and dynamic port

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 kotlin = "2.2.21"
 
 # MCP SDK
-mcp-sdk = "0.7.2"
+mcp-sdk = "0.8.1"
 kotlinx-io = "0.8.2"
 
 

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/mcp/McpDebugTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/mcp/McpDebugTest.kt
@@ -21,9 +21,9 @@ class McpDebugTest : BaseKoinTest() {
         // Verify we have tools registered
         assertThat(tools).isNotEmpty()
 
-        // Verify some expected tools are present
+        // Verify some expected tools are present (namespaced names)
         val toolNames = tools.map { it.name }
-        assertThat(toolNames).contains("init", "up", "down")
+        assertThat(toolNames).contains("init", "up", "cassandra_down")
     }
 
     @Test

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/mcp/McpServerSimpleTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/mcp/McpServerSimpleTest.kt
@@ -45,7 +45,8 @@ class McpServerSimpleTest : BaseKoinTest() {
         assertThat(schema.size).isGreaterThan(0)
 
         // Verify the tool has the basic properties we expect
-        assertThat(toolInfo.name).isEqualTo("simple-test")
+        // Note: hyphens are normalized to underscores in tool names
+        assertThat(toolInfo.name).isEqualTo("simple_test")
         assertThat(toolInfo.description).isEqualTo("Simple test command")
     }
 

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/mcp/McpToolNamespacingTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/mcp/McpToolNamespacingTest.kt
@@ -1,0 +1,118 @@
+package com.rustyrazorblade.easydblab.mcp
+
+import com.rustyrazorblade.easydblab.BaseKoinTest
+import com.rustyrazorblade.easydblab.commands.Status
+import com.rustyrazorblade.easydblab.commands.cassandra.Start
+import com.rustyrazorblade.easydblab.commands.cassandra.UpdateConfig
+import com.rustyrazorblade.easydblab.commands.cassandra.stress.StressStart
+import com.rustyrazorblade.easydblab.commands.clickhouse.ClickHouseStart
+import com.rustyrazorblade.easydblab.commands.k8.K8Apply
+import com.rustyrazorblade.easydblab.commands.opensearch.OpenSearchStart
+import com.rustyrazorblade.easydblab.commands.spark.SparkSubmit
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests for MCP tool name namespacing.
+ *
+ * Verifies that tool names are generated correctly based on the command's
+ * package path and @Command(name=...) annotation value.
+ */
+class McpToolNamespacingTest : BaseKoinTest() {
+    private lateinit var registry: McpToolRegistry
+
+    @BeforeEach
+    fun setup() {
+        registry = McpToolRegistry(context)
+    }
+
+    @Test
+    fun `top-level command generates simple name without namespace`() {
+        // Status is in com.rustyrazorblade.easydblab.commands (top-level)
+        val command = Status(context)
+        val toolName = registry.generateToolName(command, "status")
+
+        assertThat(toolName).isEqualTo("status")
+    }
+
+    @Test
+    fun `single-level nested command generates namespace_name`() {
+        // Start is in com.rustyrazorblade.easydblab.commands.cassandra
+        val command = Start(context)
+        val toolName = registry.generateToolName(command, "start")
+
+        assertThat(toolName).isEqualTo("cassandra_start")
+    }
+
+    @Test
+    fun `double-level nested command generates full namespace_name`() {
+        // StressStart is in com.rustyrazorblade.easydblab.commands.cassandra.stress
+        val command = StressStart(context)
+        val toolName = registry.generateToolName(command, "start")
+
+        assertThat(toolName).isEqualTo("cassandra_stress_start")
+    }
+
+    @Test
+    fun `hyphenated command name converts to underscores`() {
+        // UpdateConfig has name="update-config"
+        val command = UpdateConfig(context)
+        val toolName = registry.generateToolName(command, "update-config")
+
+        assertThat(toolName).isEqualTo("cassandra_update_config")
+    }
+
+    @Test
+    fun `clickhouse namespace is correct`() {
+        val command = ClickHouseStart(context)
+        val toolName = registry.generateToolName(command, "start")
+
+        assertThat(toolName).isEqualTo("clickhouse_start")
+    }
+
+    @Test
+    fun `opensearch namespace is correct`() {
+        val command = OpenSearchStart(context)
+        val toolName = registry.generateToolName(command, "start")
+
+        assertThat(toolName).isEqualTo("opensearch_start")
+    }
+
+    @Test
+    fun `spark namespace is correct`() {
+        val command = SparkSubmit(context)
+        val toolName = registry.generateToolName(command, "submit")
+
+        assertThat(toolName).isEqualTo("spark_submit")
+    }
+
+    @Test
+    fun `k8 namespace is correct`() {
+        val command = K8Apply(context)
+        val toolName = registry.generateToolName(command, "apply")
+
+        assertThat(toolName).isEqualTo("k8_apply")
+    }
+
+    @Test
+    fun `getTools returns uniquely named tools`() {
+        val tools = registry.getTools()
+        val toolNames = tools.map { it.name }
+
+        // Verify all names are unique
+        assertThat(toolNames).doesNotHaveDuplicates()
+    }
+
+    @Test
+    fun `getTools includes expected namespaced tool names`() {
+        val tools = registry.getTools()
+        val toolNames = tools.map { it.name }
+
+        // Verify some expected namespaced names exist
+        // Note: Only commands with @McpCommand annotation are included
+        assertThat(toolNames).contains("status")
+        assertThat(toolNames).contains("hosts")
+        assertThat(toolNames).contains("clean")
+    }
+}


### PR DESCRIPTION
- Upgrade MCP SDK from 0.7.2 to 0.8.1
- Add tool name namespacing (e.g., cassandra_stress_start)
- Use explicit SSE routing at /sse endpoint
- Support dynamic port allocation (default port 0 = any free port)
- Generate .mcp.json config with actual allocated port via callback
- Update Server constructor and API for SDK 0.8.1 compatibility