### PR TITLE
Improve Spark bulk writer for TB-scale data and fix DNS resolution

### DIFF
--- a/bin/end-to-end-test
+++ b/bin/end-to-end-test
@@ -616,9 +616,8 @@ step_bulk_writer_direct() {
     fi
 
     echo "=== Creating bulk writer test table ==="
-    local db0_private=$(easy-db-lab ip db0 --private)
-    ssh db0 "cqlsh $db0_private -e \"CREATE KEYSPACE IF NOT EXISTS bulk_test WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};\""
-    ssh db0 "cqlsh $db0_private -e \"CREATE TABLE IF NOT EXISTS bulk_test.data (id bigint PRIMARY KEY, course blob, marks bigint);\""
+    easy-db-lab cassandra cql "CREATE KEYSPACE IF NOT EXISTS bulk_test WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}"
+    easy-db-lab cassandra cql "CREATE TABLE IF NOT EXISTS bulk_test.data (id bigint PRIMARY KEY, course blob, marks bigint)"
 
     echo "=== Submitting bulk writer (direct mode) to EMR ==="
     local sidecar_hosts=$(easy-db-lab hosts --type cassandra --private | tr '\n' ',' | sed 's/,$//')
@@ -630,7 +629,7 @@ step_bulk_writer_direct() {
       --wait
 
     echo "=== Verifying bulk write results ==="
-    ssh db0 "cqlsh $db0_private -e 'SELECT COUNT(*) FROM bulk_test.data;'"
+    easy-db-lab cassandra cql "SELECT COUNT(*) FROM bulk_test.data"
 }
 
 step_clickhouse_start() {

--- a/bin/setup-spark-cluster
+++ b/bin/setup-spark-cluster
@@ -17,6 +17,9 @@
 #   --no-clean            Don't clean existing cluster state
 #   --cassandra <version> Cassandra version (default: 5.0)
 #
+# Storage: 1TB gp3 EBS with 16K IOPS, 128 MB/s throughput
+# Spark: r5.xlarge instances (32GB RAM)
+#
 # Examples:
 #   setup-spark-cluster
 #   setup-spark-cluster --name my-spark-test --db 6
@@ -38,8 +41,17 @@ APP_COUNT="0"
 CLEAN="--clean"
 CASSANDRA_VERSION="5.0"
 
+# EBS configuration for high-performance storage
+EBS_TYPE="gp3"
+EBS_SIZE="1024"        # 1TB
+EBS_IOPS="16000"       # 16K IOPS
+EBS_THROUGHPUT="128"   # 128 MB/s
+
+# Spark instance type with at least 32GB RAM
+SPARK_INSTANCE_TYPE="r5.xlarge"
+
 usage() {
-    sed -n '2,24p' "$0" | sed 's/^# //' | sed 's/^#//'
+    sed -n '2,27p' "$0" | sed 's/^# //' | sed 's/^#//'
     exit 1
 }
 
@@ -86,6 +98,8 @@ echo "  Cluster dir: $CLUSTER_DIR"
 echo "  Cassandra nodes: $DB_COUNT"
 echo "  App nodes: $APP_COUNT"
 echo "  Cassandra version: $CASSANDRA_VERSION"
+echo "  EBS: ${EBS_SIZE}GB $EBS_TYPE (${EBS_IOPS} IOPS, ${EBS_THROUGHPUT} MB/s)"
+echo "  Spark instance: $SPARK_INSTANCE_TYPE (32GB RAM)"
 echo ""
 
 echo "=== Building easy-db-lab ==="
@@ -95,7 +109,19 @@ echo "=== Building easy-db-lab ==="
 cd "$CLUSTER_DIR"
 
 echo "=== Initializing and provisioning cluster with Spark enabled ==="
-easy-db-lab init "$CLUSTER_NAME" --spark.enable $CLEAN --db "$DB_COUNT" --app "$APP_COUNT" --up
+easy-db-lab init "$CLUSTER_NAME" \
+    --spark.enable \
+    --spark.master.instance.type "$SPARK_INSTANCE_TYPE" \
+    --spark.worker.instance.type "$SPARK_INSTANCE_TYPE" \
+    --ebs.type "$EBS_TYPE" \
+    --ebs.size "$EBS_SIZE" \
+    --ebs.iops "$EBS_IOPS" \
+    --ebs.throughput "$EBS_THROUGHPUT" \
+    --ebs.optimized \
+    $CLEAN \
+    --db "$DB_COUNT" \
+    --app "$APP_COUNT" \
+    --up
 
 # Source env.sh for ssh wrapper
 if [ -f "$CLUSTER_DIR/env.sh" ]; then

--- a/bin/spark-bulk-write
+++ b/bin/spark-bulk-write
@@ -16,8 +16,9 @@
 # Options:
 #   --keyspace <name>     Keyspace name (default: bulk_test)
 #   --table <name>        Table name (default: data)
-#   --rows <count>        Number of rows to write (default: 1000000)
-#   --parallelism <num>   Number of partitions (default: 10)
+#   --rows <count>        Number of rows to write (default: 1000000, supports billions)
+#   --parallelism <num>   Number of Spark partitions for generation (default: 10)
+#   --partitions <count>  Number of Cassandra partitions to distribute data across (default: 10000)
 #   --rf <num>            Replication factor (default: 1)
 #   --compaction <name>   Compaction strategy (e.g., LeveledCompactionStrategy)
 #   --skip-ddl            Skip keyspace/table creation
@@ -48,6 +49,7 @@ KEYSPACE="bulk_test"
 TABLE="data"
 ROW_COUNT="1000000"
 PARALLELISM="10"
+PARTITION_COUNT="10000"
 REPLICATION_FACTOR="1"
 COMPACTION=""
 SKIP_DDL="false"
@@ -82,6 +84,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --parallelism)
             PARALLELISM="$2"
+            shift 2
+            ;;
+        --partitions)
+            PARTITION_COUNT="$2"
             shift 2
             ;;
         --rf)
