### PR TITLE
Add optional OpenTelemetry CLI instrumentation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -120,6 +120,9 @@ dependencies {
     // Cassandra Driver
     implementation(libs.cassandra.driver.core)
 
+    // OpenTelemetry
+    implementation(libs.bundles.opentelemetry)
+
     // Testing
     testImplementation(libs.bundles.testing)
     testImplementation(libs.bundles.koin.test)

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -26,6 +26,7 @@
 - [Commands](reference/commands.md)
 - [Ports](reference/ports.md)
 - [Log Infrastructure](reference/log-infrastructure.md)
+- [OpenTelemetry](reference/opentelemetry.md)
 
 # Development
 

--- a/docs/reference/opentelemetry.md
+++ b/docs/reference/opentelemetry.md
@@ -1,0 +1,128 @@
+# OpenTelemetry Instrumentation
+
+easy-db-lab includes optional OpenTelemetry (OTel) instrumentation for distributed tracing and metrics. When enabled, traces and metrics are exported to an OTLP-compatible collector.
+
+## Enabling OpenTelemetry
+
+Set the `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable to your OTLP collector endpoint:
+
+```bash
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
+easy-db-lab up
+```
+
+When this environment variable is:
+- **Set**: Traces and metrics are exported via gRPC to the specified endpoint
+- **Not set**: OpenTelemetry is completely disabled with zero overhead
+
+## Instrumented Operations
+
+### Commands
+
+All CLI commands are automatically instrumented with:
+- A span for each command execution
+- Duration metrics
+- Command count metrics
+- Success/failure attributes
+
+### SSH Operations
+
+Remote SSH operations are instrumented including:
+- Command execution (`ssh.execute`)
+- File uploads (`ssh.upload`, `ssh.upload_directory`)
+- File downloads (`ssh.download`, `ssh.download_directory`)
+
+Span attributes include host alias, target IP, and (for non-secret commands) the command text.
+
+### Kubernetes Operations
+
+K8s operations via the fabric8 client are instrumented:
+- Manifest application (`k8s.apply_manifests`, `k8s.apply_yaml`)
+- Namespace deletion (`k8s.delete_namespace`)
+- StatefulSet scaling (`k8s.scale_statefulset`)
+
+### AWS SDK Calls
+
+When OTel is enabled, AWS SDK calls are automatically instrumented using the OpenTelemetry AWS SDK instrumentation library. This includes:
+- EC2 operations
+- S3 operations
+- IAM operations
+- EMR operations
+- STS operations
+- OpenSearch operations
+- SQS operations
+
+## Resource Attributes
+
+Traces include the following resource attributes:
+- `service.name`: `easy-db-lab`
+- `service.version`: Application version
+- `host.name`: Local hostname
+
+## Metrics
+
+The following metrics are exported:
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `easydblab.command.duration` | Histogram | Command execution duration (ms) |
+| `easydblab.command.count` | Counter | Number of commands executed |
+| `easydblab.ssh.operation.duration` | Histogram | SSH operation duration (ms) |
+| `easydblab.ssh.operation.count` | Counter | Number of SSH operations |
+| `easydblab.k8s.operation.duration` | Histogram | K8s operation duration (ms) |
+| `easydblab.k8s.operation.count` | Counter | Number of K8s operations |
+
+## Configuration
+
+The following environment variables are supported:
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP gRPC endpoint | None (OTel disabled) |
+
+Additional standard OTel environment variables may work depending on the SDK defaults.
+
+## Example: Using with Jaeger
+
+Start Jaeger with OTLP support:
+
+```bash
+docker run -d --name jaeger \
+  -p 16686:16686 \
+  -p 4317:4317 \
+  jaegertracing/all-in-one:latest
+```
+
+Export traces to Jaeger:
+
+```bash
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
+easy-db-lab up
+```
+
+View traces at http://localhost:16686
+
+## Example: Using with Grafana Tempo
+
+If you have Grafana Tempo running with OTLP gRPC ingestion:
+
+```bash
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://tempo:4317
+easy-db-lab up
+```
+
+## Troubleshooting
+
+### No Traces Appearing
+
+1. Verify the endpoint is correct and reachable
+2. Check that the collector accepts gRPC OTLP (port 4317 is standard)
+3. Look for OpenTelemetry initialization logs on startup
+
+### High Latency
+
+Traces are batched before export (default 1 second delay). This is normal and reduces overhead.
+
+### Shutdown Warnings
+
+A shutdown hook flushes remaining telemetry on exit. Brief delays during shutdown are expected.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -60,6 +60,10 @@ classgraph = "4.8.184"
 resilience4j = "2.3.0"
 fabric8-kubernetes = "7.5.0"
 
+# OpenTelemetry
+opentelemetry = "1.40.0"
+opentelemetry-instrumentation = "2.16.0-alpha"
+
 # Gradle Plugins
 shadow = "8.1.1"
 versions = "0.53.0"
@@ -154,6 +158,13 @@ fabric8-kubernetes-client = { module = "io.fabric8:kubernetes-client", version.r
 # Cassandra Driver
 cassandra-driver-core = { module = "org.apache.cassandra:java-driver-core", version.ref = "cassandra-driver" }
 
+# OpenTelemetry
+opentelemetry-api = { module = "io.opentelemetry:opentelemetry-api", version.ref = "opentelemetry" }
+opentelemetry-sdk = { module = "io.opentelemetry:opentelemetry-sdk", version.ref = "opentelemetry" }
+opentelemetry-exporter-otlp = { module = "io.opentelemetry:opentelemetry-exporter-otlp", version.ref = "opentelemetry" }
+opentelemetry-aws-sdk = { module = "io.opentelemetry.instrumentation:opentelemetry-aws-sdk-2.2", version.ref = "opentelemetry-instrumentation" }
+opentelemetry-okhttp = { module = "io.opentelemetry.instrumentation:opentelemetry-okhttp-3.0", version.ref = "opentelemetry-instrumentation" }
+
 [bundles]
 # Logging bundle
 logging = ["logback-classic", "kotlin-logging"]
@@ -186,6 +197,8 @@ sshd = ["sshd-core", "sshd-scp"]
 # Resilience4j bundle
 resilience4j = ["resilience4j-retry", "resilience4j-kotlin"]
 
+# OpenTelemetry bundle
+opentelemetry = ["opentelemetry-api", "opentelemetry-sdk", "opentelemetry-exporter-otlp", "opentelemetry-aws-sdk", "opentelemetry-okhttp"]
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/observability/NoOpTelemetryProvider.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/observability/NoOpTelemetryProvider.kt
@@ -1,0 +1,55 @@
+package com.rustyrazorblade.easydblab.observability
+
+import io.opentelemetry.api.metrics.Meter
+import io.opentelemetry.api.trace.Tracer
+
+/**
+ * No-operation implementation of TelemetryProvider.
+ *
+ * Used when OpenTelemetry is not configured (OTEL_EXPORTER_OTLP_ENDPOINT not set).
+ * All operations are no-ops with minimal overhead:
+ * - withSpan() executes the block directly without any tracing
+ * - Metric recording methods do nothing
+ * - Returns no-op Tracer and Meter instances from OpenTelemetry API
+ */
+class NoOpTelemetryProvider : TelemetryProvider {
+    private val noOpTracer: Tracer =
+        io.opentelemetry.api.trace.TracerProvider
+            .noop()
+            .get("noop")
+    private val noOpMeter: Meter =
+        io.opentelemetry.api.metrics.MeterProvider
+            .noop()
+            .get("noop")
+
+    override fun getTracer(name: String): Tracer = noOpTracer
+
+    override fun getMeter(name: String): Meter = noOpMeter
+
+    override fun <T> withSpan(
+        name: SpanName,
+        attributes: Map<String, String>,
+        block: () -> T,
+    ): T = block()
+
+    override fun recordDuration(
+        metric: MetricName,
+        durationMs: Long,
+        attributes: Map<String, String>,
+    ) {
+        // No-op
+    }
+
+    override fun incrementCounter(
+        metric: MetricName,
+        attributes: Map<String, String>,
+    ) {
+        // No-op
+    }
+
+    override fun shutdown() {
+        // No-op
+    }
+
+    override fun isEnabled(): Boolean = false
+}

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/observability/ObservabilityModule.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/observability/ObservabilityModule.kt
@@ -11,13 +11,13 @@ import org.koin.dsl.module
  *
  * This module provides services for logging, metrics, and monitoring:
  * - VictoriaLogsService: Query logs from Victoria Logs
- *
- * Future additions may include:
- * - Metrics services (Victoria Metrics)
- * - Tracing services
- * - Alerting services
+ * - TelemetryProvider: OpenTelemetry tracing and metrics
  */
 val observabilityModule =
     module {
         factoryOf(::DefaultVictoriaLogsService) bind VictoriaLogsService::class
+
+        // TelemetryProvider - singleton because it manages SDK lifecycle
+        // Uses TelemetryFactory to create the appropriate implementation based on environment
+        single<TelemetryProvider> { TelemetryFactory.create() }
     }

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/observability/OtelTelemetryProvider.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/observability/OtelTelemetryProvider.kt
@@ -1,0 +1,249 @@
+package com.rustyrazorblade.easydblab.observability
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.opentelemetry.api.OpenTelemetry
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.common.Attributes
+import io.opentelemetry.api.metrics.Meter
+import io.opentelemetry.api.trace.StatusCode
+import io.opentelemetry.api.trace.Tracer
+import io.opentelemetry.context.Context
+import io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporter
+import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter
+import io.opentelemetry.sdk.OpenTelemetrySdk
+import io.opentelemetry.sdk.metrics.SdkMeterProvider
+import io.opentelemetry.sdk.metrics.export.PeriodicMetricReader
+import io.opentelemetry.sdk.resources.Resource
+import io.opentelemetry.sdk.trace.SdkTracerProvider
+import io.opentelemetry.sdk.trace.export.BatchSpanProcessor
+import java.time.Duration
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.TimeUnit
+
+private val log = KotlinLogging.logger {}
+
+/**
+ * OpenTelemetry implementation of TelemetryProvider.
+ *
+ * Exports traces and metrics via gRPC to the configured OTLP endpoint.
+ * This implementation is used when OTEL_EXPORTER_OTLP_ENDPOINT is set.
+ *
+ * Features:
+ * - Batch span processing for efficient trace export
+ * - Periodic metric reading with configurable interval
+ * - Resource attributes for service identification
+ * - Graceful shutdown with flush on exit
+ *
+ * @param endpoint The OTLP gRPC endpoint (e.g., "http://localhost:4317")
+ */
+class OtelTelemetryProvider(
+    private val endpoint: String,
+) : TelemetryProvider {
+    private val openTelemetry: OpenTelemetry
+    private val sdkTracerProvider: SdkTracerProvider
+    private val sdkMeterProvider: SdkMeterProvider
+
+    // Cache for histograms and counters to avoid recreation
+    private val histogramCache = ConcurrentHashMap<String, io.opentelemetry.api.metrics.LongHistogram>()
+    private val counterCache = ConcurrentHashMap<String, io.opentelemetry.api.metrics.LongCounter>()
+
+    init {
+        log.info { "Initializing OpenTelemetry with endpoint: $endpoint" }
+
+        // Build resource with service information
+        val resource =
+            Resource
+                .getDefault()
+                .merge(
+                    Resource.create(
+                        Attributes.of(
+                            AttributeKey.stringKey("service.name"),
+                            TelemetryNames.SERVICE_NAME,
+                            AttributeKey.stringKey("service.version"),
+                            getVersion(),
+                            AttributeKey.stringKey("host.name"),
+                            getHostName(),
+                        ),
+                    ),
+                )
+
+        // Configure span exporter
+        val spanExporter =
+            OtlpGrpcSpanExporter
+                .builder()
+                .setEndpoint(endpoint)
+                .setTimeout(Duration.ofSeconds(EXPORT_TIMEOUT_SECONDS))
+                .build()
+
+        // Configure tracer provider with batch processor
+        sdkTracerProvider =
+            SdkTracerProvider
+                .builder()
+                .setResource(resource)
+                .addSpanProcessor(
+                    BatchSpanProcessor
+                        .builder(spanExporter)
+                        .setScheduleDelay(Duration.ofMillis(BATCH_DELAY_MS))
+                        .setMaxQueueSize(MAX_QUEUE_SIZE)
+                        .setMaxExportBatchSize(MAX_BATCH_SIZE)
+                        .build(),
+                ).build()
+
+        // Configure metric exporter
+        val metricExporter =
+            OtlpGrpcMetricExporter
+                .builder()
+                .setEndpoint(endpoint)
+                .setTimeout(Duration.ofSeconds(EXPORT_TIMEOUT_SECONDS))
+                .build()
+
+        // Configure meter provider with periodic reader
+        sdkMeterProvider =
+            SdkMeterProvider
+                .builder()
+                .setResource(resource)
+                .registerMetricReader(
+                    PeriodicMetricReader
+                        .builder(metricExporter)
+                        .setInterval(Duration.ofSeconds(METRIC_EXPORT_INTERVAL_SECONDS))
+                        .build(),
+                ).build()
+
+        // Build the OpenTelemetry instance
+        openTelemetry =
+            OpenTelemetrySdk
+                .builder()
+                .setTracerProvider(sdkTracerProvider)
+                .setMeterProvider(sdkMeterProvider)
+                .build()
+
+        log.info { "OpenTelemetry initialized successfully" }
+    }
+
+    override fun getTracer(name: String): Tracer = openTelemetry.getTracer(name)
+
+    override fun getMeter(name: String): Meter = openTelemetry.getMeter(name)
+
+    override fun <T> withSpan(
+        name: SpanName,
+        attributes: Map<String, String>,
+        block: () -> T,
+    ): T {
+        val tracer = getTracer(TelemetryNames.SERVICE_NAME)
+        val spanBuilder = tracer.spanBuilder(name)
+
+        // Attach to current context if one exists
+        val parentContext = Context.current()
+        spanBuilder.setParent(parentContext)
+
+        // Add attributes
+        attributes.forEach { (key, value) ->
+            spanBuilder.setAttribute(AttributeKey.stringKey(key), value)
+        }
+
+        val span = spanBuilder.startSpan()
+        val scope = span.makeCurrent()
+
+        return try {
+            val result = block()
+            span.setStatus(StatusCode.OK)
+            result
+        } catch (e: Exception) {
+            span.setStatus(StatusCode.ERROR, e.message ?: "Unknown error")
+            span.recordException(e)
+            throw e
+        } finally {
+            scope.close()
+            span.end()
+        }
+    }
+
+    override fun recordDuration(
+        metric: MetricName,
+        durationMs: Long,
+        attributes: Map<String, String>,
+    ) {
+        val histogram =
+            histogramCache.getOrPut(metric) {
+                getMeter(TelemetryNames.SERVICE_NAME)
+                    .histogramBuilder(metric)
+                    .setUnit("ms")
+                    .setDescription("Duration in milliseconds")
+                    .ofLongs()
+                    .build()
+            }
+
+        val otelAttributes = buildAttributes(attributes)
+        histogram.record(durationMs, otelAttributes)
+    }
+
+    override fun incrementCounter(
+        metric: MetricName,
+        attributes: Map<String, String>,
+    ) {
+        val counter =
+            counterCache.getOrPut(metric) {
+                getMeter(TelemetryNames.SERVICE_NAME)
+                    .counterBuilder(metric)
+                    .setDescription("Count of operations")
+                    .build()
+            }
+
+        val otelAttributes = buildAttributes(attributes)
+        counter.add(1, otelAttributes)
+    }
+
+    override fun shutdown() {
+        log.info { "Shutting down OpenTelemetry..." }
+        try {
+            // Flush and shutdown tracer provider
+            sdkTracerProvider.forceFlush().join(SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            sdkTracerProvider.shutdown().join(SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+
+            // Flush and shutdown meter provider
+            sdkMeterProvider.forceFlush().join(SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            sdkMeterProvider.shutdown().join(SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+
+            log.info { "OpenTelemetry shutdown complete" }
+        } catch (e: Exception) {
+            log.warn(e) { "Error during OpenTelemetry shutdown" }
+        }
+    }
+
+    override fun isEnabled(): Boolean = true
+
+    /**
+     * Gets the current OpenTelemetry instance for use with auto-instrumentation libraries.
+     *
+     * This is needed for configuring AWS SDK and OkHttp auto-instrumentation.
+     */
+    fun getOpenTelemetry(): OpenTelemetry = openTelemetry
+
+    private fun buildAttributes(attributes: Map<String, String>): Attributes {
+        val builder = Attributes.builder()
+        attributes.forEach { (key, value) ->
+            builder.put(AttributeKey.stringKey(key), value)
+        }
+        return builder.build()
+    }
+
+    private fun getVersion(): String = System.getProperty("easydblab.version", "unknown")
+
+    private fun getHostName(): String =
+        try {
+            java.net.InetAddress
+                .getLocalHost()
+                .hostName
+        } catch (e: Exception) {
+            "unknown"
+        }
+
+    companion object {
+        private const val EXPORT_TIMEOUT_SECONDS = 10L
+        private const val BATCH_DELAY_MS = 1000L
+        private const val MAX_QUEUE_SIZE = 2048
+        private const val MAX_BATCH_SIZE = 512
+        private const val METRIC_EXPORT_INTERVAL_SECONDS = 30L
+        private const val SHUTDOWN_TIMEOUT_SECONDS = 5L
+    }
+}

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/observability/TelemetryFactory.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/observability/TelemetryFactory.kt
@@ -1,0 +1,51 @@
+package com.rustyrazorblade.easydblab.observability
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+
+private val log = KotlinLogging.logger {}
+
+/**
+ * Factory for creating TelemetryProvider instances based on environment configuration.
+ *
+ * Behavior:
+ * - If OTEL_EXPORTER_OTLP_ENDPOINT is set: creates OtelTelemetryProvider (traces & metrics exported)
+ * - If OTEL_EXPORTER_OTLP_ENDPOINT is not set: creates NoOpTelemetryProvider (zero overhead)
+ *
+ * Usage:
+ * ```kotlin
+ * val telemetry = TelemetryFactory.create()
+ * telemetry.withSpan("operation.name") {
+ *     // instrumented code
+ * }
+ * ```
+ */
+object TelemetryFactory {
+    /**
+     * Environment variable name for configuring the OTLP endpoint.
+     */
+    const val OTEL_ENDPOINT_ENV_VAR = "OTEL_EXPORTER_OTLP_ENDPOINT"
+
+    /**
+     * Creates a TelemetryProvider based on environment configuration.
+     *
+     * @return OtelTelemetryProvider if OTEL_EXPORTER_OTLP_ENDPOINT is set,
+     *         NoOpTelemetryProvider otherwise
+     */
+    @Suppress("TooGenericExceptionCaught")
+    fun create(): TelemetryProvider {
+        val endpoint = System.getenv(OTEL_ENDPOINT_ENV_VAR)
+
+        return if (endpoint.isNullOrBlank()) {
+            log.debug { "OpenTelemetry disabled: $OTEL_ENDPOINT_ENV_VAR not set" }
+            NoOpTelemetryProvider()
+        } else {
+            log.info { "OpenTelemetry enabled: exporting to $endpoint" }
+            try {
+                OtelTelemetryProvider(endpoint)
+            } catch (e: Exception) {
+                log.error(e) { "Failed to initialize OpenTelemetry, falling back to no-op" }
+                NoOpTelemetryProvider()
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/observability/TelemetryNames.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/observability/TelemetryNames.kt
@@ -1,0 +1,98 @@
+package com.rustyrazorblade.easydblab.observability
+
+/**
+ * Type alias for span names to improve code readability.
+ */
+typealias SpanName = String
+
+/**
+ * Type alias for metric names to improve code readability.
+ */
+typealias MetricName = String
+
+/**
+ * Centralized constants for OpenTelemetry instrumentation names.
+ *
+ * This object provides type-safe, consistent naming for all spans, metrics,
+ * and attributes used in telemetry throughout the application.
+ */
+object TelemetryNames {
+    /**
+     * Span names for distributed tracing.
+     */
+    object Spans {
+        // Command spans
+        const val COMMAND_EXECUTE: SpanName = "command.execute"
+        const val COMMAND_UP: SpanName = "command.up"
+        const val COMMAND_DOWN: SpanName = "command.down"
+        const val COMMAND_INIT: SpanName = "command.init"
+        const val COMMAND_STATUS: SpanName = "command.status"
+        const val COMMAND_EXEC: SpanName = "command.exec"
+
+        // SSH operation spans
+        const val SSH_EXECUTE: SpanName = "ssh.execute"
+        const val SSH_UPLOAD: SpanName = "ssh.upload"
+        const val SSH_UPLOAD_DIRECTORY: SpanName = "ssh.upload_directory"
+        const val SSH_DOWNLOAD: SpanName = "ssh.download"
+        const val SSH_DOWNLOAD_DIRECTORY: SpanName = "ssh.download_directory"
+
+        // Kubernetes operation spans
+        const val K8S_APPLY_MANIFESTS: SpanName = "k8s.apply_manifests"
+        const val K8S_DELETE_NAMESPACE: SpanName = "k8s.delete_namespace"
+        const val K8S_GET_STATUS: SpanName = "k8s.get_status"
+        const val K8S_WAIT_PODS_READY: SpanName = "k8s.wait_pods_ready"
+        const val K8S_SCALE_STATEFULSET: SpanName = "k8s.scale_statefulset"
+        const val K8S_CREATE_JOB: SpanName = "k8s.create_job"
+        const val K8S_DELETE_JOB: SpanName = "k8s.delete_job"
+        const val K8S_CREATE_CONFIG_MAP: SpanName = "k8s.create_config_map"
+        const val K8S_APPLY_YAML: SpanName = "k8s.apply_yaml"
+        const val K8S_LABEL_NODE: SpanName = "k8s.label_node"
+
+        // Docker operation spans
+        const val DOCKER_RUN: SpanName = "docker.run"
+        const val DOCKER_BUILD: SpanName = "docker.build"
+        const val DOCKER_PULL: SpanName = "docker.pull"
+
+        // AWS operation spans (manual, auto-instrumentation handles SDK calls)
+        const val AWS_CREATE_INSTANCES: SpanName = "aws.create_instances"
+        const val AWS_TERMINATE_INSTANCES: SpanName = "aws.terminate_instances"
+        const val AWS_WAIT_INSTANCES_READY: SpanName = "aws.wait_instances_ready"
+    }
+
+    /**
+     * Metric names for observability.
+     */
+    object Metrics {
+        const val COMMAND_DURATION: MetricName = "easydblab.command.duration"
+        const val COMMAND_COUNT: MetricName = "easydblab.command.count"
+        const val SSH_OPERATION_DURATION: MetricName = "easydblab.ssh.operation.duration"
+        const val SSH_OPERATION_COUNT: MetricName = "easydblab.ssh.operation.count"
+        const val K8S_OPERATION_DURATION: MetricName = "easydblab.k8s.operation.duration"
+        const val K8S_OPERATION_COUNT: MetricName = "easydblab.k8s.operation.count"
+    }
+
+    /**
+     * Attribute keys for span and metric attributes.
+     */
+    object Attributes {
+        const val COMMAND_NAME = "command.name"
+        const val CLUSTER_ID = "cluster.id"
+        const val SERVER_TYPE = "server.type"
+        const val HOST_TARGET = "host.target"
+        const val HOST_ALIAS = "host.alias"
+        const val K8S_NAMESPACE = "k8s.namespace"
+        const val K8S_RESOURCE_NAME = "k8s.resource.name"
+        const val SSH_COMMAND = "ssh.command"
+        const val SSH_COMMAND_REDACTED = "ssh.command.redacted"
+        const val FILE_PATH_LOCAL = "file.path.local"
+        const val FILE_PATH_REMOTE = "file.path.remote"
+        const val OPERATION_TYPE = "operation.type"
+        const val SUCCESS = "success"
+        const val ERROR_MESSAGE = "error.message"
+    }
+
+    /**
+     * Service name for OpenTelemetry resource.
+     */
+    const val SERVICE_NAME = "easy-db-lab"
+}

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/observability/TelemetryProvider.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/observability/TelemetryProvider.kt
@@ -1,0 +1,87 @@
+package com.rustyrazorblade.easydblab.observability
+
+import io.opentelemetry.api.metrics.Meter
+import io.opentelemetry.api.trace.Tracer
+
+/**
+ * Interface for telemetry operations providing tracing and metrics capabilities.
+ *
+ * This abstraction allows for different implementations based on whether
+ * OpenTelemetry is configured (via OTEL_EXPORTER_OTLP_ENDPOINT environment variable):
+ * - When configured: OtelTelemetryProvider exports traces and metrics via gRPC
+ * - When not configured: NoOpTelemetryProvider provides zero-overhead no-ops
+ */
+interface TelemetryProvider {
+    /**
+     * Gets a tracer for creating spans.
+     *
+     * @param name The name of the tracer (typically the class or component name)
+     * @return A Tracer instance
+     */
+    fun getTracer(name: String): Tracer
+
+    /**
+     * Gets a meter for recording metrics.
+     *
+     * @param name The name of the meter (typically the class or component name)
+     * @return A Meter instance
+     */
+    fun getMeter(name: String): Meter
+
+    /**
+     * Executes a block of code within a named span.
+     *
+     * This is the primary method for instrumenting operations. It handles
+     * span lifecycle (start, end), error recording, and attribute attachment.
+     *
+     * @param name The span name (use constants from TelemetryNames.Spans)
+     * @param attributes Optional attributes to attach to the span
+     * @param block The code block to execute within the span
+     * @return The result of the block execution
+     * @throws Exception Any exception thrown by the block is recorded and re-thrown
+     */
+    fun <T> withSpan(
+        name: SpanName,
+        attributes: Map<String, String> = emptyMap(),
+        block: () -> T,
+    ): T
+
+    /**
+     * Records a duration metric.
+     *
+     * @param metric The metric name (use constants from TelemetryNames.Metrics)
+     * @param durationMs Duration in milliseconds
+     * @param attributes Optional attributes to attach to the metric
+     */
+    fun recordDuration(
+        metric: MetricName,
+        durationMs: Long,
+        attributes: Map<String, String> = emptyMap(),
+    )
+
+    /**
+     * Increments a counter metric.
+     *
+     * @param metric The metric name (use constants from TelemetryNames.Metrics)
+     * @param attributes Optional attributes to attach to the metric
+     */
+    fun incrementCounter(
+        metric: MetricName,
+        attributes: Map<String, String> = emptyMap(),
+    )
+
+    /**
+     * Shuts down the telemetry provider, flushing any pending data.
+     *
+     * Should be called during application shutdown to ensure all telemetry
+     * data is exported before the process exits.
+     */
+    fun shutdown()
+
+    /**
+     * Checks if telemetry is enabled.
+     *
+     * @return true if telemetry is being exported, false for no-op mode
+     */
+    fun isEnabled(): Boolean
+}

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/ServicesModule.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/ServicesModule.kt
@@ -6,6 +6,7 @@ import com.rustyrazorblade.easydblab.configuration.User
 import com.rustyrazorblade.easydblab.configuration.UserConfigProvider
 import com.rustyrazorblade.easydblab.driver.CqlSessionFactory
 import com.rustyrazorblade.easydblab.driver.DefaultCqlSessionFactory
+import com.rustyrazorblade.easydblab.observability.TelemetryProvider
 import com.rustyrazorblade.easydblab.output.OutputHandler
 import com.rustyrazorblade.easydblab.providers.aws.AWS
 import com.rustyrazorblade.easydblab.providers.aws.EC2InstanceService
@@ -107,6 +108,7 @@ val servicesModule =
                 get<UserConfigProvider>(),
                 get<DockerClientProvider>(),
                 get<ResourceManager>(),
+                get<TelemetryProvider>(),
             )
         }
     }

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/di/AWSModuleTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/di/AWSModuleTest.kt
@@ -1,6 +1,7 @@
 package com.rustyrazorblade.easydblab.di
 
 import com.rustyrazorblade.easydblab.configuration.User
+import com.rustyrazorblade.easydblab.observability.observabilityModule
 import com.rustyrazorblade.easydblab.providers.aws.awsModule
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -35,9 +36,9 @@ internal class AWSModuleTest : KoinTest {
             }
 
         try {
-            // Start Koin with awsModule and testModule
+            // Start Koin with awsModule, observabilityModule, and testModule
             startKoin {
-                modules(awsModule, testModule)
+                modules(observabilityModule, awsModule, testModule)
             }
 
             // Get the credentials provider from Koin
@@ -70,9 +71,9 @@ internal class AWSModuleTest : KoinTest {
             }
 
         try {
-            // Start Koin with awsModule and testModule
+            // Start Koin with awsModule, observabilityModule, and testModule
             startKoin {
-                modules(awsModule, testModule)
+                modules(observabilityModule, awsModule, testModule)
             }
 
             // Get the credentials provider from Koin
@@ -110,9 +111,9 @@ internal class AWSModuleTest : KoinTest {
             }
 
         try {
-            // Start Koin with awsModule and testModule
+            // Start Koin with awsModule, observabilityModule, and testModule
             startKoin {
-                modules(awsModule, testModule)
+                modules(observabilityModule, awsModule, testModule)
             }
 
             // Get the EMR client from Koin


### PR DESCRIPTION
Add distributed tracing and metrics support via OpenTelemetry. When OTEL_EXPORTER_OTLP_ENDPOINT is set, traces and metrics are exported via gRPC. When unset, OTel is completely disabled with zero overhead.

Instrumented operations:
- Command execution (spans and duration/count metrics)
- SSH operations (execute, upload, download)
- Kubernetes operations (apply manifests, delete namespace, scale)
- AWS SDK calls (auto-instrumentation via OTel AWS SDK library)

Architecture uses TelemetryProvider interface with two implementations:
- NoOpTelemetryProvider: zero-overhead when disabled
- OtelTelemetryProvider: full tracing/metrics when enabled