### PR TITLE
Use AutoConfiguredOpenTelemetrySdk for OTEL resource attributes

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -203,7 +203,7 @@ sshd = ["sshd-core", "sshd-scp"]
 resilience4j = ["resilience4j-retry", "resilience4j-kotlin"]
 
 # OpenTelemetry bundle
-opentelemetry = ["opentelemetry-api", "opentelemetry-sdk", "opentelemetry-exporter-otlp", "opentelemetry-aws-sdk", "opentelemetry-okhttp", "opentelemetry-instrumentation-logback"]
+opentelemetry = ["opentelemetry-api", "opentelemetry-sdk", "opentelemetry-sdk-extension-autoconfigure", "opentelemetry-exporter-otlp", "opentelemetry-aws-sdk", "opentelemetry-okhttp", "opentelemetry-instrumentation-logback"]
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/observability/OtelResourceBuilder.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/observability/OtelResourceBuilder.kt
@@ -1,0 +1,56 @@
+package com.rustyrazorblade.easydblab.observability
+
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.common.Attributes
+import io.opentelemetry.sdk.resources.Resource
+
+/**
+ * Builds OpenTelemetry resource with proper attribute precedence.
+ *
+ * Resource attributes are merged with the following precedence (highest to lowest):
+ * 1. Environment variables (OTEL_RESOURCE_ATTRIBUTES, OTEL_SERVICE_NAME)
+ * 2. Default application attributes (service.name, service.version, host.name)
+ *
+ * This allows external tools to override default attributes by setting environment
+ * variables, which is essential for multi-tenant or dynamic deployment scenarios.
+ */
+object OtelResourceBuilder {
+    /**
+     * Builds a resource by merging environment-provided attributes with defaults.
+     *
+     * Environment attributes take precedence over defaults, allowing customization
+     * via OTEL_RESOURCE_ATTRIBUTES without code changes.
+     *
+     * @param envResource Resource containing attributes from environment variables
+     *                    (provided by AutoConfiguredOpenTelemetrySdk)
+     * @return Merged resource with env vars overriding defaults
+     */
+    fun buildResource(envResource: Resource): Resource {
+        val defaults =
+            Resource.create(
+                Attributes.of(
+                    AttributeKey.stringKey("service.name"),
+                    TelemetryNames.SERVICE_NAME,
+                    AttributeKey.stringKey("service.version"),
+                    getVersion(),
+                    AttributeKey.stringKey("host.name"),
+                    getHostName(),
+                ),
+            )
+
+        // Merge order: defaults first, then env vars
+        // This ensures env vars override defaults when keys conflict
+        return defaults.merge(envResource)
+    }
+
+    private fun getVersion(): String = System.getProperty("easydblab.version", "unknown")
+
+    private fun getHostName(): String =
+        try {
+            java.net.InetAddress
+                .getLocalHost()
+                .hostName
+        } catch (e: Exception) {
+            "unknown"
+        }
+}

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/observability/TelemetryFactory.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/observability/TelemetryFactory.kt
@@ -41,7 +41,7 @@ object TelemetryFactory {
         } else {
             log.info { "OpenTelemetry enabled: exporting to $endpoint" }
             try {
-                OtelTelemetryProvider(endpoint)
+                OtelTelemetryProvider()
             } catch (e: Exception) {
                 log.error(e) { "Failed to initialize OpenTelemetry, falling back to no-op" }
                 NoOpTelemetryProvider()

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/observability/OtelResourceBuilderTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/observability/OtelResourceBuilderTest.kt
@@ -1,0 +1,127 @@
+package com.rustyrazorblade.easydblab.observability
+
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.common.Attributes
+import io.opentelemetry.sdk.resources.Resource
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests for OtelResourceBuilder to verify resource attribute merging behavior.
+ *
+ * Key behavior: Environment variable attributes should take precedence over
+ * hardcoded defaults. This allows external tools to customize telemetry
+ * attributes via OTEL_RESOURCE_ATTRIBUTES.
+ */
+class OtelResourceBuilderTest {
+    @Test
+    fun `buildResource should include default service name when no env override`() {
+        val envResource = Resource.empty()
+
+        val result = OtelResourceBuilder.buildResource(envResource)
+
+        assertThat(result.getAttribute(AttributeKey.stringKey("service.name")))
+            .isEqualTo(TelemetryNames.SERVICE_NAME)
+    }
+
+    @Test
+    fun `buildResource should include default service version`() {
+        val envResource = Resource.empty()
+
+        val result = OtelResourceBuilder.buildResource(envResource)
+
+        assertThat(result.getAttribute(AttributeKey.stringKey("service.version")))
+            .isNotNull()
+    }
+
+    @Test
+    fun `buildResource should include default host name`() {
+        val envResource = Resource.empty()
+
+        val result = OtelResourceBuilder.buildResource(envResource)
+
+        assertThat(result.getAttribute(AttributeKey.stringKey("host.name")))
+            .isNotNull()
+    }
+
+    @Test
+    fun `buildResource should allow env vars to override service name`() {
+        val customServiceName = "custom-service-from-env"
+        val envResource =
+            Resource.create(
+                Attributes.of(
+                    AttributeKey.stringKey("service.name"),
+                    customServiceName,
+                ),
+            )
+
+        val result = OtelResourceBuilder.buildResource(envResource)
+
+        assertThat(result.getAttribute(AttributeKey.stringKey("service.name")))
+            .isEqualTo(customServiceName)
+    }
+
+    @Test
+    fun `buildResource should allow env vars to override host name`() {
+        val customHostName = "custom-host-from-env"
+        val envResource =
+            Resource.create(
+                Attributes.of(
+                    AttributeKey.stringKey("host.name"),
+                    customHostName,
+                ),
+            )
+
+        val result = OtelResourceBuilder.buildResource(envResource)
+
+        assertThat(result.getAttribute(AttributeKey.stringKey("host.name")))
+            .isEqualTo(customHostName)
+    }
+
+    @Test
+    fun `buildResource should preserve custom env attributes alongside defaults`() {
+        val envResource =
+            Resource.create(
+                Attributes.of(
+                    AttributeKey.stringKey("custom.attribute"),
+                    "custom-value",
+                    AttributeKey.stringKey("cluster.id"),
+                    "my-cluster-123",
+                ),
+            )
+
+        val result = OtelResourceBuilder.buildResource(envResource)
+
+        // Custom attributes from env should be present
+        assertThat(result.getAttribute(AttributeKey.stringKey("custom.attribute")))
+            .isEqualTo("custom-value")
+        assertThat(result.getAttribute(AttributeKey.stringKey("cluster.id")))
+            .isEqualTo("my-cluster-123")
+
+        // Default attributes should also be present
+        assertThat(result.getAttribute(AttributeKey.stringKey("service.name")))
+            .isEqualTo(TelemetryNames.SERVICE_NAME)
+    }
+
+    @Test
+    fun `buildResource should allow partial override of defaults`() {
+        // Override only service.name, leave host.name as default
+        val envResource =
+            Resource.create(
+                Attributes.of(
+                    AttributeKey.stringKey("service.name"),
+                    "overridden-service",
+                ),
+            )
+
+        val result = OtelResourceBuilder.buildResource(envResource)
+
+        // service.name should be overridden
+        assertThat(result.getAttribute(AttributeKey.stringKey("service.name")))
+            .isEqualTo("overridden-service")
+
+        // host.name should still be the default (non-null)
+        assertThat(result.getAttribute(AttributeKey.stringKey("host.name")))
+            .isNotNull()
+    }
+}


### PR DESCRIPTION
Replace manual SDK building with AutoConfiguredOpenTelemetrySdk which automatically reads standard OTEL environment variables including OTEL_RESOURCE_ATTRIBUTES. This allows external tools to pass custom resource attributes that appear in telemetry data.

Changes:
- Add opentelemetry-sdk-extension-autoconfigure dependency
- Extract OtelResourceBuilder for testable resource building logic
- Env vars now properly override default attributes (fixed merge order)
- Add comprehensive tests for resource attribute precedence
- Add logging of effective OTEL configuration for debugging