@@ -260,6 +266,7 @@ echo "  Keyspace: $KEYSPACE"
 echo "  Table: $TABLE"
 echo "  Rows: $ROW_COUNT"
 echo "  Parallelism: $PARALLELISM"
+echo "  Partition Count: $PARTITION_COUNT"
 echo "  Replication Factor: $REPLICATION_FACTOR"
 echo "  Compaction: ${COMPACTION:-default}"
 echo "  Skip DDL: $SKIP_DDL"
@@ -299,6 +306,7 @@ CONF_OPTS="$CONF_OPTS --conf spark.easydblab.table=$TABLE"
 CONF_OPTS="$CONF_OPTS --conf spark.easydblab.localDc=$DC"
 CONF_OPTS="$CONF_OPTS --conf spark.easydblab.rowCount=$ROW_COUNT"
 CONF_OPTS="$CONF_OPTS --conf spark.easydblab.parallelism=$PARALLELISM"
+CONF_OPTS="$CONF_OPTS --conf spark.easydblab.partitionCount=$PARTITION_COUNT"
 CONF_OPTS="$CONF_OPTS --conf spark.easydblab.replicationFactor=$REPLICATION_FACTOR"
 
 if [ "$SKIP_DDL" = "true" ]; then

--- a/bin/submit-direct-bulk-writer
+++ b/bin/submit-direct-bulk-writer
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # Submit DirectBulkWriter to an existing Spark/EMR cluster
-# Usage: bin/submit-direct-bulk-writer [rowCount] [parallelism] [replicationFactor]
+# Usage: bin/submit-direct-bulk-writer [rowCount] [parallelism] [partitionCount] [replicationFactor]
 #
 set -e
 
@@ -14,7 +14,8 @@ export AWS_PAGER=""
 # Default args
 ROW_COUNT="${1:-1000}"
 PARALLELISM="${2:-4}"
-REPLICATION_FACTOR="${3:-1}"
+PARTITION_COUNT="${3:-100}"
+REPLICATION_FACTOR="${4:-1}"
 
 echo "=== Building bulk-writer JAR ==="
 (cd "$PROJECT_ROOT" && ./gradlew :bulk-writer:shadowJar -q)
