### PR TITLE
Add Serena and Context7 MCP server configuration for devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -105,6 +105,11 @@ RUN sh -c "$(wget -O- https://github.com/deluan/zsh-in-docker/releases/download/
     -a "export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhistory/.bash_history" \
     -x
 
-# Install Claude
-RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}
+# Install Claude and ast-grep
+RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION} @ast-grep/cli
+
+# Install uv for Serena MCP server
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+ENV PATH="/home/node/.local/bin:$PATH"
+
 USER node

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,7 @@
 {
   "name": "Claude Code Sandbox",
   "build": {
+    "context": "..",
     "dockerfile": "Dockerfile",
     "args": {
       "TZ": "${localEnv:TZ:America/Los_Angeles}",
@@ -16,6 +17,7 @@
   "appPort": [8000],
   "runArgs": ["--cap-add=NET_ADMIN", "--cap-add=NET_RAW"],
   "customizations": {},
+  "postCreateCommand": ".devcontainer/setup-mcp.sh",
   "remoteUser": "node",
   "mounts": [
     "source=claude-code-bashhistory-${devcontainerId},target=/commandhistory,type=volume"

--- a/.devcontainer/setup-mcp.sh
+++ b/.devcontainer/setup-mcp.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Configure MCP servers for Claude Code
+
+set -e
+
+echo "Configuring MCP servers..."
+
+# Configure Serena MCP server (code understanding and refactoring)
+claude mcp add serena -- uvx --from git+https://github.com/oraios/serena serena start-mcp-server --context claude-code --project-from-cwd
+
+# Configure Context7 MCP server (library documentation lookup)
+claude mcp add context7 -- npx -y @upstash/context7-mcp
+
+echo "MCP servers configured successfully."
+echo "Run 'claude mcp list' to verify."


### PR DESCRIPTION
- Install ast-grep CLI and uv package manager in Dockerfile
- Add postCreateCommand to auto-configure MCP servers on container creation
- Add setup-mcp.sh script that registers Serena (code understanding) and Context7 (library documentation) servers with Claude Code

Fixes #447