### PR TITLE
Add custom VPC CIDR support and Tailscale-aware network access

### DIFF
--- a/bin/end-to-end-test
+++ b/bin/end-to-end-test
@@ -130,7 +130,7 @@ step_init_cluster() {
         echo "=== EBS volumes enabled (gp3, 256GB) ==="
     fi
     local created_timestamp=$(date +%s)
-    easy-db-lab init -c 3 -i c5.2xlarge test --clean --up -s 1 --tag "created=$created_timestamp" $spark_opts $ebs_opts
+    easy-db-lab init -c 3 -i c5.2xlarge test --clean --up -s 1 --tag "created=$created_timestamp" --cidr 10.14.0.0/20 $spark_opts $ebs_opts
 }
 
 step_setup_kubectl() {
@@ -500,8 +500,9 @@ step_registry_push_pull() {
 
     # Pull busybox locally and use skopeo to push to private registry
     # skopeo routes through SOCKS5 proxy (configured in env.sh)
-    echo "=== Pulling busybox and pushing to private registry via skopeo ==="
-    docker pull busybox:latest
+    # Must pull linux/amd64 since EC2 instances are x86_64
+    echo "=== Pulling busybox (amd64) and pushing to private registry via skopeo ==="
+    docker pull --platform linux/amd64 busybox:latest
     skopeo copy --dest-tls-verify=false \
         docker-daemon:busybox:latest \
         docker://${registry}/busybox:e2e

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -186,6 +186,8 @@ tasks.test {
     }
 
     doFirst {
+        environment("EASY_DB_LAB_PROFILE", "default")
+
         println("========================================")
         println("Test Execution Configuration:")
         println("  Available processors: $processors")

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -14,6 +14,7 @@
 - [Tutorial](user-guide/tutorial.md)
 - [Cassandra](user-guide/installing-cassandra.md)
 - [Kubernetes](user-guide/kubernetes.md)
+- [Network Connectivity](user-guide/network-connectivity.md)
 - [SSH Proxying](user-guide/ssh-proxying.md)
 - [Victoria Logs](user-guide/victoria-logs.md)
 - [Spark](user-guide/spark.md)

--- a/docs/user-guide/network-connectivity.md
+++ b/docs/user-guide/network-connectivity.md
@@ -1,0 +1,250 @@
+# Network Connectivity
+
+This guide covers the different ways to connect to your easy-db-lab cluster from your local machine.
+
+## Overview
+
+easy-db-lab clusters run in a private AWS VPC. By default, cluster nodes have private IPs (10.0.x.x) that aren't directly accessible from the internet. There are two methods to access your cluster:
+
+| Method | Best For | Setup Complexity |
+|--------|----------|------------------|
+| **SOCKS Proxy** | Quick access, development | Low (automatic) |
+| **Tailscale VPN** | Persistent access, multiple tools, team sharing | Medium (one-time setup) |
+
+## SOCKS Proxy (Default)
+
+The SOCKS proxy is the default connectivity method. It creates an SSH tunnel through the control node.
+
+```
+┌─────────────────┐     SSH Tunnel      ┌──────────────┐
+│  Your Machine   │ ──────────────────► │ Control Node │
+│  localhost:1080 │                     │  (control0)  │
+└────────┬────────┘                     └──────┬───────┘
+         │                                     │
+    SOCKS5 Proxy                         Private VPC
+         │                                     │
+         ▼                                     ▼
+   kubectl, curl                        10.0.x.x network
+```
+
+### Quick Start
+
+```bash
+# Load environment (starts proxy automatically)
+source env.sh
+
+# Use kubectl, curl, etc. - they're pre-configured
+kubectl get pods
+curl http://control0:9428/health
+```
+
+### When to Use SOCKS Proxy
+
+- Quick development and testing
+- Single-user access
+- When you don't want to set up additional services
+
+For detailed SOCKS proxy usage, see [SSH Proxying](ssh-proxying.md).
+
+## Tailscale VPN
+
+Tailscale provides a persistent VPN connection to your cluster. Once connected, you can access cluster resources as if you were on the same network.
+
+```
+┌─────────────────┐                     ┌──────────────┐
+│  Your Machine   │ ◄── Tailscale ───► │ Control Node │
+│  (Tailscale IP) │      VPN Mesh      │  (Tailscale) │
+└────────┬────────┘                     └──────┬───────┘
+         │                                     │
+    Direct Access                        Subnet Router
+         │                                     │
+         ▼                                     ▼
+   Any application                      10.0.x.x network
+```
+
+### When to Use Tailscale
+
+- Persistent connectivity across sessions
+- Access from multiple applications without proxy configuration
+- Sharing cluster access with team members
+- Using tools that don't support SOCKS proxies
+
+### Setup
+
+Tailscale requires a one-time setup in your Tailscale account before using it with easy-db-lab.
+
+#### Step 1: Configure Tailscale ACL
+
+1. Go to [Tailscale ACL Editor](https://login.tailscale.com/admin/acls)
+2. Add the tag to your ACL policy. Find the `tagOwners` section (or create one) and add:
+
+```json
+{
+  "tagOwners": {
+    "tag:easy-db-lab": ["autogroup:admin"]
+  }
+}
+```
+
+If you have existing tags, just add the new one:
+
+```json
+{
+  "tagOwners": {
+    "tag:existing-tag": ["autogroup:admin"],
+    "tag:easy-db-lab": ["autogroup:admin"]
+  }
+}
+```
+
+#### Step 2: Create OAuth Client
+
+1. Go to [Tailscale OAuth Settings](https://login.tailscale.com/admin/settings/oauth)
+2. Click **Generate OAuth Client**
+3. Set the following:
+   - **Description**: easy-db-lab (or any name you prefer)
+   - **Scopes**: Select **Devices: Write**
+   - **Tags**: Add `tag:easy-db-lab`
+4. Click **Generate**
+5. Copy the **Client ID** and **Client Secret** (you won't see the secret again)
+
+#### Step 3: Configure easy-db-lab
+
+Run the setup profile command and enter your Tailscale credentials:
+
+```bash
+easy-db-lab setup-profile --update
+```
+
+Or provide them during initial setup:
+
+```bash
+easy-db-lab setup-profile
+```
+
+When prompted for Tailscale OAuth Client ID and Secret, enter the values from Step 2.
+
+### Usage
+
+#### Automatic Start (Recommended)
+
+If you've configured Tailscale credentials in your profile, Tailscale starts automatically when you run `easy-db-lab up`.
+
+#### Manual Start
+
+```bash
+# Start Tailscale on the control node
+easy-db-lab tailscale start
+
+# Check status
+easy-db-lab tailscale status
+
+# Stop Tailscale
+easy-db-lab tailscale stop
+```
+
+#### Approve Subnet Route
+
+After starting Tailscale for the first time, you need to approve the subnet route. You can do this manually or configure auto-approval.
+
+##### Manual Approval
+
+1. Go to [Tailscale Machines](https://login.tailscale.com/admin/machines)
+2. Find the machine named after your control node (e.g., `control0`)
+3. Click on it and find **Subnet routes**
+4. Approve the route (e.g., `10.0.0.0/16`)
+
+##### Auto-Approval (Recommended)
+
+To avoid manual approval each time, add an `autoApprovers` section to your [Tailscale ACL](https://login.tailscale.com/admin/acls):
+
+```json
+{
+  "tagOwners": {
+    "tag:easy-db-lab": ["autogroup:admin"]
+  },
+  "autoApprovers": {
+    "routes": {
+      "10.0.0.0/8": ["tag:easy-db-lab"]
+    }
+  }
+}
+```
+
+This auto-approves any `10.x.x.x` subnet route advertised by devices with the `tag:easy-db-lab` tag. After adding this, subnet routes are approved automatically when Tailscale starts.
+
+Once approved (manually or automatically), you can access all cluster nodes directly using their private IPs.
+
+### Using Tailscale Connection
+
+After Tailscale is connected and the subnet route is approved:
+
+```bash
+# SSH directly to nodes using private IPs
+ssh ubuntu@10.0.1.50
+
+# Access services without proxy configuration
+curl http://10.0.1.50:9428/health
+
+# kubectl works without SOCKS proxy
+kubectl get pods
+
+# Access web UIs directly in your browser
+# http://10.0.1.50:3000 (Grafana)
+```
+
+### Tailscale Commands Reference
+
+| Command | Description |
+|---------|-------------|
+| `easy-db-lab tailscale start` | Start Tailscale on control node |
+| `easy-db-lab tailscale stop` | Stop Tailscale on control node |
+| `easy-db-lab tailscale status` | Show Tailscale connection status |
+
+### Troubleshooting Tailscale
+
+#### "requested tags are invalid or not permitted"
+
+The tag must be configured in your Tailscale ACL. See [Step 1: Configure Tailscale ACL](#step-1-configure-tailscale-acl).
+
+#### "tailnet-owned auth key must have tags set"
+
+Tags are required for OAuth-based authentication. Ensure you've added `tag:easy-db-lab` to your ACL policy.
+
+#### Can't reach private IPs after connecting
+
+1. Check that the subnet route is approved in Tailscale admin (or configure [auto-approval](#auto-approval-recommended))
+2. Verify Tailscale status: `easy-db-lab tailscale status`
+3. On your local machine, check Tailscale is running: `tailscale status`
+4. Restart Tailscale if you just added auto-approval: `easy-db-lab tailscale stop && easy-db-lab tailscale start`
+
+#### Using a custom tag
+
+If you want to use a different tag:
+
+```bash
+easy-db-lab tailscale start --tag tag:my-custom-tag
+```
+
+Make sure the custom tag is configured in your ACL and added to your OAuth client.
+
+## Comparison
+
+| Feature | SOCKS Proxy | Tailscale |
+|---------|-------------|-----------|
+| Setup time | Instant | ~10 minutes (one-time) |
+| Persistence | Per-session | Persistent |
+| Multiple apps | Requires proxy config | Works natively |
+| Team sharing | Not supported | Supported |
+| Requires `source env.sh` | Yes | No |
+| Works offline | No | No |
+| External dependencies | None | Tailscale account |
+
+## Recommendation
+
+- **Start with SOCKS Proxy** - It works out of the box with no setup
+- **Switch to Tailscale** when you:
+  - Want persistent access without running `source env.sh`
+  - Need to use tools that don't support SOCKS proxies
+  - Want to share cluster access with team members
+  - Find yourself frequently reconnecting the SOCKS proxy

--- a/packer/base/base.pkr.hcl
+++ b/packer/base/base.pkr.hcl
@@ -129,6 +129,11 @@ build {
     script = "install/install_k3s.sh"
   }
 
+  # install tailscale (disabled, not auto-started)
+  provisioner "shell" {
+    script = "install/install_tailscale.sh"
+  }
+
   # install k9s (Kubernetes TUI)
   provisioner "shell" {
     script = "install/install_k9s.sh"

--- a/packer/base/install/install_async_profiler.sh
+++ b/packer/base/install/install_async_profiler.sh
@@ -17,7 +17,7 @@ fi
 
 echo "ARCH is set to: $ARCH"
 
-RELEASE_VERSION="4.0"
+RELEASE_VERSION="4.3"
 RELEASE="async-profiler-${RELEASE_VERSION}-linux-${ARCH}"
 ARCHIVE="${RELEASE}.tar.gz"
 

--- a/packer/base/install/install_tailscale.sh
+++ b/packer/base/install/install_tailscale.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Install Tailscale VPN client
+# Tailscale is installed but NOT auto-started - the daemon is started on-demand via easy-db-lab commands
+set -e
+
+echo "=== Installing Tailscale ==="
+
+# Add Tailscale's official GPG key and repository
+curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/noble.noarmor.gpg | sudo tee /usr/share/keyrings/tailscale-archive-keyring.gpg >/dev/null
+curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/noble.tailscale-keyring.list | sudo tee /etc/apt/sources.list.d/tailscale.list
+
+# Install tailscale
+sudo apt-get update
+sudo apt-get install -y tailscale
+
+# Disable auto-start - we start on-demand via easy-db-lab tailscale start
+sudo systemctl disable tailscaled
+sudo systemctl stop tailscaled
+
+echo "✓ Tailscale installed successfully (daemon disabled)"

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/CommandLineParser.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/CommandLineParser.kt
@@ -31,6 +31,7 @@ import com.rustyrazorblade.easydblab.commands.k8.K8
 import com.rustyrazorblade.easydblab.commands.logs.Logs
 import com.rustyrazorblade.easydblab.commands.opensearch.OpenSearch
 import com.rustyrazorblade.easydblab.commands.spark.Spark
+import com.rustyrazorblade.easydblab.commands.tailscale.Tailscale
 import com.rustyrazorblade.easydblab.configuration.UserConfigProvider
 import com.rustyrazorblade.easydblab.di.KoinCommandFactory
 import com.rustyrazorblade.easydblab.output.OutputHandler
@@ -85,6 +86,7 @@ import kotlin.system.exitProcess
         OpenSearch::class,
         Aws::class,
         Logs::class,
+        Tailscale::class,
     ],
 )
 class EasyDBLabCommand : Runnable {
@@ -149,7 +151,7 @@ class CommandLineParser : KoinComponent {
         val exitCode = commandLine.execute(*input)
 
         // Show profile setup hint if no command was provided and profile not configured
-        if (input.isEmpty() || (input.size == 1 && (input[0] == "--help" || input[0] == "-h"))) {
+        if (isHelpRequested(input)) {
             val userConfigProvider: UserConfigProvider by inject()
             if (!userConfigProvider.isSetup()) {
                 with(TermColors()) {
@@ -170,4 +172,9 @@ class CommandLineParser : KoinComponent {
             exitProcess(exitCode)
         }
     }
+
+    /**
+     * Determines if the input represents a help request (no command or explicit help flag).
+     */
+    private fun isHelpRequested(input: Array<String>): Boolean = input.isEmpty() || input.singleOrNull() in listOf("--help", "-h")
 }

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/Constants.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/Constants.kt
@@ -217,6 +217,17 @@ object Constants {
         const val DEFAULT_SOCKS5_PORT = 1080
     }
 
+    // Tailscale VPN configuration
+    object Tailscale {
+        const val OAUTH_TOKEN_ENDPOINT = "https://api.tailscale.com/api/v2/oauth/token"
+        const val AUTH_KEYS_ENDPOINT = "https://api.tailscale.com/api/v2/tailnet/-/keys"
+        const val CONNECTION_TIMEOUT_SECONDS = 30L
+        const val READ_TIMEOUT_SECONDS = 30L
+        const val AUTH_KEY_EXPIRY_SECONDS = 300
+        const val DAEMON_STARTUP_DELAY_MS = 2000L
+        const val DEFAULT_DEVICE_TAG = "tag:easy-db-lab"
+    }
+
     // Container Registry configuration
     object Registry {
         /** Default registry port */

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/Context.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/Context.kt
@@ -51,10 +51,11 @@ data class Context(
     var profileDir = File(profilesDir, profile)
 
     init {
+        if (profile.isEmpty()) {
+            profile = "default"
+        }
         profileDir.mkdirs()
     }
-
-    val home = File(System.getProperty("user.home"))
 
     /**
      * Version is either supplied by the in-repo script,

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Init.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Init.kt
@@ -14,6 +14,7 @@ import com.rustyrazorblade.easydblab.configuration.Arch
 import com.rustyrazorblade.easydblab.configuration.ClusterState
 import com.rustyrazorblade.easydblab.configuration.InitConfig
 import com.rustyrazorblade.easydblab.configuration.User
+import com.rustyrazorblade.easydblab.network.CidrBlock
 import com.rustyrazorblade.easydblab.services.CommandExecutor
 import io.github.classgraph.ClassGraph
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -192,6 +193,12 @@ class Init : PicoBaseCommand() {
     )
     var existingVpcId: String? = null
 
+    @Option(
+        names = ["--cidr"],
+        description = ["VPC CIDR block (default: 10.0.0.0/16). Must be /20 or larger."],
+    )
+    var cidr: String = Constants.Vpc.DEFAULT_CIDR
+
     override fun execute() {
         validateParameters()
 
@@ -234,6 +241,8 @@ class Init : PicoBaseCommand() {
         require(ebsSize > 0) { "EBS size must be positive" }
         require(ebsIops >= 0) { "EBS IOPS cannot be negative" }
         require(ebsThroughput >= 0) { "EBS throughput cannot be negative" }
+        // Validate CIDR block format and prefix length
+        CidrBlock(cidr)
     }
 
     private fun checkExistingFiles() {

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/stress/StressStart.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/stress/StressStart.kt
@@ -133,6 +133,11 @@ class StressStart : PicoBaseCommand() {
     }
 
     /**
+     * Known stress subcommands that don't require "run" prefix.
+     */
+    private fun isStressSubcommand(arg: String): Boolean = arg in listOf("run", "list", "info", "fields")
+
+    /**
      * Builds the command arguments for cassandra-easy-stress.
      * Uses passthrough args from user, adding defaults for host, dc, and profile if needed.
      */
@@ -146,7 +151,7 @@ class StressStart : PicoBaseCommand() {
         if (stressArgs.isNotEmpty()) {
             // Check if this looks like a "run" command (starts with workload name or has run keyword)
             val firstArg = stressArgs.first()
-            if (firstArg != "run" && firstArg != "list" && firstArg != "info" && firstArg != "fields") {
+            if (!isStressSubcommand(firstArg)) {
                 // Assume it's a workload name, prepend "run"
                 args.add("run")
             }

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/tailscale/Tailscale.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/tailscale/Tailscale.kt
@@ -1,0 +1,54 @@
+package com.rustyrazorblade.easydblab.commands.tailscale
+
+import picocli.CommandLine.Command
+import picocli.CommandLine.Model.CommandSpec
+import picocli.CommandLine.Spec
+
+/**
+ * Parent command for Tailscale VPN operations.
+ *
+ * Tailscale provides secure mesh VPN access to the cluster control node,
+ * which can then be used as a jump host to access all other nodes.
+ *
+ * Available sub-commands:
+ * - start: Start Tailscale and authenticate on the control node
+ * - stop: Disconnect and stop Tailscale on the control node
+ * - status: Show Tailscale connection status
+ *
+ * Prerequisites:
+ * - Tailscale OAuth credentials configured via setup-profile or CLI args
+ * - A running cluster with a control node
+ *
+ * Usage:
+ * ```
+ * # Start Tailscale (uses credentials from setup-profile)
+ * easy-db-lab tailscale start
+ *
+ * # Start with explicit credentials
+ * easy-db-lab tailscale start --client-id tskey-client-xxx --client-secret tskey-xxx
+ *
+ * # Check status
+ * easy-db-lab tailscale status
+ *
+ * # Stop Tailscale
+ * easy-db-lab tailscale stop
+ * ```
+ */
+@Command(
+    name = "tailscale",
+    description = ["Tailscale VPN operations for secure cluster access"],
+    mixinStandardHelpOptions = true,
+    subcommands = [
+        TailscaleStart::class,
+        TailscaleStop::class,
+        TailscaleStatus::class,
+    ],
+)
+class Tailscale : Runnable {
+    @Spec
+    lateinit var spec: CommandSpec
+
+    override fun run() {
+        spec.commandLine().usage(System.out)
+    }
+}

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/tailscale/TailscaleStart.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/tailscale/TailscaleStart.kt
@@ -1,0 +1,213 @@
+package com.rustyrazorblade.easydblab.commands.tailscale
+
+import com.github.ajalt.mordant.TermColors
+import com.rustyrazorblade.easydblab.Constants
+import com.rustyrazorblade.easydblab.annotations.McpCommand
+import com.rustyrazorblade.easydblab.annotations.RequireProfileSetup
+import com.rustyrazorblade.easydblab.commands.PicoBaseCommand
+import com.rustyrazorblade.easydblab.configuration.ClusterHost
+import com.rustyrazorblade.easydblab.configuration.Host
+import com.rustyrazorblade.easydblab.configuration.User
+import com.rustyrazorblade.easydblab.configuration.toHost
+import com.rustyrazorblade.easydblab.services.TailscaleApiException
+import com.rustyrazorblade.easydblab.services.TailscaleService
+import org.koin.core.component.inject
+import picocli.CommandLine.Command
+import picocli.CommandLine.Option
+
+/**
+ * Start Tailscale VPN on the control node and authenticate.
+ *
+ * This command:
+ * 1. Generates an ephemeral auth key using OAuth credentials
+ * 2. Starts the Tailscale daemon on the control node
+ * 3. Authenticates with the auth key and advertises VPC CIDR as a subnet route
+ *
+ * After running this command, you can access the control node via its Tailscale IP,
+ * and through the advertised route, access all other nodes in the VPC.
+ *
+ * OAuth credentials can be provided via:
+ * - CLI arguments (--client-id, --client-secret)
+ * - User configuration (setup-profile)
+ */
+@McpCommand
+@RequireProfileSetup
+@Command(
+    name = "start",
+    description = ["Start Tailscale VPN on the control node"],
+)
+class TailscaleStart : PicoBaseCommand() {
+    private val tailscaleService: TailscaleService by inject()
+    private val user: User by inject()
+
+    @Option(
+        names = ["--client-id"],
+        description = ["Tailscale OAuth client ID (overrides config)"],
+    )
+    var clientId: String? = null
+
+    @Option(
+        names = ["--client-secret"],
+        description = ["Tailscale OAuth client secret (overrides config)"],
+    )
+    var clientSecret: String? = null
+
+    @Option(
+        names = ["--tag"],
+        description = ["Tailscale device tag (default: tag:easy-db-lab)"],
+    )
+    var tag: String? = null
+
+    override fun execute() {
+        val credentials = resolveCredentials() ?: return
+        val controlHost = getControlHostOrReturn() ?: return
+        val host = controlHost.toHost()
+
+        if (checkAlreadyConnected(host, controlHost.alias)) return
+
+        startTailscaleConnection(credentials, host, controlHost)
+    }
+
+    private fun resolveCredentials(): TailscaleCredentials? {
+        val resolvedClientId = clientId ?: user.tailscaleClientId
+        val resolvedClientSecret = clientSecret ?: user.tailscaleClientSecret
+        val resolvedTag = tag ?: user.tailscaleTag.ifEmpty { Constants.Tailscale.DEFAULT_DEVICE_TAG }
+
+        if (resolvedClientId.isBlank() || resolvedClientSecret.isBlank()) {
+            showMissingCredentialsError()
+            return null
+        }
+
+        return TailscaleCredentials(resolvedClientId, resolvedClientSecret, resolvedTag)
+    }
+
+    private fun showMissingCredentialsError() {
+        with(TermColors()) {
+            outputHandler.handleMessage(
+                red(
+                    """
+                    Tailscale OAuth credentials not configured.
+
+                    Please provide credentials via:
+                    1. CLI arguments: --client-id and --client-secret
+                    2. Setup profile: easy-db-lab setup-profile
+
+                    To get OAuth credentials:
+                    1. Go to https://login.tailscale.com/admin/settings/oauth
+                    2. Generate an OAuth client with "Devices: write" scope
+                    3. Copy the client ID and secret
+                    """.trimIndent(),
+                ),
+            )
+        }
+    }
+
+    private fun getControlHostOrReturn(): ClusterHost? {
+        val controlHost = clusterState.getControlHost()
+        if (controlHost == null) {
+            with(TermColors()) {
+                outputHandler.handleMessage(
+                    red("No control node found. Ensure your cluster is running with 'easy-db-lab up'."),
+                )
+            }
+        }
+        return controlHost
+    }
+
+    private fun checkAlreadyConnected(
+        host: Host,
+        alias: String,
+    ): Boolean {
+        val isConnected = tailscaleService.isConnected(host).getOrElse { false }
+        if (isConnected) {
+            with(TermColors()) {
+                outputHandler.handleMessage(yellow("Tailscale is already connected on $alias."))
+            }
+            tailscaleService.getStatus(host).onSuccess { status ->
+                outputHandler.handleMessage(status)
+            }
+        }
+        return isConnected
+    }
+
+    private fun startTailscaleConnection(
+        credentials: TailscaleCredentials,
+        host: Host,
+        controlHost: ClusterHost,
+    ) {
+        val cidr = clusterState.initConfig?.cidr ?: Constants.Vpc.DEFAULT_CIDR
+
+        try {
+            outputHandler.handleMessage("Generating Tailscale auth key...")
+            val authKey =
+                tailscaleService.generateAuthKey(
+                    credentials.clientId,
+                    credentials.clientSecret,
+                    credentials.tag,
+                )
+
+            tailscaleService.startTailscale(host, authKey, controlHost.alias, cidr).getOrThrow()
+            showSuccessMessage(controlHost.alias, cidr)
+            showCurrentStatus(host)
+        } catch (e: TailscaleApiException) {
+            with(TermColors()) {
+                outputHandler.handleMessage(red("Failed to start Tailscale: ${e.message}"))
+                if (e.message?.contains("tags") == true) {
+                    outputHandler.handleMessage(
+                        yellow(
+                            """
+
+                            The tag '${credentials.tag}' must be configured in your Tailscale ACL.
+
+                            To fix this:
+                            1. Go to https://login.tailscale.com/admin/acls
+                            2. Add this to your ACL policy:
+                               "tagOwners": {
+                                 "${credentials.tag}": ["autogroup:admin"]
+                               }
+                            3. Ensure your OAuth client has permission to use this tag
+
+                            Or use a different tag: --tag tag:your-existing-tag
+                            """.trimIndent(),
+                        ),
+                    )
+                }
+            }
+        }
+    }
+
+    private fun showSuccessMessage(
+        alias: String,
+        cidr: String,
+    ) {
+        with(TermColors()) {
+            outputHandler.handleMessage(green("\nTailscale started successfully!"))
+            outputHandler.handleMessage(
+                """
+
+                The control node ($alias) is now accessible via Tailscale.
+                Subnet route advertised: $cidr
+
+                NOTE: You may need to approve the subnet route in the Tailscale admin console:
+                https://login.tailscale.com/admin/machines
+
+                Once approved, you can access all cluster nodes through the control node's
+                Tailscale connection using their private IPs.
+                """.trimIndent(),
+            )
+        }
+    }
+
+    private fun showCurrentStatus(host: Host) {
+        tailscaleService.getStatus(host).onSuccess { status ->
+            outputHandler.handleMessage("\nCurrent status:")
+            outputHandler.handleMessage(status)
+        }
+    }
+
+    private data class TailscaleCredentials(
+        val clientId: String,
+        val clientSecret: String,
+        val tag: String,
+    )
+}

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/tailscale/TailscaleStatus.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/tailscale/TailscaleStatus.kt
@@ -1,0 +1,69 @@
+package com.rustyrazorblade.easydblab.commands.tailscale
+
+import com.github.ajalt.mordant.TermColors
+import com.rustyrazorblade.easydblab.annotations.McpCommand
+import com.rustyrazorblade.easydblab.annotations.RequireProfileSetup
+import com.rustyrazorblade.easydblab.commands.PicoBaseCommand
+import com.rustyrazorblade.easydblab.configuration.toHost
+import com.rustyrazorblade.easydblab.services.TailscaleService
+import org.koin.core.component.inject
+import picocli.CommandLine.Command
+
+/**
+ * Show Tailscale connection status on the control node.
+ *
+ * Displays the current Tailscale connection state, including:
+ * - Connection status (connected/disconnected)
+ * - Tailscale IP address
+ * - Connected peers
+ * - Advertised routes
+ */
+@McpCommand
+@RequireProfileSetup
+@Command(
+    name = "status",
+    description = ["Show Tailscale connection status"],
+)
+class TailscaleStatus : PicoBaseCommand() {
+    private val tailscaleService: TailscaleService by inject()
+
+    override fun execute() {
+        // Get control host
+        val controlHost = clusterState.getControlHost()
+        if (controlHost == null) {
+            with(TermColors()) {
+                outputHandler.handleMessage(
+                    red("No control node found. Ensure your cluster is running with 'easy-db-lab up'."),
+                )
+            }
+            return
+        }
+
+        // Convert ClusterHost to Host for service calls
+        val host = controlHost.toHost()
+
+        // Check if Tailscale is connected
+        val isConnected =
+            tailscaleService.isConnected(host).getOrElse { false }
+
+        if (!isConnected) {
+            outputHandler.handleMessage("Tailscale is not running on ${controlHost.alias}.")
+            outputHandler.handleMessage("Run 'easy-db-lab tailscale start' to connect.")
+            return
+        }
+
+        // Get and display status
+        tailscaleService
+            .getStatus(host)
+            .onSuccess { status ->
+                outputHandler.handleMessage("Tailscale status on ${controlHost.alias}:")
+                outputHandler.handleMessage(status)
+            }.onFailure { error ->
+                with(TermColors()) {
+                    outputHandler.handleMessage(
+                        red("Failed to get Tailscale status: ${error.message}"),
+                    )
+                }
+            }
+    }
+}

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/tailscale/TailscaleStop.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/tailscale/TailscaleStop.kt
@@ -1,0 +1,65 @@
+package com.rustyrazorblade.easydblab.commands.tailscale
+
+import com.github.ajalt.mordant.TermColors
+import com.rustyrazorblade.easydblab.annotations.McpCommand
+import com.rustyrazorblade.easydblab.annotations.RequireProfileSetup
+import com.rustyrazorblade.easydblab.commands.PicoBaseCommand
+import com.rustyrazorblade.easydblab.configuration.toHost
+import com.rustyrazorblade.easydblab.services.TailscaleService
+import org.koin.core.component.inject
+import picocli.CommandLine.Command
+
+/**
+ * Stop Tailscale VPN on the control node.
+ *
+ * This command disconnects from the Tailscale network and stops the daemon.
+ * The node will no longer be accessible via Tailscale until `tailscale start` is run again.
+ */
+@McpCommand
+@RequireProfileSetup
+@Command(
+    name = "stop",
+    description = ["Stop Tailscale VPN on the control node"],
+)
+class TailscaleStop : PicoBaseCommand() {
+    private val tailscaleService: TailscaleService by inject()
+
+    override fun execute() {
+        // Get control host
+        val controlHost = clusterState.getControlHost()
+        if (controlHost == null) {
+            with(TermColors()) {
+                outputHandler.handleMessage(
+                    red("No control node found. Ensure your cluster is running with 'easy-db-lab up'."),
+                )
+            }
+            return
+        }
+
+        // Convert ClusterHost to Host for service calls
+        val host = controlHost.toHost()
+
+        // Check if Tailscale is running
+        val isConnected =
+            tailscaleService.isConnected(host).getOrElse { false }
+        if (!isConnected) {
+            outputHandler.handleMessage("Tailscale is not running on ${controlHost.alias}.")
+            return
+        }
+
+        // Stop Tailscale
+        tailscaleService
+            .stopTailscale(host)
+            .onSuccess {
+                with(TermColors()) {
+                    outputHandler.handleMessage(green("Tailscale stopped successfully."))
+                }
+            }.onFailure { error ->
+                with(TermColors()) {
+                    outputHandler.handleMessage(
+                        red("Failed to stop Tailscale: ${error.message}"),
+                    )
+                }
+            }
+    }
+}

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/ClusterConfigWriter.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/ClusterConfigWriter.kt
@@ -43,13 +43,11 @@ object ClusterConfigWriter {
      *
      * @param writer BufferedWriter to write environment file to
      * @param hosts Map of server types to their hosts
-     * @param identityFile Path to the SSH identity file (for embedded SSH config generation)
      * @param clusterName Name of the cluster for prompt customization
      */
     fun writeEnvironmentFile(
         writer: BufferedWriter,
         hosts: Map<ServerType, List<ClusterHost>>,
-        identityFile: String,
         clusterName: String,
     ) {
         // write the initial SSH aliases

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/ClusterS3Path.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/ClusterS3Path.kt
@@ -36,7 +36,6 @@ data class ClusterS3Path(
         private const val BACKUPS_DIR = "backups"
         private const val LOGS_DIR = "logs"
         private const val DATA_DIR = "data"
-        private const val K3S_DIR = "k3s"
         private const val KUBECONFIG_FILE = "kubeconfig"
         private const val K8S_DIR = "k8s"
         private const val CONFIG_DIR = "config"

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/ClusterState.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/ClusterState.kt
@@ -1,5 +1,6 @@
 package com.rustyrazorblade.easydblab.configuration
 
+import com.rustyrazorblade.easydblab.Constants
 import com.rustyrazorblade.easydblab.commands.Init
 import java.time.Instant
 import java.util.UUID
@@ -99,6 +100,7 @@ data class InitConfig(
     val opensearchInstanceCount: Int = 1,
     val opensearchVersion: String = "2.11",
     val opensearchEbsSize: Int = 100,
+    val cidr: String = Constants.Vpc.DEFAULT_CIDR,
 ) {
     companion object {
         /**
@@ -141,6 +143,7 @@ data class InitConfig(
                 opensearchInstanceCount = init.opensearch.instanceCount,
                 opensearchVersion = init.opensearch.version,
                 opensearchEbsSize = init.opensearch.ebsSize,
+                cidr = init.cidr,
             )
     }
 }

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/User.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/User.kt
@@ -38,6 +38,10 @@ data class User(
     var awsSecret: String,
     var axonOpsOrg: String = "",
     var axonOpsKey: String = "",
+    // Tailscale OAuth credentials for VPN access
+    var tailscaleClientId: String = "",
+    var tailscaleClientSecret: String = "",
+    var tailscaleTag: String = Constants.Tailscale.DEFAULT_DEVICE_TAG,
     // Profile-level S3 bucket for shared resources (AMIs, base images, etc.)
     var s3Bucket: String = "",
 ) {

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/driver/SocksProxyNettyOptions.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/driver/SocksProxyNettyOptions.kt
@@ -26,6 +26,7 @@ class SocksProxyNettyOptions(
 ) : DefaultNettyOptions(context) {
     companion object {
         private val log = KotlinLogging.logger {}
+        private const val SOCKS5_CONNECT_TIMEOUT_MS = 30_000L
     }
 
     init {
@@ -77,7 +78,7 @@ class SocksProxyNettyOptions(
                     // This must be added AFTER the original pipeline is set up, so it
                     // intercepts connections before any other handlers process them
                     val proxyHandler = Socks5ProxyHandler(InetSocketAddress(proxyHost, proxyPort))
-                    proxyHandler.setConnectTimeoutMillis(30000L)
+                    proxyHandler.setConnectTimeoutMillis(SOCKS5_CONNECT_TIMEOUT_MS)
                     pipeline.addFirst("socks5-proxy", proxyHandler)
 
                     log.info { "Added SOCKS5 proxy handler to channel pipeline" }

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/network/CidrBlock.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/network/CidrBlock.kt
@@ -1,0 +1,112 @@
+package com.rustyrazorblade.easydblab.network
+
+import com.rustyrazorblade.easydblab.Constants
+
+/**
+ * A value class representing a CIDR block for VPC networking.
+ *
+ * Provides validation and subnet calculation for VPC CIDR blocks.
+ * The CIDR block must be /20 or larger to support /24 subnets for availability zones.
+ *
+ * Example usage:
+ * ```
+ * val cidr = CidrBlock("172.16.0.0/16")
+ * val subnet0 = cidr.subnetCidr(0)  // "172.16.1.0/24"
+ * val subnet1 = cidr.subnetCidr(1)  // "172.16.2.0/24"
+ * ```
+ */
+@JvmInline
+value class CidrBlock(
+    val value: String,
+) {
+    init {
+        require(isValidCidr(value)) { "Invalid CIDR: $value" }
+        require(prefixLength <= MAX_PREFIX_LENGTH) {
+            "CIDR prefix must be /$MAX_PREFIX_LENGTH or larger to support /24 subnets, got /$prefixLength"
+        }
+    }
+
+    /**
+     * The prefix length (e.g., 16 for /16, 20 for /20).
+     */
+    val prefixLength: Int
+        get() = value.substringAfter("/").toInt()
+
+    /**
+     * The network address without the prefix (e.g., "10.0.0.0" from "10.0.0.0/16").
+     */
+    val networkAddress: String
+        get() = value.substringBefore("/")
+
+    /**
+     * Generates a /24 subnet CIDR for the given index within this VPC CIDR.
+     *
+     * The subnet is created by taking the first two octets of the VPC CIDR
+     * and using (index + 1) as the third octet.
+     *
+     * @param index Zero-based index (0 → .1.0/24, 1 → .2.0/24, etc.)
+     * @return Subnet CIDR string (e.g., "10.0.1.0/24")
+     */
+    fun subnetCidr(index: Int): String {
+        require(index >= 0) { "Subnet index must be non-negative" }
+        require(index < MAX_SUBNET_INDEX) { "Subnet index must be less than $MAX_SUBNET_INDEX" }
+
+        val octets = networkAddress.split(".").map { it.toInt() }
+        return "${octets[0]}.${octets[1]}.${index + 1}.0/$SUBNET_PREFIX_LENGTH"
+    }
+
+    override fun toString(): String = value
+
+    companion object {
+        /** Default CIDR block for VPCs */
+        val DEFAULT = CidrBlock(Constants.Vpc.DEFAULT_CIDR)
+
+        /** Maximum prefix length that can support /24 subnets */
+        private const val MAX_PREFIX_LENGTH = 20
+
+        /** Prefix length for subnets */
+        private const val SUBNET_PREFIX_LENGTH = 24
+
+        /** Maximum subnet index (third octet can be 1-254) */
+        private const val MAX_SUBNET_INDEX = 254
+
+        /** Valid range for octets */
+        private const val MIN_OCTET = 0
+        private const val MAX_OCTET = 255
+
+        /** Valid range for prefix length */
+        private const val MIN_PREFIX = 0
+        private const val MAX_PREFIX = 32
+
+        /** Number of octets in an IPv4 address */
+        private const val IPV4_OCTET_COUNT = 4
+
+        /**
+         * Validates whether a string is a valid IPv4 CIDR block.
+         *
+         * @param cidr The CIDR string to validate
+         * @return true if valid, false otherwise
+         */
+        fun isValidCidr(cidr: String): Boolean {
+            if (!cidr.contains("/")) return false
+
+            val parts = cidr.split("/")
+            if (parts.size != 2) return false
+
+            val (address, prefixStr) = parts
+
+            // Validate prefix
+            val prefix = prefixStr.toIntOrNull() ?: return false
+            if (prefix < MIN_PREFIX || prefix > MAX_PREFIX) return false
+
+            // Validate IP address
+            val octets = address.split(".")
+            if (octets.size != IPV4_OCTET_COUNT) return false
+
+            return octets.all { octet ->
+                val value = octet.toIntOrNull() ?: return false
+                value in MIN_OCTET..MAX_OCTET
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/providers/aws/EC2InstanceService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/providers/aws/EC2InstanceService.kt
@@ -70,7 +70,7 @@ class EC2InstanceService(
             val subnetId = config.subnetIds[instanceIndex % config.subnetIds.size]
             val alias = "${config.serverType.serverType}$instanceIndex"
 
-            val instance = createSingleInstance(config, subnetId, alias, instanceIndex)
+            val instance = createSingleInstance(config, subnetId, alias)
             instances.add(instance)
 
             log.info { "Created instance ${instance.instanceId} ($alias) in subnet $subnetId" }
@@ -90,7 +90,6 @@ class EC2InstanceService(
         config: InstanceCreationConfig,
         subnetId: SubnetId,
         alias: String,
-        index: Int,
     ): CreatedInstance {
         val tagSpec = buildTagSpecification(config, alias)
         val blockDeviceMappings = buildBlockDeviceMappings(config.ebsConfig)

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/AWSResourceSetupService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/AWSResourceSetupService.kt
@@ -272,7 +272,7 @@ class AWSResourceSetupService(
         // Try to get account ID, fallback to placeholder if that fails
         val accountId =
             try {
-                aws.getAccountId() ?: throw IllegalStateException("Account ID is null")
+                aws.getAccountId() ?: error("Account ID is null")
             } catch (e: Exception) {
                 outputHandler.handleMessage(
                     """

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/ClusterConfigurationService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/ClusterConfigurationService.kt
@@ -129,7 +129,6 @@ class DefaultClusterConfigurationService(
             ClusterConfigWriter.writeEnvironmentFile(
                 writer,
                 clusterState.hosts,
-                sshKeyPath,
                 clusterState.name,
             )
         }

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/EC2RegistryService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/EC2RegistryService.kt
@@ -108,7 +108,7 @@ class EC2RegistryService(
         val resourcePath = "/com/rustyrazorblade/easydblab/commands/$scriptName"
         val scriptContent =
             this::class.java.getResourceAsStream(resourcePath)
-                ?: throw IllegalStateException("Script not found: $resourcePath")
+                ?: error("Script not found: $resourcePath")
 
         val tempFile = Files.createTempFile("registry-", "-$scriptName")
         try {

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/K3sService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/K3sService.kt
@@ -212,10 +212,8 @@ class DefaultK3sService(
         kubeconfigPath: Path,
     ): Result<List<KubernetesJob>> =
         runCatching {
-            // Start the SOCKS proxy to the control node
             socksProxyService.ensureRunning(controlHost)
 
-            // Create Kubernetes service with the proxy
             val clientFactory =
                 ProxiedKubernetesClientFactory(
                     proxyHost = "localhost",
@@ -232,10 +230,8 @@ class DefaultK3sService(
         kubeconfigPath: Path,
     ): Result<List<KubernetesPod>> =
         runCatching {
-            // Start the SOCKS proxy to the control node
             socksProxyService.ensureRunning(controlHost)
 
-            // Create Kubernetes service with the proxy
             val clientFactory =
                 ProxiedKubernetesClientFactory(
                     proxyHost = "localhost",

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/ServicesModule.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/ServicesModule.kt
@@ -33,6 +33,7 @@ val servicesModule =
 
         factoryOf(::DefaultCassandraService) bind CassandraService::class
         factoryOf(::DefaultClickHouseConfigService) bind ClickHouseConfigService::class
+        factoryOf(::DefaultTailscaleService) bind TailscaleService::class
 
         // CQL session factory and service - singleton for session caching in REPL/Server mode
         singleOf(::DefaultCqlSessionFactory) bind CqlSessionFactory::class

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/TailscaleService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/TailscaleService.kt
@@ -1,0 +1,307 @@
+package com.rustyrazorblade.easydblab.services
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.rustyrazorblade.easydblab.Constants
+import com.rustyrazorblade.easydblab.configuration.Host
+import com.rustyrazorblade.easydblab.output.OutputHandler
+import com.rustyrazorblade.easydblab.providers.ssh.RemoteOperationsService
+import io.github.oshai.kotlinlogging.KotlinLogging
+import okhttp3.FormBody
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.Response
+import java.util.concurrent.TimeUnit
+
+private val log = KotlinLogging.logger {}
+
+/**
+ * Exception thrown when Tailscale API operations fail.
+ */
+class TailscaleApiException(
+    message: String,
+    cause: Throwable? = null,
+) : RuntimeException(message, cause)
+
+/**
+ * Service for managing Tailscale VPN connections on cluster nodes.
+ *
+ * Tailscale provides secure mesh VPN access to the cluster. This service handles:
+ * - OAuth authentication with Tailscale API to generate ephemeral auth keys
+ * - Starting/stopping the Tailscale daemon on control nodes
+ * - Advertising VPC CIDR as a subnet route for full cluster access
+ *
+ * The OAuth flow works as follows:
+ * 1. Exchange client credentials for an access token
+ * 2. Use the access token to generate an ephemeral auth key
+ * 3. Use the auth key to authenticate the Tailscale daemon
+ */
+interface TailscaleService {
+    /**
+     * Generates an ephemeral Tailscale auth key using OAuth credentials.
+     *
+     * @param clientId Tailscale OAuth client ID
+     * @param clientSecret Tailscale OAuth client secret
+     * @param tag Device tag to apply (e.g., "tag:easy-db-lab"). Required for OAuth-based auth keys.
+     * @return Ephemeral auth key for use with `tailscale up --authkey`
+     * @throws TailscaleApiException if the API request fails
+     */
+    fun generateAuthKey(
+        clientId: String,
+        clientSecret: String,
+        tag: String,
+    ): String
+
+    /**
+     * Starts Tailscale on the specified host and authenticates with the provided auth key.
+     *
+     * This method:
+     * 1. Starts the tailscaled daemon
+     * 2. Runs `tailscale up` with the auth key and subnet routes
+     *
+     * @param host The host to start Tailscale on
+     * @param authKey The ephemeral auth key from generateAuthKey()
+     * @param hostname The hostname to register with Tailscale (typically host.alias)
+     * @param cidr The VPC CIDR to advertise as a subnet route
+     * @return Result indicating success or failure
+     */
+    fun startTailscale(
+        host: Host,
+        authKey: String,
+        hostname: String,
+        cidr: String,
+    ): Result<Unit>
+
+    /**
+     * Stops Tailscale on the specified host.
+     *
+     * This method runs `tailscale down` and stops the daemon.
+     *
+     * @param host The host to stop Tailscale on
+     * @return Result indicating success or failure
+     */
+    fun stopTailscale(host: Host): Result<Unit>
+
+    /**
+     * Gets the Tailscale connection status on the specified host.
+     *
+     * @param host The host to check
+     * @return Result containing the status output or failure details
+     */
+    fun getStatus(host: Host): Result<String>
+
+    /**
+     * Checks if Tailscale is currently connected on the specified host.
+     *
+     * @param host The host to check
+     * @return Result containing true if connected, false otherwise
+     */
+    fun isConnected(host: Host): Result<Boolean>
+}
+
+/**
+ * Default implementation of TailscaleService using OkHttp for API calls
+ * and RemoteOperationsService for SSH commands.
+ */
+class DefaultTailscaleService(
+    private val remoteOps: RemoteOperationsService,
+    private val outputHandler: OutputHandler,
+) : TailscaleService {
+    private val httpClient: OkHttpClient =
+        OkHttpClient
+            .Builder()
+            .connectTimeout(Constants.Tailscale.CONNECTION_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            .readTimeout(Constants.Tailscale.READ_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            .build()
+
+    private val objectMapper: ObjectMapper = jacksonObjectMapper()
+
+    override fun generateAuthKey(
+        clientId: String,
+        clientSecret: String,
+        tag: String,
+    ): String {
+        log.info { "Generating Tailscale auth key with tag: $tag" }
+
+        // Step 1: Exchange client credentials for access token
+        val accessToken = getAccessToken(clientId, clientSecret)
+
+        // Step 2: Generate ephemeral auth key
+        return createAuthKey(accessToken, tag)
+    }
+
+    /**
+     * Exchanges OAuth client credentials for an access token.
+     */
+    private fun getAccessToken(
+        clientId: String,
+        clientSecret: String,
+    ): String {
+        val requestBody =
+            FormBody
+                .Builder()
+                .add("grant_type", "client_credentials")
+                .add("client_id", clientId)
+                .add("client_secret", clientSecret)
+                .build()
+
+        val request =
+            Request
+                .Builder()
+                .url(Constants.Tailscale.OAUTH_TOKEN_ENDPOINT)
+                .post(requestBody)
+                .build()
+
+        return httpClient.newCall(request).execute().use { response ->
+            val body = parseSuccessfulResponse(response, "get OAuth access token")
+            val tokenResponse: Map<String, Any> = objectMapper.readValue(body)
+            tokenResponse["access_token"] as? String
+                ?: throw TailscaleApiException("No access_token in response")
+        }
+    }
+
+    /**
+     * Creates an ephemeral auth key using the access token.
+     */
+    private fun createAuthKey(
+        accessToken: String,
+        tag: String,
+    ): String {
+        val keyRequest =
+            mapOf(
+                "capabilities" to
+                    mapOf(
+                        "devices" to
+                            mapOf(
+                                "create" to
+                                    mapOf(
+                                        "reusable" to false,
+                                        "ephemeral" to true,
+                                        "preauthorized" to true,
+                                        "tags" to listOf(tag),
+                                    ),
+                            ),
+                    ),
+                "expirySeconds" to Constants.Tailscale.AUTH_KEY_EXPIRY_SECONDS,
+            )
+
+        val requestBody =
+            objectMapper
+                .writeValueAsString(keyRequest)
+                .toRequestBody("application/json".toMediaType())
+
+        val request =
+            Request
+                .Builder()
+                .url(Constants.Tailscale.AUTH_KEYS_ENDPOINT)
+                .header("Authorization", "Bearer $accessToken")
+                .post(requestBody)
+                .build()
+
+        return httpClient.newCall(request).execute().use { response ->
+            val body = parseSuccessfulResponse(response, "create auth key")
+            val keyResponse: Map<String, Any> = objectMapper.readValue(body)
+            keyResponse["key"] as? String
+                ?: throw TailscaleApiException("No key in response")
+        }
+    }
+
+    /**
+     * Parses and validates an HTTP response, returning the body on success.
+     * @throws TailscaleApiException if the response indicates failure or has no body
+     */
+    private fun parseSuccessfulResponse(
+        response: Response,
+        operation: String,
+    ): String {
+        if (!response.isSuccessful) {
+            val errorBody = response.body?.string() ?: "No error details"
+            throw TailscaleApiException("Failed to $operation: ${response.code} - $errorBody")
+        }
+        return response.body?.string()
+            ?: throw TailscaleApiException("Empty response body from $operation")
+    }
+
+    override fun startTailscale(
+        host: Host,
+        authKey: String,
+        hostname: String,
+        cidr: String,
+    ): Result<Unit> =
+        runCatching {
+            outputHandler.handleMessage("Starting Tailscale daemon on ${host.alias}...")
+
+            // Start the daemon
+            remoteOps.executeRemotely(
+                host,
+                "sudo systemctl start tailscaled",
+            )
+
+            // Give the daemon a moment to initialize
+            Thread.sleep(Constants.Tailscale.DAEMON_STARTUP_DELAY_MS)
+
+            outputHandler.handleMessage("Authenticating Tailscale on ${host.alias}...")
+
+            // Authenticate and advertise routes
+            // Note: secret=true to prevent auth key from being logged
+            remoteOps.executeRemotely(
+                host,
+                "sudo tailscale up --authkey=$authKey --hostname=$hostname --advertise-routes=$cidr --accept-routes",
+                secret = true,
+            )
+
+            log.info { "Tailscale started successfully on ${host.alias}" }
+            outputHandler.handleMessage("Tailscale connected on ${host.alias}")
+        }
+
+    override fun stopTailscale(host: Host): Result<Unit> =
+        runCatching {
+            outputHandler.handleMessage("Stopping Tailscale on ${host.alias}...")
+
+            // Disconnect from Tailscale network
+            remoteOps.executeRemotely(
+                host,
+                "sudo tailscale down",
+            )
+
+            // Stop the daemon
+            remoteOps.executeRemotely(
+                host,
+                "sudo systemctl stop tailscaled",
+            )
+
+            log.info { "Tailscale stopped on ${host.alias}" }
+            outputHandler.handleMessage("Tailscale stopped on ${host.alias}")
+        }
+
+    override fun getStatus(host: Host): Result<String> =
+        runCatching {
+            val response =
+                remoteOps.executeRemotely(
+                    host,
+                    "sudo tailscale status",
+                )
+            response.text
+        }
+
+    override fun isConnected(host: Host): Result<Boolean> =
+        runCatching {
+            val response =
+                remoteOps.executeRemotely(
+                    host,
+                    "sudo tailscale status --json",
+                    output = false,
+                )
+
+            if (response.text.isBlank()) {
+                return@runCatching false
+            }
+
+            val status: Map<String, Any> = objectMapper.readValue(response.text)
+            val backendState = status["BackendState"] as? String
+            backendState == "Running"
+        }
+}

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/di/OutputModuleTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/di/OutputModuleTest.kt
@@ -4,10 +4,8 @@ import com.rustyrazorblade.easydblab.output.CompositeOutputHandler
 import com.rustyrazorblade.easydblab.output.ConsoleOutputHandler
 import com.rustyrazorblade.easydblab.output.LoggerOutputHandler
 import com.rustyrazorblade.easydblab.output.OutputHandler
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertSame
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.koin.core.context.startKoin
@@ -32,14 +30,14 @@ class OutputModuleTest : KoinTest {
     fun `default OutputHandler should be CompositeOutputHandler with Logger and Console handlers`() {
         val handler: OutputHandler by inject()
 
-        assertTrue(handler is CompositeOutputHandler, "Default OutputHandler should be CompositeOutputHandler")
+        assertThat(handler).isInstanceOf(CompositeOutputHandler::class.java)
 
         val composite = handler as CompositeOutputHandler
-        assertEquals(2, composite.getHandlerCount(), "CompositeOutputHandler should contain exactly 2 handlers")
+        assertThat(composite.getHandlerCount()).isEqualTo(2)
 
         val handlers = composite.getHandlers()
-        assertTrue(handlers.any { it is LoggerOutputHandler }, "Should contain LoggerOutputHandler")
-        assertTrue(handlers.any { it is ConsoleOutputHandler }, "Should contain ConsoleOutputHandler")
+        assertThat(handlers).anyMatch { it is LoggerOutputHandler }
+        assertThat(handlers).anyMatch { it is ConsoleOutputHandler }
     }
 
     @Test
@@ -50,7 +48,7 @@ class OutputModuleTest : KoinTest {
                     .named("console"),
         )
 
-        assertTrue(consoleHandler is ConsoleOutputHandler, "Named 'console' handler should be ConsoleOutputHandler")
+        assertThat(consoleHandler).isInstanceOf(ConsoleOutputHandler::class.java)
     }
 
     @Test
@@ -61,7 +59,7 @@ class OutputModuleTest : KoinTest {
                     .named("logger"),
         )
 
-        assertTrue(loggerHandler is LoggerOutputHandler, "Named 'logger' handler should be LoggerOutputHandler")
+        assertThat(loggerHandler).isInstanceOf(LoggerOutputHandler::class.java)
     }
 
     @Test
@@ -69,6 +67,6 @@ class OutputModuleTest : KoinTest {
         val handler1: OutputHandler by inject()
         val handler2: OutputHandler by inject()
 
-        assertSame(handler1, handler2, "Default OutputHandler should be singleton")
+        assertThat(handler1).isSameAs(handler2)
     }
 }

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/network/CidrBlockTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/network/CidrBlockTest.kt
@@ -1,0 +1,71 @@
+package com.rustyrazorblade.easydblab.network
+
+import com.rustyrazorblade.easydblab.Constants
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+class CidrBlockTest {
+    @Test
+    fun `accepts valid CIDR blocks with prefix 20 or smaller`() {
+        listOf("10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "10.10.0.0/20").forEach { cidrStr ->
+            val cidr = CidrBlock(cidrStr)
+            assertThat(cidr.value).isEqualTo(cidrStr)
+        }
+    }
+
+    @Test
+    fun `rejects CIDR with prefix larger than 20`() {
+        listOf("10.0.0.0/21", "10.0.0.0/24", "10.0.0.0/28").forEach { cidrStr ->
+            assertThatThrownBy { CidrBlock(cidrStr) }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("CIDR prefix must be /20 or larger")
+        }
+    }
+
+    @Test
+    fun `rejects invalid CIDR formats`() {
+        listOf(
+            "invalid",
+            "10.0.0.0",
+            "10.0.0/16",
+            "10.0.0.0.0/16",
+            "10.0.0.256/16",
+            "",
+            "10.0.0.0/-1",
+            "10.0.0.0/33",
+        ).forEach { cidrStr ->
+            assertThatThrownBy { CidrBlock(cidrStr) }
+                .isInstanceOf(IllegalArgumentException::class.java)
+        }
+    }
+
+    @Test
+    fun `prefixLength and networkAddress return correct values`() {
+        val cidr = CidrBlock("172.31.0.0/16")
+        assertThat(cidr.prefixLength).isEqualTo(16)
+        assertThat(cidr.networkAddress).isEqualTo("172.31.0.0")
+        assertThat(cidr.toString()).isEqualTo("172.31.0.0/16")
+    }
+
+    @Test
+    fun `subnetCidr generates correct subnets for different VPC CIDRs`() {
+        assertThat(CidrBlock("10.0.0.0/16").subnetCidr(0)).isEqualTo("10.0.1.0/24")
+        assertThat(CidrBlock("10.0.0.0/16").subnetCidr(1)).isEqualTo("10.0.2.0/24")
+        assertThat(CidrBlock("172.16.0.0/16").subnetCidr(0)).isEqualTo("172.16.1.0/24")
+        assertThat(CidrBlock("192.168.0.0/16").subnetCidr(253)).isEqualTo("192.168.254.0/24")
+    }
+
+    @Test
+    fun `subnetCidr rejects invalid indices`() {
+        val cidr = CidrBlock("10.0.0.0/16")
+        assertThatThrownBy { cidr.subnetCidr(-1) }.isInstanceOf(IllegalArgumentException::class.java)
+        assertThatThrownBy { cidr.subnetCidr(254) }.isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun `DEFAULT matches Constants and produces expected subnets`() {
+        assertThat(CidrBlock.DEFAULT.value).isEqualTo(Constants.Vpc.DEFAULT_CIDR)
+        assertThat(CidrBlock.DEFAULT.subnetCidr(0)).isEqualTo("10.0.1.0/24")
+    }
+}

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/services/K8sServiceTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/services/K8sServiceTest.kt
@@ -4,7 +4,6 @@ import com.rustyrazorblade.easydblab.BaseKoinTest
 import com.rustyrazorblade.easydblab.configuration.ClusterHost
 import com.rustyrazorblade.easydblab.observability.TelemetryProvider
 import com.rustyrazorblade.easydblab.proxy.SocksProxyService
-import com.rustyrazorblade.easydblab.proxy.SocksProxyState
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -14,7 +13,6 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import java.time.Instant
 
 /**
  * Test suite for K8sService following TDD principles.
@@ -35,13 +33,6 @@ class K8sServiceTest : BaseKoinTest() {
             alias = "control0",
             availabilityZone = "us-west-2a",
             instanceId = "i-test123",
-        )
-
-    private val testProxyState =
-        SocksProxyState(
-            localPort = 1080,
-            gatewayHost = testClusterHost,
-            startTime = Instant.now(),
         )
 
     override fun additionalTestModules(): List<Module> =
@@ -68,24 +59,23 @@ class K8sServiceTest : BaseKoinTest() {
         k8sService = getKoin().get()
     }
 
-    // ========== PROXY CONNECTION TESTS ==========
+    // ========== SOCKS PROXY TESTS ==========
 
     @Test
-    fun `applyManifests should ensure SOCKS proxy is running`() {
+    fun `applyManifests should always use SOCKS proxy`() {
         // Given
         val manifestDir = createTestManifestDir()
-        whenever(mockSocksProxyService.ensureRunning(any())).thenReturn(testProxyState)
         whenever(mockSocksProxyService.getLocalPort()).thenReturn(1080)
 
-        // When - This will fail because there's no real kubeconfig, but we can verify proxy was started
+        // When - This will fail because there's no real kubeconfig, but we can verify SOCKS proxy was started
         val result = k8sService.applyManifests(testClusterHost, manifestDir)
 
-        // Then - Verify proxy service was called
+        // Then - Verify SOCKS proxy service was called
         verify(mockSocksProxyService).ensureRunning(testClusterHost)
     }
 
     @Test
-    fun `applyManifests should return failure when proxy fails to start`() {
+    fun `applyManifests should return failure when SOCKS proxy fails`() {
         // Given
         val manifestDir = createTestManifestDir()
         whenever(mockSocksProxyService.ensureRunning(any()))
@@ -101,20 +91,19 @@ class K8sServiceTest : BaseKoinTest() {
     }
 
     @Test
-    fun `getObservabilityStatus should ensure SOCKS proxy is running`() {
+    fun `getObservabilityStatus should always use SOCKS proxy`() {
         // Given
-        whenever(mockSocksProxyService.ensureRunning(any())).thenReturn(testProxyState)
         whenever(mockSocksProxyService.getLocalPort()).thenReturn(1080)
 
         // When - This will fail because there's no real kubeconfig
         val result = k8sService.getObservabilityStatus(testClusterHost)
 
-        // Then - Verify proxy service was called
+        // Then - Verify SOCKS proxy service was called
         verify(mockSocksProxyService).ensureRunning(testClusterHost)
     }
 
     @Test
-    fun `getObservabilityStatus should return failure when proxy fails`() {
+    fun `getObservabilityStatus should return failure when SOCKS proxy fails`() {
         // Given
         whenever(mockSocksProxyService.ensureRunning(any()))
             .thenThrow(RuntimeException("Connection refused"))
@@ -129,20 +118,19 @@ class K8sServiceTest : BaseKoinTest() {
     }
 
     @Test
-    fun `deleteObservability should ensure SOCKS proxy is running`() {
+    fun `deleteObservability should always use SOCKS proxy`() {
         // Given
-        whenever(mockSocksProxyService.ensureRunning(any())).thenReturn(testProxyState)
         whenever(mockSocksProxyService.getLocalPort()).thenReturn(1080)
 
         // When
         val result = k8sService.deleteObservability(testClusterHost)
 
-        // Then - Verify proxy service was called
+        // Then - Verify SOCKS proxy service was called
         verify(mockSocksProxyService).ensureRunning(testClusterHost)
     }
 
     @Test
-    fun `deleteObservability should return failure when proxy fails`() {
+    fun `deleteObservability should return failure when SOCKS proxy fails`() {
         // Given
         whenever(mockSocksProxyService.ensureRunning(any()))
             .thenThrow(RuntimeException("Permission denied"))
@@ -157,20 +145,19 @@ class K8sServiceTest : BaseKoinTest() {
     }
 
     @Test
-    fun `waitForPodsReady should ensure SOCKS proxy is running`() {
+    fun `waitForPodsReady should always use SOCKS proxy`() {
         // Given
-        whenever(mockSocksProxyService.ensureRunning(any())).thenReturn(testProxyState)
         whenever(mockSocksProxyService.getLocalPort()).thenReturn(1080)
 
         // When
         val result = k8sService.waitForPodsReady(testClusterHost, 60)
 
-        // Then - Verify proxy service was called
+        // Then - Verify SOCKS proxy service was called
         verify(mockSocksProxyService).ensureRunning(testClusterHost)
     }
 
     @Test
-    fun `waitForPodsReady should return failure when proxy fails`() {
+    fun `waitForPodsReady should return failure when SOCKS proxy fails`() {
         // Given
         whenever(mockSocksProxyService.ensureRunning(any()))
             .thenThrow(RuntimeException("Network unreachable"))

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/services/TailscaleServiceTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/services/TailscaleServiceTest.kt
@@ -1,0 +1,338 @@
+package com.rustyrazorblade.easydblab.services
+
+import com.rustyrazorblade.easydblab.BaseKoinTest
+import com.rustyrazorblade.easydblab.configuration.Host
+import com.rustyrazorblade.easydblab.providers.ssh.RemoteOperationsService
+import com.rustyrazorblade.easydblab.ssh.Response
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.koin.core.module.Module
+import org.koin.dsl.module
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argThat
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+/**
+ * Test suite for TailscaleService.
+ *
+ * These tests verify Tailscale VPN operations including starting/stopping
+ * the daemon and checking connection status.
+ *
+ * Note: OAuth API tests require mocking HTTP calls, so this test suite
+ * focuses on SSH-based operations that can be easily mocked.
+ */
+class TailscaleServiceTest : BaseKoinTest() {
+    private lateinit var mockRemoteOps: RemoteOperationsService
+    private lateinit var tailscaleService: TailscaleService
+
+    private val testHost =
+        Host(
+            public = "54.123.45.67",
+            private = "10.0.1.5",
+            alias = "control0",
+            availabilityZone = "us-west-2a",
+        )
+
+    override fun additionalTestModules(): List<Module> =
+        listOf(
+            module {
+                single<RemoteOperationsService> { mockRemoteOps }
+                factory<TailscaleService> { DefaultTailscaleService(get(), get()) }
+            },
+        )
+
+    @BeforeEach
+    fun setupMocks() {
+        mockRemoteOps = mock()
+        tailscaleService = getKoin().get()
+    }
+
+    // ========== START TAILSCALE TESTS ==========
+
+    @Test
+    fun `startTailscale should start daemon and authenticate`() {
+        // Given
+        val authKey = "tskey-auth-xxx"
+        val hostname = "control0"
+        val cidr = "10.0.0.0/16"
+        val successResponse = Response(text = "", stderr = "")
+
+        whenever(mockRemoteOps.executeRemotely(eq(testHost), eq("sudo systemctl start tailscaled"), any(), any()))
+            .thenReturn(successResponse)
+        whenever(
+            mockRemoteOps.executeRemotely(
+                eq(testHost),
+                argThat { contains("tailscale up") && contains("--authkey=") },
+                any(),
+                any(),
+            ),
+        ).thenReturn(successResponse)
+
+        // When
+        val result = tailscaleService.startTailscale(testHost, authKey, hostname, cidr)
+
+        // Then
+        assertThat(result.isSuccess).isTrue()
+        verify(mockRemoteOps).executeRemotely(eq(testHost), eq("sudo systemctl start tailscaled"), any(), any())
+        verify(mockRemoteOps).executeRemotely(
+            eq(testHost),
+            argThat {
+                contains("tailscale up") &&
+                    contains("--authkey=$authKey") &&
+                    contains("--hostname=$hostname") &&
+                    contains("--advertise-routes=$cidr")
+            },
+            any(),
+            eq(true), // secret=true
+        )
+    }
+
+    @Test
+    fun `startTailscale should return failure when daemon start fails`() {
+        // Given
+        val authKey = "tskey-auth-xxx"
+        val hostname = "control0"
+        val cidr = "10.0.0.0/16"
+
+        whenever(mockRemoteOps.executeRemotely(eq(testHost), eq("sudo systemctl start tailscaled"), any(), any()))
+            .thenThrow(RuntimeException("Failed to start tailscaled"))
+
+        // When
+        val result = tailscaleService.startTailscale(testHost, authKey, hostname, cidr)
+
+        // Then
+        assertThat(result.isFailure).isTrue()
+        assertThat(result.exceptionOrNull())
+            .hasMessageContaining("Failed to start tailscaled")
+    }
+
+    @Test
+    fun `startTailscale should return failure when authentication fails`() {
+        // Given
+        val authKey = "tskey-auth-xxx"
+        val hostname = "control0"
+        val cidr = "10.0.0.0/16"
+        val successResponse = Response(text = "", stderr = "")
+
+        whenever(mockRemoteOps.executeRemotely(eq(testHost), eq("sudo systemctl start tailscaled"), any(), any()))
+            .thenReturn(successResponse)
+        whenever(
+            mockRemoteOps.executeRemotely(
+                eq(testHost),
+                argThat { contains("tailscale up") },
+                any(),
+                any(),
+            ),
+        ).thenThrow(RuntimeException("Authentication failed"))
+
+        // When
+        val result = tailscaleService.startTailscale(testHost, authKey, hostname, cidr)
+
+        // Then
+        assertThat(result.isFailure).isTrue()
+        assertThat(result.exceptionOrNull())
+            .hasMessageContaining("Authentication failed")
+    }
+
+    // ========== STOP TAILSCALE TESTS ==========
+
+    @Test
+    fun `stopTailscale should disconnect and stop daemon`() {
+        // Given
+        val successResponse = Response(text = "", stderr = "")
+
+        whenever(mockRemoteOps.executeRemotely(eq(testHost), eq("sudo tailscale down"), any(), any()))
+            .thenReturn(successResponse)
+        whenever(mockRemoteOps.executeRemotely(eq(testHost), eq("sudo systemctl stop tailscaled"), any(), any()))
+            .thenReturn(successResponse)
+
+        // When
+        val result = tailscaleService.stopTailscale(testHost)
+
+        // Then
+        assertThat(result.isSuccess).isTrue()
+        verify(mockRemoteOps).executeRemotely(eq(testHost), eq("sudo tailscale down"), any(), any())
+        verify(mockRemoteOps).executeRemotely(eq(testHost), eq("sudo systemctl stop tailscaled"), any(), any())
+    }
+
+    @Test
+    fun `stopTailscale should return failure when disconnect fails`() {
+        // Given
+        whenever(mockRemoteOps.executeRemotely(eq(testHost), eq("sudo tailscale down"), any(), any()))
+            .thenThrow(RuntimeException("Failed to disconnect"))
+
+        // When
+        val result = tailscaleService.stopTailscale(testHost)
+
+        // Then
+        assertThat(result.isFailure).isTrue()
+        assertThat(result.exceptionOrNull())
+            .hasMessageContaining("Failed to disconnect")
+    }
+
+    // ========== STATUS TESTS ==========
+
+    @Test
+    fun `getStatus should return status output`() {
+        // Given
+        val statusOutput =
+            """
+            # My devices
+            100.64.0.1      control0         -
+            """.trimIndent()
+        val statusResponse = Response(text = statusOutput, stderr = "")
+
+        whenever(mockRemoteOps.executeRemotely(eq(testHost), eq("sudo tailscale status"), any(), any()))
+            .thenReturn(statusResponse)
+
+        // When
+        val result = tailscaleService.getStatus(testHost)
+
+        // Then
+        assertThat(result.isSuccess).isTrue()
+        assertThat(result.getOrNull()).isEqualTo(statusOutput)
+    }
+
+    @Test
+    fun `getStatus should return failure when command fails`() {
+        // Given
+        whenever(mockRemoteOps.executeRemotely(eq(testHost), eq("sudo tailscale status"), any(), any()))
+            .thenThrow(RuntimeException("Tailscale not running"))
+
+        // When
+        val result = tailscaleService.getStatus(testHost)
+
+        // Then
+        assertThat(result.isFailure).isTrue()
+        assertThat(result.exceptionOrNull())
+            .hasMessageContaining("Tailscale not running")
+    }
+
+    // ========== CONNECTION CHECK TESTS ==========
+
+    @Test
+    fun `isConnected should return true when backend state is Running`() {
+        // Given
+        val jsonResponse =
+            """
+            {"BackendState":"Running","Self":{"ID":"12345"}}
+            """.trimIndent()
+        val statusResponse = Response(text = jsonResponse, stderr = "")
+
+        whenever(mockRemoteOps.executeRemotely(eq(testHost), eq("sudo tailscale status --json"), eq(false), any()))
+            .thenReturn(statusResponse)
+
+        // When
+        val result = tailscaleService.isConnected(testHost)
+
+        // Then
+        assertThat(result.isSuccess).isTrue()
+        assertThat(result.getOrNull()).isTrue()
+    }
+
+    @Test
+    fun `isConnected should return false when backend state is not Running`() {
+        // Given
+        val jsonResponse =
+            """
+            {"BackendState":"Stopped","Self":null}
+            """.trimIndent()
+        val statusResponse = Response(text = jsonResponse, stderr = "")
+
+        whenever(mockRemoteOps.executeRemotely(eq(testHost), eq("sudo tailscale status --json"), eq(false), any()))
+            .thenReturn(statusResponse)
+
+        // When
+        val result = tailscaleService.isConnected(testHost)
+
+        // Then
+        assertThat(result.isSuccess).isTrue()
+        assertThat(result.getOrNull()).isFalse()
+    }
+
+    @Test
+    fun `isConnected should return false when response is blank`() {
+        // Given
+        val statusResponse = Response(text = "", stderr = "")
+
+        whenever(mockRemoteOps.executeRemotely(eq(testHost), eq("sudo tailscale status --json"), eq(false), any()))
+            .thenReturn(statusResponse)
+
+        // When
+        val result = tailscaleService.isConnected(testHost)
+
+        // Then
+        assertThat(result.isSuccess).isTrue()
+        assertThat(result.getOrNull()).isFalse()
+    }
+
+    @Test
+    fun `isConnected should return failure when command fails`() {
+        // Given
+        whenever(mockRemoteOps.executeRemotely(eq(testHost), eq("sudo tailscale status --json"), eq(false), any()))
+            .thenThrow(RuntimeException("SSH connection lost"))
+
+        // When
+        val result = tailscaleService.isConnected(testHost)
+
+        // Then
+        assertThat(result.isFailure).isTrue()
+        assertThat(result.exceptionOrNull())
+            .hasMessageContaining("SSH connection lost")
+    }
+
+    // ========== AUTH KEY MARK AS SECRET TESTS ==========
+
+    @Test
+    fun `startTailscale should mark authkey command as secret`() {
+        // Given
+        val authKey = "tskey-auth-secret-key"
+        val hostname = "control0"
+        val cidr = "10.0.0.0/16"
+        val successResponse = Response(text = "", stderr = "")
+
+        whenever(mockRemoteOps.executeRemotely(any(), any(), any(), any()))
+            .thenReturn(successResponse)
+
+        // When
+        tailscaleService.startTailscale(testHost, authKey, hostname, cidr)
+
+        // Then - verify the tailscale up command is marked as secret
+        verify(mockRemoteOps).executeRemotely(
+            eq(testHost),
+            argThat { contains("tailscale up") && contains("--authkey=") },
+            any(),
+            eq(true), // secret parameter should be true
+        )
+    }
+
+    @Test
+    fun `stopTailscale should not mark commands as secret`() {
+        // Given
+        val successResponse = Response(text = "", stderr = "")
+
+        whenever(mockRemoteOps.executeRemotely(any(), any(), any(), any()))
+            .thenReturn(successResponse)
+
+        // When
+        tailscaleService.stopTailscale(testHost)
+
+        // Then - verify commands are not marked as secret (default is false)
+        verify(mockRemoteOps).executeRemotely(
+            eq(testHost),
+            eq("sudo tailscale down"),
+            any(),
+            eq(false),
+        )
+        verify(mockRemoteOps).executeRemotely(
+            eq(testHost),
+            eq("sudo systemctl stop tailscaled"),
+            any(),
+            eq(false),
+        )
+    }
+}


### PR DESCRIPTION
  ## Summary
  - Add `--cidr` flag to `init` command for specifying custom VPC CIDR blocks (default: 10.0.0.0/16)
  - Skip SOCKS5 proxy in env.sh when Tailscale VPN is connected, using direct network access to VPC resources
  - Add TailscaleService for managing Tailscale lifecycle on cluster nodes
  - End-to-end test now uses dedicated CIDR (10.14.0.0/20) 

  ## Changes

  ### Custom CIDR Support
  - New `--cidr` option on `init` command allows specifying VPC CIDR block - allows for multiple clusters in conjunction with tailscale
  - Automatic subnet calculation within the specified CIDR range
  - Validation ensures CIDR is valid and subnets fit within the block

  ### Tailscale-Aware Network Access
  - Shell environment (`env.sh`) conditionally starts SOCKS proxy based on Tailscale status

  ### New Services
  - `TailscaleService` - start/stop/status operations for Tailscale on cluster nodes
  - `NetworkAccessService` - determines optimal network access mode (Tailscale vs SOCKS proxy)