@@ -43,7 +44,7 @@ SIDECAR_HOSTS=$(jq -r '.hosts.Cassandra | map(.privateIp) | join(",")' "$PROJECT
 
 echo "Hosts: $SIDECAR_HOSTS"
 echo "Datacenter: $DC"
-echo "Rows: $ROW_COUNT, Parallelism: $PARALLELISM, RF: $REPLICATION_FACTOR"
+echo "Rows: $ROW_COUNT, Parallelism: $PARALLELISM, Partitions: $PARTITION_COUNT, RF: $REPLICATION_FACTOR"
 echo ""
 
 echo "=== Submitting bulk writer job ==="
@@ -53,7 +54,14 @@ set +e
 easy-db-lab spark submit \
     --jar "$JAR_FILE" \
     --main-class com.rustyrazorblade.easydblab.spark.DirectBulkWriter \
-    --args "$SIDECAR_HOSTS" bulk_test data "$DC" "$ROW_COUNT" "$PARALLELISM" "$REPLICATION_FACTOR" \
+    --conf "spark.easydblab.sidecar.contactPoints=$SIDECAR_HOSTS" \
+    --conf "spark.easydblab.keyspace=bulk_test" \
+    --conf "spark.easydblab.table=data" \
+    --conf "spark.easydblab.localDc=$DC" \
+    --conf "spark.easydblab.rowCount=$ROW_COUNT" \
+    --conf "spark.easydblab.parallelism=$PARALLELISM" \
+    --conf "spark.easydblab.partitionCount=$PARTITION_COUNT" \
+    --conf "spark.easydblab.replicationFactor=$REPLICATION_FACTOR" \
     --wait
 SPARK_EXIT_CODE=$?
 set -e

--- a/bin/test-local-bulk-writer
+++ b/bin/test-local-bulk-writer
@@ -1,4 +1,26 @@
 #!/bin/bash
+#
+# Test the Spark bulk writer locally using Docker Compose.
+# Starts Cassandra, Sidecar, and Spark containers, then runs a bulk write job.
+#
+# Usage:
+#   bin/test-local-bulk-writer [options]
+#
+# Options:
+#   --rows <count>        Number of rows to write (default: 1000)
+#   --parallelism <num>   Number of Spark partitions for generation (default: 2)
+#   --partitions <count>  Number of Cassandra partitions to distribute data across (default: 100)
+#   --rf <num>            Replication factor (default: 1)
+#   --keyspace <name>     Keyspace name (default: bulk_test)
+#   --table <name>        Table name (default: data_<timestamp> for uniqueness)
+#   -h, --help            Show this help message
+#
+# Examples:
+#   bin/test-local-bulk-writer
+#   bin/test-local-bulk-writer --rows 10000
+#   bin/test-local-bulk-writer --rows 100000 --parallelism 4 --partitions 1000
+#   bin/test-local-bulk-writer --keyspace myks --table mytable --rows 5000
+#
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -6,21 +28,72 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 BULK_WRITER_DIR="$PROJECT_ROOT/bulk-writer"
 
 # Default values
-ROW_COUNT="${1:-1000}"
-PARALLELISM="${2:-2}"
-REPLICATION_FACTOR="${3:-1}"
+ROW_COUNT="1000"
+PARALLELISM="2"
+PARTITION_COUNT="100"
+REPLICATION_FACTOR="1"
 KEYSPACE="bulk_test"
-TABLE="data"
+TABLE=""  # Empty means auto-generate with timestamp
 LOCAL_DC="dc1"
+
+usage() {
+    sed -n '2,22p' "$0" | sed 's/^# //' | sed 's/^#//'
+    exit 1
+}
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --rows)
+            ROW_COUNT="$2"
+            shift 2
+            ;;
+        --parallelism)
+            PARALLELISM="$2"
+            shift 2
+            ;;
+        --partitions)
+            PARTITION_COUNT="$2"
+            shift 2
+            ;;
+        --rf)
+            REPLICATION_FACTOR="$2"
+            shift 2
+            ;;
+        --keyspace)
+            KEYSPACE="$2"
+            shift 2
+            ;;
+        --table)
+            TABLE="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            ;;
+        *)
+            echo "Error: Unknown option $1"
+            usage
+            ;;
+    esac
+done
+
+# Generate unique table name if not provided
+if [ -z "$TABLE" ]; then
+    TABLE="data_$(date +%s)"
+fi
 
 echo "=== Local Bulk Writer Test ==="
 echo "Row count: $ROW_COUNT"
 echo "Parallelism: $PARALLELISM"
+echo "Partition count: $PARTITION_COUNT"
 echo "Replication factor: $REPLICATION_FACTOR"
+echo "Keyspace: $KEYSPACE"
+echo "Table: $TABLE"
 echo ""
 
 echo "=== Step 1: Building bulk-writer shadow JAR ==="
-(cd "$PROJECT_ROOT" && ./gradlew :bulk-writer:shadowJar -q)
+(cd "$PROJECT_ROOT" && ./gradlew :spark-shared:clean :bulk-writer:clean :bulk-writer:shadowJar -q)
 
 # Find the built JAR
 JAR_FILE=$(ls "$BULK_WRITER_DIR/build/libs/bulk-writer-"*".jar" 2>/dev/null | grep -v sources | grep -v javadoc | head -1)
@@ -134,6 +207,7 @@ echo "  table: $TABLE"
 echo "  localDc: $LOCAL_DC"
 echo "  rowCount: $ROW_COUNT"
 echo "  parallelism: $PARALLELISM"
+echo "  partitionCount: $PARTITION_COUNT"
 echo "  replicationFactor: $REPLICATION_FACTOR"
 echo ""
 
@@ -148,6 +222,7 @@ docker compose exec -T spark-master /opt/spark/bin/spark-submit \
     --conf "spark.easydblab.localDc=$LOCAL_DC" \
     --conf "spark.easydblab.rowCount=$ROW_COUNT" \
     --conf "spark.easydblab.parallelism=$PARALLELISM" \
+    --conf "spark.easydblab.partitionCount=$PARTITION_COUNT" \
     --conf "spark.easydblab.replicationFactor=$REPLICATION_FACTOR" \
     "/jars/$JAR_NAME"
 set +x

--- a/bin/test-spark-bulk-writer
+++ b/bin/test-spark-bulk-writer
@@ -82,6 +82,7 @@ easy-db-lab spark submit \
   --conf "spark.easydblab.localDc=$DC" \
   --conf "spark.easydblab.rowCount=1000" \
   --conf "spark.easydblab.parallelism=4" \
+  --conf "spark.easydblab.partitionCount=100" \
   --conf "spark.easydblab.replicationFactor=1" \
   --wait || SPARK_EXIT_CODE=$?
 

--- a/packer/cassandra/environment
+++ b/packer/cassandra/environment
@@ -1,3 +1,3 @@
-PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin:/usr/local/cassandra/current/bin:/usr/local/async-profiler/bin/:/usr/local/cassandra-sidecar/bin"
+PATH="/usr/local/cassandra/current/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin:/usr/local/async-profiler/bin/:/usr/local/cassandra-sidecar/bin"
 CASSANDRA_LOG_DIR=/mnt/db1/cassandra/tmp
 CASSANDRA_EASY_STRESS_LOG_DIR=/mnt/db1/cassandra/stress

--- a/spark-shared/src/main/java/com/rustyrazorblade/easydblab/spark/BulkTestDataGenerator.java
+++ b/spark-shared/src/main/java/com/rustyrazorblade/easydblab/spark/BulkTestDataGenerator.java
@@ -1,62 +1,51 @@
 package com.rustyrazorblade.easydblab.spark;
 
-import org.apache.spark.api.java.JavaRDD;
-import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
-import org.apache.spark.sql.RowFactory;
+import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructType;
 
-import java.nio.ByteBuffer;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Random;
+import static org.apache.spark.sql.functions.expr;
 
 /**
- * Generates test data matching the cassandra-analytics example schema:
- * - id: bigint (sequential, partitioned across executors)
- * - course: blob (16 random bytes)
- * - marks: bigint (0-99)
+ * Generates test data for bulk write performance testing with a clustered table schema:
+ * - partition_id: bigint (distributed across configurable number of partitions)
+ * - sequence_id: bigint (sequential ordering within each partition)
+ * - course: blob (16 bytes, deterministic from row id)
+ * - marks: bigint (0-99, deterministic from row id)
  *
- * Uses seeded Random for reproducibility - same rowCount and parallelism
- * will always produce the same data.
+ * Uses DataFrame API with spark.range() for lazy evaluation - supports TB-scale
+ * data generation (tens of billions of rows) without memory pressure.
+ *
+ * Data is deterministic: the same row id always produces the same values,
+ * enabling reproducible tests.
  */
 public class BulkTestDataGenerator implements DataGenerator {
-
-    private static final int COURSE_BLOB_SIZE = 16;
-    private static final int MARKS_MAX = 100;
 
     @Override
     public StructType getSchema() {
         return new StructType()
-            .add("id", DataTypes.LongType, false)
+            .add("partition_id", DataTypes.LongType, false)
+            .add("sequence_id", DataTypes.LongType, false)
             .add("course", DataTypes.BinaryType, false)
             .add("marks", DataTypes.LongType, false);
     }
 
     @Override
-    public JavaRDD<Row> generate(JavaSparkContext sc, int rowCount, int parallelism) {
-        List<Long> seeds = new ArrayList<>();
-        for (int i = 0; i < parallelism; i++) {
-            seeds.add((long) i);
-        }
-
-        int rowsPerPartition = rowCount / parallelism;
-
-        return sc.parallelize(seeds, parallelism).flatMap(seed -> {
-            List<Row> rows = new ArrayList<>();
-            Random random = new Random(seed);
-            long startId = seed * rowsPerPartition;
-
-            for (int i = 0; i < rowsPerPartition; i++) {
-                long id = startId + i;
-                byte[] courseBytes = new byte[COURSE_BLOB_SIZE];
-                random.nextBytes(courseBytes);
-                ByteBuffer course = ByteBuffer.wrap(courseBytes);
-                long marks = random.nextInt(MARKS_MAX);
-                rows.add(RowFactory.create(id, course.array(), marks));
-            }
-            return rows.iterator();
-        });
+    public Dataset<Row> generate(SparkSession spark, long rowCount, int parallelism, long partitionCount) {
+        // spark.range() is lazy - generates data on-the-fly without memory pressure
+        // Each row gets a unique id from 0 to rowCount-1
+        return spark.range(0, rowCount, 1, parallelism)
+            // Distribute rows evenly across Cassandra partitions
+            .withColumn("partition_id", expr("id % " + partitionCount))
+            // Sequential ordering within each partition
+            .withColumn("sequence_id", expr("floor(id / " + partitionCount + ")"))
+            // Deterministic 16-byte blob from MD5 hash (32 hex chars = 16 bytes)
+            .withColumn("course", expr("unhex(substring(md5(cast(id as string)), 1, 32))"))
+            // Deterministic marks value 0-99
+            .withColumn("marks", expr("abs(hash(id)) % 100"))
+            // Remove the original range column, keep only our schema columns
+            .drop("id");
     }
 }

--- a/spark-shared/src/main/java/com/rustyrazorblade/easydblab/spark/DataGenerator.java
+++ b/spark-shared/src/main/java/com/rustyrazorblade/easydblab/spark/DataGenerator.java
@@ -1,13 +1,16 @@
 package com.rustyrazorblade.easydblab.spark;
 
-import org.apache.spark.api.java.JavaRDD;
-import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.types.StructType;
 
 /**
  * Interface for generating test data for Spark write performance comparison.
- * Implementations should use seeded Random for reproducibility.
+ * Implementations should use deterministic column expressions for reproducibility.
+ *
+ * Uses DataFrame API with lazy evaluation for TB-scale data generation without
+ * memory pressure.
  */
 public interface DataGenerator {
     /**
@@ -16,12 +19,13 @@ public interface DataGenerator {
     StructType getSchema();
 
     /**
-     * Generates test data as an RDD of Rows.
+     * Generates test data as a DataFrame using lazy evaluation.
      *
-     * @param sc Spark context
-     * @param rowCount Total number of rows to generate
-     * @param parallelism Number of partitions (also used as seed distribution)
-     * @return RDD of Rows matching getSchema()
+     * @param spark SparkSession for DataFrame creation
+     * @param rowCount Total number of rows to generate (supports billions)
+     * @param parallelism Number of Spark partitions for parallel generation
+     * @param partitionCount Number of Cassandra partitions to distribute data across
+     * @return DataFrame matching getSchema()
      */
-    JavaRDD<Row> generate(JavaSparkContext sc, int rowCount, int parallelism);
+    Dataset<Row> generate(SparkSession spark, long rowCount, int parallelism, long partitionCount);
 }

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/UpdateConfig.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/UpdateConfig.kt
@@ -57,7 +57,10 @@ class UpdateConfig : PicoBaseCommand() {
             outputHandler.handleMessage("Uploading $file to $it")
 
             val yaml = context.yaml.readTree(Path.of(file).inputStream())
-            (yaml as ObjectNode).put("listen_address", it.private).put("rpc_address", it.private)
+            (yaml as ObjectNode)
+                .put("listen_address", it.private)
+                .put("rpc_address", it.private)
+                .put("broadcast_rpc_address", it.private)
 
             outputHandler.handleMessage("Patching $it")
             val tmp = Files.createTempFile("easydblab", "yaml")

--- a/src/main/resources/com/rustyrazorblade/easydblab/commands/cassandra-sidecar.yaml
+++ b/src/main/resources/com/rustyrazorblade/easydblab/commands/cassandra-sidecar.yaml
@@ -40,6 +40,7 @@ cassandra_instances:
 sidecar:
   host: 0.0.0.0
   port: 9043
+  dns_resolver: resolve_to_ip
   request_idle_timeout_millis: 300000 # this field expects integer value
   request_timeout_millis: 300000
   tcp_keep_alive: false


### PR DESCRIPTION
- Replace RDD-based data generator with DataFrame using spark.range() for lazy, memory-efficient generation of billions of rows
- Change row count from int to long to support 10TB+ datasets
- Add clustered table schema with partition_id and sequence_id
- Add dns_resolver: resolve_to_ip to Sidecar config to fix EMR DNS resolution errors (CASSSIDECAR-263)
- Add broadcast_rpc_address to Cassandra config for IP-based topology
- Update test scripts with flags, unique table names, and EBS config
- Configure high-performance EBS (1TB gp3, 16K IOPS) for Spark clusters