### PR TITLE
Add VictoriaMetrics and VictoriaLogs backup functionality

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -24,15 +24,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     nano \
     vim \
     curl \
+    wget \
     zip \
     python3 \
     python3-pip \
     python3-venv \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
-
-# Install MkDocs and Cinder theme for documentation
-COPY docs/requirements.txt /tmp/docs-requirements.txt
-RUN pip3 install --break-system-packages -r /tmp/docs-requirements.txt
 
 # Ensure default node user has access to /usr/local/share
 RUN mkdir -p /usr/local/share/npm-global && \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,7 +16,7 @@
   "appPort": [8000],
   "runArgs": ["--cap-add=NET_ADMIN", "--cap-add=NET_RAW"],
   "customizations": {},
-    "remoteUser": "node",
+  "remoteUser": "node",
   "mounts": [
     "source=claude-code-bashhistory-${devcontainerId},target=/commandhistory,type=volume",
     "source=${localWorkspaceFolder}/.devcontainer/claude,target=/home/node/.claude,type=bind"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,6 +199,10 @@ For more details, see [packer/README.md](packer/README.md) and [packer/TESTING.m
 - Always use @TempDir for temporary directories in tests - JUnit handles lifecycle automatically
 - **Never disable functionality as a solution.** If something isn't working, fix the root cause. Adding flags to skip features, making things optional, or suggesting users disable components is not an acceptable solution.
 - **Configuration problems require configuration fixes.** If a service can't connect to a dependency, the fix is to provide the correct endpoint/credentials, not to make the dependency optional.
+- Include testing when planning.  Integration tests use TestContainers.
+- When planning, iterate with me.  Ask questions.  Don't automatically add features I didn't ask for.  Ask if I want them first.
+- Include updates to the documentation as part of planning.
+- CRITICAL: Tests must pass, in CI, on my local, and in the devcontainer.  It is UNACCEPTABLE to say that tests are only failing in devcontainers and to ignore them.
 
 ### Retry Logic with Resilience4j
 

--- a/bin/end-to-end-test
+++ b/bin/end-to-end-test
@@ -845,6 +845,60 @@ step_test_logs_query() {
     echo "=== Logs query test completed ==="
 }
 
+step_test_metrics_backup() {
+    echo "=== Testing VictoriaMetrics backup ==="
+
+    # Run metrics backup command
+    easy-db-lab metrics backup
+
+    # Extract S3 bucket from state.json
+    local s3_bucket=$(jq -r '.s3Bucket' state.json)
+    if [ -z "$s3_bucket" ] || [ "$s3_bucket" = "null" ]; then
+        echo "ERROR: S3 bucket not found in state.json"
+        return 1
+    fi
+
+    # Verify backup was created in S3
+    echo "=== Checking VictoriaMetrics backup in S3 ==="
+    local backup_count=$(aws s3 ls "s3://${s3_bucket}/victoriametrics/" 2>/dev/null | wc -l)
+    if [ "$backup_count" -gt 0 ]; then
+        echo "  victoriametrics backup: OK ($backup_count entries)"
+        aws s3 ls "s3://${s3_bucket}/victoriametrics/" | head -5
+    else
+        echo "ERROR: VictoriaMetrics backup not found in S3"
+        return 1
+    fi
+
+    echo "=== VictoriaMetrics backup test completed ==="
+}
+
+step_test_logs_backup() {
+    echo "=== Testing VictoriaLogs backup ==="
+
+    # Run logs backup command
+    easy-db-lab logs backup
+
+    # Extract S3 bucket from state.json
+    local s3_bucket=$(jq -r '.s3Bucket' state.json)
+    if [ -z "$s3_bucket" ] || [ "$s3_bucket" = "null" ]; then
+        echo "ERROR: S3 bucket not found in state.json"
+        return 1
+    fi
+
+    # Verify backup was created in S3
+    echo "=== Checking VictoriaLogs backup in S3 ==="
+    local backup_count=$(aws s3 ls "s3://${s3_bucket}/victorialogs/" 2>/dev/null | wc -l)
+    if [ "$backup_count" -gt 0 ]; then
+        echo "  victorialogs backup: OK ($backup_count entries)"
+        aws s3 ls "s3://${s3_bucket}/victorialogs/" | head -5
+    else
+        echo "ERROR: VictoriaLogs backup not found in S3"
+        return 1
+    fi
+
+    echo "=== VictoriaLogs backup test completed ==="
+}
+
 step_teardown() {
     echo "=== Tearing down cluster ==="
     easy-db-lab down --yes
@@ -894,6 +948,8 @@ STEPS_WORKDIR=(
     "step_opensearch_stop:Stop OpenSearch"
     "step_test_observability:Test observability stack"
     "step_test_logs_query:Test logs query command"
+    "step_test_metrics_backup:Test VictoriaMetrics backup"
+    "step_test_logs_backup:Test VictoriaLogs backup"
     "step_teardown:Teardown cluster"
 )
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -16,6 +16,7 @@
 - [Kubernetes](user-guide/kubernetes.md)
 - [Network Connectivity](user-guide/network-connectivity.md)
 - [Victoria Logs](user-guide/victoria-logs.md)
+- [Victoria Metrics](user-guide/victoria-metrics.md)
 - [Spark](user-guide/spark.md)
 - [ClickHouse](user-guide/clickhouse.md)
 - [Shell Aliases](user-guide/shell-aliases.md)

--- a/docs/user-guide/victoria-logs.md
+++ b/docs/user-guide/victoria-logs.md
@@ -253,3 +253,33 @@ The `logs query` command uses the internal SOCKS5 proxy to connect to Victoria L
 1. Ensure the cluster is running: `easy-db-lab status`
 2. The proxy is started automatically when needed
 3. Check that control node is accessible: `ssh control0 hostname`
+
+## Backup
+
+Victoria Logs data can be backed up to S3 for disaster recovery.
+
+### Creating a Backup
+
+```bash
+# Backup to cluster's default S3 bucket
+easy-db-lab logs backup
+
+# Backup to a custom S3 location
+easy-db-lab logs backup --dest s3://my-backup-bucket/victorialogs
+```
+
+By default, backups are stored at:
+`s3://{cluster-bucket}/victorialogs/{timestamp}/`
+
+Use `--dest` to override the destination bucket and path.
+
+### What Gets Backed Up
+
+- All log partitions (organized by date)
+- Complete log history up to retention period (7 days default)
+
+### Notes
+
+- Backups are created by syncing the data directory to S3
+- The process is non-disruptive; log ingestion continues during backup
+- Persistent storage at `/mnt/db1/victorialogs` ensures logs survive pod restarts

--- a/docs/user-guide/victoria-metrics.md
+++ b/docs/user-guide/victoria-metrics.md
@@ -1,0 +1,163 @@
+# Victoria Metrics
+
+Victoria Metrics is a time-series database that stores metrics from all nodes in your easy-db-lab cluster. It receives metrics via OTLP from the OpenTelemetry Collector.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                     All Nodes (DaemonSet)                    │
+├─────────────────────────────────────────────────────────────┤
+│   System metrics (CPU, memory, disk, network)               │
+│   Cassandra metrics (via JMX)                               │
+│   Application metrics                                        │
+└──────────────────────────┬──────────────────────────────────┘
+                           │
+                           ▼
+              ┌────────────────────────┐
+              │   OTel Collector       │
+              │   (DaemonSet)          │
+              └───────────┬────────────┘
+                          │
+┌─────────────────────────┼─────────────────────────┐
+│   Control Node          │                          │
+├─────────────────────────┼─────────────────────────┤
+│                         ▼                          │
+│              ┌──────────────────┐                  │
+│              │ Victoria Metrics │                  │
+│              │    (:8428)       │                  │
+│              └────────┬─────────┘                  │
+└───────────────────────┼────────────────────────────┘
+                        │
+                        ▼
+              ┌──────────────────┐
+              │     Grafana      │
+              │    (:3000)       │
+              └──────────────────┘
+```
+
+## Configuration
+
+Victoria Metrics runs on the control node as a Kubernetes deployment:
+
+- **Port**: 8428 (HTTP API)
+- **Storage**: Persistent at `/mnt/db1/victoriametrics`
+- **Retention**: 7 days (configurable via `-retentionPeriod` flag)
+
+## Accessing Metrics
+
+### Grafana
+
+1. Access Grafana at `http://control0:3000` (via SOCKS proxy)
+2. Victoria Metrics is pre-configured as the Prometheus datasource
+3. System dashboards show node metrics
+
+### Direct API
+
+Query metrics directly using the Prometheus-compatible API:
+
+```bash
+source env.sh
+
+# Get all metric names
+with-proxy curl "http://control0:8428/api/v1/label/__name__/values"
+
+# Query specific metric
+with-proxy curl "http://control0:8428/api/v1/query?query=up"
+
+# Query with time range
+with-proxy curl "http://control0:8428/api/v1/query_range?query=node_cpu_seconds_total&start=$(date -d '1 hour ago' +%s)&end=$(date +%s)&step=60"
+```
+
+### Common Queries
+
+```promql
+# CPU usage by node
+100 - (avg by(instance) (rate(node_cpu_seconds_total{mode="idle"}[5m])) * 100)
+
+# Memory usage percentage
+100 * (1 - node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)
+
+# Disk usage
+100 - (node_filesystem_avail_bytes{mountpoint="/"} / node_filesystem_size_bytes{mountpoint="/"} * 100)
+
+# Network received bytes
+rate(node_network_receive_bytes_total[5m])
+```
+
+## Backup
+
+Backup Victoria Metrics data to S3:
+
+```bash
+# Backup to cluster's default S3 bucket
+easy-db-lab metrics backup
+
+# Backup to a custom S3 location
+easy-db-lab metrics backup --dest s3://my-backup-bucket/victoriametrics
+```
+
+By default, backups are stored at:
+`s3://{cluster-bucket}/victoriametrics/{timestamp}/`
+
+Use `--dest` to override the destination bucket and path
+
+### Features
+
+- Uses native vmbackup tool with snapshot support
+- Non-disruptive; metrics collection continues during backup
+- Direct S3 upload (no intermediate storage needed)
+- Incremental backup support for faster subsequent backups
+
+## Troubleshooting
+
+### No metrics appearing
+
+1. Verify Victoria Metrics pod is running:
+   ```bash
+   kubectl get pods -l app.kubernetes.io/name=victoriametrics
+   kubectl logs -l app.kubernetes.io/name=victoriametrics
+   ```
+
+2. Check OTel Collector is forwarding metrics:
+   ```bash
+   kubectl get pods -l app=otel-collector
+   kubectl logs -l app=otel-collector
+   ```
+
+3. Verify the cluster-config ConfigMap exists:
+   ```bash
+   kubectl get configmap cluster-config -o yaml
+   ```
+
+### Connection errors
+
+If you see connection errors when querying metrics:
+
+1. Ensure the cluster is running: `easy-db-lab status`
+2. The proxy is started automatically when needed
+3. Check that control node is accessible: `ssh control0 hostname`
+
+### High memory usage
+
+Victoria Metrics is configured with memory limits. If you see OOM kills:
+
+1. Check current memory usage:
+   ```bash
+   kubectl top pod -l app.kubernetes.io/name=victoriametrics
+   ```
+
+2. Consider adjusting the memory limits in the deployment manifest
+
+### Backup failures
+
+If backup fails:
+
+1. Check the backup job logs:
+   ```bash
+   kubectl logs -l app.kubernetes.io/name=victoriametrics-backup
+   ```
+
+2. Verify S3 bucket permissions (IAM role should have S3 access)
+
+3. Ensure there's sufficient disk space on the control node

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/CommandLineParser.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/CommandLineParser.kt
@@ -29,6 +29,7 @@ import com.rustyrazorblade.easydblab.commands.cassandra.Cassandra
 import com.rustyrazorblade.easydblab.commands.clickhouse.ClickHouse
 import com.rustyrazorblade.easydblab.commands.k8.K8
 import com.rustyrazorblade.easydblab.commands.logs.Logs
+import com.rustyrazorblade.easydblab.commands.metrics.Metrics
 import com.rustyrazorblade.easydblab.commands.opensearch.OpenSearch
 import com.rustyrazorblade.easydblab.commands.spark.Spark
 import com.rustyrazorblade.easydblab.commands.tailscale.Tailscale
@@ -86,6 +87,7 @@ import kotlin.system.exitProcess
         OpenSearch::class,
         Aws::class,
         Logs::class,
+        Metrics::class,
         Tailscale::class,
     ],
 )

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/logs/Logs.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/logs/Logs.kt
@@ -24,6 +24,7 @@ import picocli.CommandLine.Spec
     description = ["Query logs from Victoria Logs"],
     mixinStandardHelpOptions = true,
     subcommands = [
+        LogsBackup::class,
         LogsQuery::class,
     ],
 )

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/logs/LogsBackup.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/logs/LogsBackup.kt
@@ -1,0 +1,52 @@
+package com.rustyrazorblade.easydblab.commands.logs
+
+import com.rustyrazorblade.easydblab.annotations.McpCommand
+import com.rustyrazorblade.easydblab.annotations.RequireProfileSetup
+import com.rustyrazorblade.easydblab.commands.PicoBaseCommand
+import com.rustyrazorblade.easydblab.services.VictoriaBackupService
+import org.koin.core.component.inject
+import picocli.CommandLine.Command
+import picocli.CommandLine.Option
+
+/**
+ * Backup VictoriaLogs data to S3.
+ *
+ * This command creates a backup of VictoriaLogs data by syncing the data directory to S3.
+ * The backup is stored in S3 at: s3://{bucket}/victorialogs/{timestamp}/
+ *
+ * The backup is non-disruptive - log ingestion continues during the backup process.
+ *
+ * Example:
+ * ```
+ * easy-db-lab logs backup
+ * ```
+ */
+@McpCommand
+@RequireProfileSetup
+@Command(
+    name = "backup",
+    description = ["Backup VictoriaLogs data to S3"],
+)
+class LogsBackup : PicoBaseCommand() {
+    private val victoriaBackupService: VictoriaBackupService by inject()
+
+    @Option(names = ["--dest"], description = ["Destination S3 URI (default: cluster S3 bucket)"])
+    var dest: String? = null
+
+    override fun execute() {
+        val controlHost = clusterState.getControlHost()
+        if (controlHost == null) {
+            outputHandler.handleError("No control node found. Please ensure the cluster is running.")
+            return
+        }
+
+        victoriaBackupService
+            .backupLogs(controlHost, clusterState, dest)
+            .onSuccess { result ->
+                outputHandler.handleMessage("VictoriaLogs backup completed successfully")
+                outputHandler.handleMessage("Backup location: ${result.s3Path.toUri()}")
+            }.onFailure { exception ->
+                outputHandler.handleError("VictoriaLogs backup failed: ${exception.message}")
+            }
+    }
+}

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/metrics/Metrics.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/metrics/Metrics.kt
@@ -1,0 +1,34 @@
+package com.rustyrazorblade.easydblab.commands.metrics
+
+import picocli.CommandLine.Command
+import picocli.CommandLine.Model.CommandSpec
+import picocli.CommandLine.Spec
+
+/**
+ * Parent command for metrics operations.
+ *
+ * This command provides a unified interface for managing VictoriaMetrics:
+ * - Backup metrics data to S3
+ *
+ * VictoriaMetrics runs on the control node and stores metrics from all nodes
+ * in the cluster via OpenTelemetry.
+ *
+ * Available sub-commands:
+ * - backup: Backup VictoriaMetrics data to S3
+ */
+@Command(
+    name = "metrics",
+    description = ["Manage VictoriaMetrics observability data"],
+    mixinStandardHelpOptions = true,
+    subcommands = [
+        MetricsBackup::class,
+    ],
+)
+class Metrics : Runnable {
+    @Spec
+    lateinit var spec: CommandSpec
+
+    override fun run() {
+        spec.commandLine().usage(System.out)
+    }
+}

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/metrics/MetricsBackup.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/metrics/MetricsBackup.kt
@@ -1,0 +1,52 @@
+package com.rustyrazorblade.easydblab.commands.metrics
+
+import com.rustyrazorblade.easydblab.annotations.McpCommand
+import com.rustyrazorblade.easydblab.annotations.RequireProfileSetup
+import com.rustyrazorblade.easydblab.commands.PicoBaseCommand
+import com.rustyrazorblade.easydblab.services.VictoriaBackupService
+import org.koin.core.component.inject
+import picocli.CommandLine.Command
+import picocli.CommandLine.Option
+
+/**
+ * Backup VictoriaMetrics data to S3.
+ *
+ * This command creates a backup of VictoriaMetrics data using the native vmbackup tool.
+ * The backup is stored in S3 at: s3://{bucket}/victoriametrics/{timestamp}/
+ *
+ * The backup is non-disruptive - metrics collection continues during the backup process.
+ *
+ * Example:
+ * ```
+ * easy-db-lab metrics backup
+ * ```
+ */
+@McpCommand
+@RequireProfileSetup
+@Command(
+    name = "backup",
+    description = ["Backup VictoriaMetrics data to S3"],
+)
+class MetricsBackup : PicoBaseCommand() {
+    private val victoriaBackupService: VictoriaBackupService by inject()
+
+    @Option(names = ["--dest"], description = ["Destination S3 URI (default: cluster S3 bucket)"])
+    var dest: String? = null
+
+    override fun execute() {
+        val controlHost = clusterState.getControlHost()
+        if (controlHost == null) {
+            outputHandler.handleError("No control node found. Please ensure the cluster is running.")
+            return
+        }
+
+        victoriaBackupService
+            .backupMetrics(controlHost, clusterState, dest)
+            .onSuccess { result ->
+                outputHandler.handleMessage("VictoriaMetrics backup completed successfully")
+                outputHandler.handleMessage("Backup location: ${result.s3Path.toUri()}")
+            }.onFailure { exception ->
+                outputHandler.handleError("VictoriaMetrics backup failed: ${exception.message}")
+            }
+    }
+}

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/ClusterS3Path.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/ClusterS3Path.kt
@@ -45,6 +45,8 @@ data class ClusterS3Path(
         private const val ENVIRONMENT_FILE = "environment.sh"
         private const val SETUP_INSTANCE_FILE = "setup_instance.sh"
         private const val TEMPO_DIR = "tempo"
+        private const val VICTORIA_METRICS_DIR = "victoriametrics"
+        private const val VICTORIA_LOGS_DIR = "victorialogs"
 
         /**
          * Create a ClusterS3Path from ClusterState.
@@ -278,4 +280,18 @@ data class ClusterS3Path(
      * @return Path: s3://bucket/config/setup_instance.sh
      */
     fun setupInstanceScript(): ClusterS3Path = resolve(CONFIG_DIR).resolve(SETUP_INSTANCE_FILE)
+
+    /**
+     * Path for VictoriaMetrics backups.
+     *
+     * @return Path: s3://bucket/victoriametrics
+     */
+    fun victoriaMetrics(): ClusterS3Path = resolve(VICTORIA_METRICS_DIR)
+
+    /**
+     * Path for VictoriaLogs backups.
+     *
+     * @return Path: s3://bucket/victorialogs
+     */
+    fun victoriaLogs(): ClusterS3Path = resolve(VICTORIA_LOGS_DIR)
 }

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/ServicesModule.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/ServicesModule.kt
@@ -43,6 +43,7 @@ val servicesModule =
         factoryOf(::DefaultK3sService) bind K3sService::class
         factoryOf(::DefaultK3sAgentService) bind K3sAgentService::class
         factoryOf(::DefaultK8sService) bind K8sService::class
+        factoryOf(::DefaultVictoriaBackupService) bind VictoriaBackupService::class
         factoryOf(::DefaultSidecarService) bind SidecarService::class
         factoryOf(::DefaultStressJobService) bind StressJobService::class
         singleOf(::HostOperationsService)

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/VictoriaBackupService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/VictoriaBackupService.kt
@@ -1,0 +1,375 @@
+package com.rustyrazorblade.easydblab.services
+
+import com.rustyrazorblade.easydblab.configuration.ClusterHost
+import com.rustyrazorblade.easydblab.configuration.ClusterS3Path
+import com.rustyrazorblade.easydblab.configuration.ClusterState
+import com.rustyrazorblade.easydblab.output.OutputHandler
+import io.github.oshai.kotlinlogging.KotlinLogging
+import java.time.Instant
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+
+/**
+ * Result of a Victoria backup operation.
+ *
+ * @property s3Path The S3 path where the backup was stored
+ * @property timestamp The timestamp of the backup
+ */
+data class VictoriaBackupResult(
+    val s3Path: ClusterS3Path,
+    val timestamp: String,
+)
+
+/**
+ * Service for backing up VictoriaMetrics and VictoriaLogs data to S3.
+ *
+ * This service creates backups using the native Victoria tools:
+ * - VictoriaMetrics: Uses vmbackup tool for native backup to S3
+ * - VictoriaLogs: Creates snapshots via API and uploads to S3
+ */
+interface VictoriaBackupService {
+    /**
+     * Backs up VictoriaMetrics data to S3.
+     *
+     * Creates a Kubernetes Job that runs vmbackup to directly backup
+     * VictoriaMetrics data to S3.
+     *
+     * @param controlHost The control node running VictoriaMetrics
+     * @param clusterState The cluster state containing S3 bucket configuration
+     * @param destinationUri Optional S3 URI to override the default destination (e.g., s3://bucket/path)
+     * @return Result containing backup details or failure
+     */
+    fun backupMetrics(
+        controlHost: ClusterHost,
+        clusterState: ClusterState,
+        destinationUri: String? = null,
+    ): Result<VictoriaBackupResult>
+
+    /**
+     * Backs up VictoriaLogs data to S3.
+     *
+     * Creates snapshots of all log partitions and uploads them to S3.
+     *
+     * @param controlHost The control node running VictoriaLogs
+     * @param clusterState The cluster state containing S3 bucket configuration
+     * @param destinationUri Optional S3 URI to override the default destination (e.g., s3://bucket/path)
+     * @return Result containing backup details or failure
+     */
+    fun backupLogs(
+        controlHost: ClusterHost,
+        clusterState: ClusterState,
+        destinationUri: String? = null,
+    ): Result<VictoriaBackupResult>
+}
+
+/**
+ * Default implementation of VictoriaBackupService.
+ *
+ * Uses Kubernetes Jobs to run backup operations on the control node.
+ *
+ * @property k8sService Service for Kubernetes operations
+ * @property socksProxyService Service for SOCKS proxy connections
+ * @property outputHandler Handler for user-facing output messages
+ */
+class DefaultVictoriaBackupService(
+    private val k8sService: K8sService,
+    private val outputHandler: OutputHandler,
+) : VictoriaBackupService {
+    private val log = KotlinLogging.logger {}
+
+    companion object {
+        private const val NAMESPACE = "default"
+        private const val VM_DATA_PATH = "/mnt/db1/victoriametrics"
+        private const val VL_DATA_PATH = "/mnt/db1/victorialogs"
+        private const val VM_HTTP_PORT = 8428
+        private const val JOB_TIMEOUT_SECONDS = 600 // 10 minutes
+        private const val JOB_POLL_INTERVAL_MS = 5000L
+        private val TIMESTAMP_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss")
+    }
+
+    override fun backupMetrics(
+        controlHost: ClusterHost,
+        clusterState: ClusterState,
+        destinationUri: String?,
+    ): Result<VictoriaBackupResult> =
+        runCatching {
+            log.info { "Starting VictoriaMetrics backup for cluster ${clusterState.name}" }
+
+            val region = clusterState.initConfig?.region ?: "us-west-2"
+            val timestamp = generateTimestamp()
+
+            val (bucket, s3Path) =
+                if (destinationUri != null) {
+                    parseS3Uri(destinationUri, timestamp)
+                } else {
+                    val s3Bucket =
+                        clusterState.s3Bucket
+                            ?: error("S3 bucket not configured for cluster '${clusterState.name}'. Run 'easy-db-lab up' first.")
+                    s3Bucket to ClusterS3Path.from(clusterState).victoriaMetrics().resolve(timestamp)
+                }
+
+            outputHandler.handleMessage("Creating VictoriaMetrics backup to ${s3Path.toUri()}...")
+
+            // Create a Job that runs vmbackup
+            val jobName = "vmbackup-${timestamp.lowercase()}"
+            val jobYaml = createVmBackupJobYaml(jobName, bucket, s3Path.getKey(), region)
+
+            // Apply the job
+            k8sService.createJob(controlHost, NAMESPACE, jobYaml).getOrThrow()
+            log.info { "Created backup job: $jobName" }
+
+            outputHandler.handleMessage("Backup job started: $jobName")
+
+            // Wait for job completion
+            waitForJobCompletion(controlHost, jobName)
+
+            // Clean up the job
+            k8sService.deleteJob(controlHost, NAMESPACE, jobName).getOrElse {
+                log.warn { "Failed to delete backup job: ${it.message}" }
+            }
+
+            outputHandler.handleMessage("VictoriaMetrics backup completed: ${s3Path.toUri()}")
+
+            VictoriaBackupResult(s3Path, timestamp)
+        }
+
+    override fun backupLogs(
+        controlHost: ClusterHost,
+        clusterState: ClusterState,
+        destinationUri: String?,
+    ): Result<VictoriaBackupResult> =
+        runCatching {
+            log.info { "Starting VictoriaLogs backup for cluster ${clusterState.name}" }
+
+            val region = clusterState.initConfig?.region ?: "us-west-2"
+            val timestamp = generateTimestamp()
+
+            val (bucket, s3Path) =
+                if (destinationUri != null) {
+                    parseS3Uri(destinationUri, timestamp)
+                } else {
+                    val s3Bucket =
+                        clusterState.s3Bucket
+                            ?: error("S3 bucket not configured for cluster '${clusterState.name}'. Run 'easy-db-lab up' first.")
+                    s3Bucket to ClusterS3Path.from(clusterState).victoriaLogs().resolve(timestamp)
+                }
+
+            outputHandler.handleMessage("Creating VictoriaLogs backup to ${s3Path.toUri()}...")
+
+            // Create a Job that copies VictoriaLogs data to S3
+            // VictoriaLogs doesn't have a dedicated backup tool like vmbackup,
+            // so we use aws s3 sync to copy the data directory
+            val jobName = "vlbackup-${timestamp.lowercase()}"
+            val jobYaml = createVlBackupJobYaml(jobName, bucket, s3Path.getKey(), region)
+
+            // Apply the job
+            k8sService.createJob(controlHost, NAMESPACE, jobYaml).getOrThrow()
+            log.info { "Created backup job: $jobName" }
+
+            outputHandler.handleMessage("Backup job started: $jobName")
+
+            // Wait for job completion
+            waitForJobCompletion(controlHost, jobName)
+
+            // Clean up the job
+            k8sService.deleteJob(controlHost, NAMESPACE, jobName).getOrElse {
+                log.warn { "Failed to delete backup job: ${it.message}" }
+            }
+
+            outputHandler.handleMessage("VictoriaLogs backup completed: ${s3Path.toUri()}")
+
+            VictoriaBackupResult(s3Path, timestamp)
+        }
+
+    private fun generateTimestamp(): String = TIMESTAMP_FORMATTER.format(Instant.now().atOffset(ZoneOffset.UTC))
+
+    /**
+     * Parse an S3 URI into bucket and path components.
+     *
+     * @param uri The S3 URI (e.g., s3://bucket/path)
+     * @param timestamp The timestamp to append to the path
+     * @return Pair of bucket name and ClusterS3Path
+     */
+    internal fun parseS3Uri(
+        uri: String,
+        timestamp: String,
+    ): Pair<String, ClusterS3Path> {
+        require(uri.startsWith("s3://")) { "Destination must be an S3 URI (s3://bucket/path)" }
+        val withoutPrefix = uri.removePrefix("s3://")
+        val slashIndex = withoutPrefix.indexOf('/')
+
+        val bucket: String
+        val basePath: String
+        if (slashIndex == -1) {
+            bucket = withoutPrefix
+            basePath = ""
+        } else {
+            bucket = withoutPrefix.substring(0, slashIndex)
+            basePath = withoutPrefix.substring(slashIndex + 1).trimEnd('/')
+        }
+
+        val s3Path =
+            if (basePath.isNotEmpty()) {
+                ClusterS3Path.root(bucket).resolve(basePath).resolve(timestamp)
+            } else {
+                ClusterS3Path.root(bucket).resolve(timestamp)
+            }
+
+        return bucket to s3Path
+    }
+
+    private fun createVmBackupJobYaml(
+        jobName: String,
+        bucket: String,
+        s3Key: String,
+        region: String,
+    ): String =
+        """
+        |apiVersion: batch/v1
+        |kind: Job
+        |metadata:
+        |  name: $jobName
+        |  namespace: $NAMESPACE
+        |  labels:
+        |    app.kubernetes.io/name: victoriametrics-backup
+        |spec:
+        |  ttlSecondsAfterFinished: 300
+        |  template:
+        |    spec:
+        |      restartPolicy: Never
+        |      hostNetwork: true
+        |      dnsPolicy: ClusterFirstWithHostNet
+        |      nodeSelector:
+        |        node-role.kubernetes.io/master: "true"
+        |      tolerations:
+        |        - key: node-role.kubernetes.io/master
+        |          operator: Exists
+        |          effect: NoSchedule
+        |      containers:
+        |        - name: vmbackup
+        |          image: victoriametrics/vmbackup:latest
+        |          env:
+        |            - name: AWS_REGION
+        |              value: $region
+        |          args:
+        |            - -storageDataPath=$VM_DATA_PATH
+        |            - -snapshot.createURL=http://localhost:$VM_HTTP_PORT/snapshot/create
+        |            - -dst=s3://$bucket/$s3Key
+        |            - -customS3Endpoint=https://s3.$region.amazonaws.com
+        |          volumeMounts:
+        |            - name: data
+        |              mountPath: $VM_DATA_PATH
+        |              readOnly: true
+        |          resources:
+        |            requests:
+        |              memory: 128Mi
+        |              cpu: 100m
+        |            limits:
+        |              memory: 512Mi
+        |      volumes:
+        |        - name: data
+        |          hostPath:
+        |            path: $VM_DATA_PATH
+        |            type: Directory
+        """.trimMargin()
+
+    private fun createVlBackupJobYaml(
+        jobName: String,
+        bucket: String,
+        s3Key: String,
+        region: String,
+    ): String =
+        """
+        |apiVersion: batch/v1
+        |kind: Job
+        |metadata:
+        |  name: $jobName
+        |  namespace: $NAMESPACE
+        |  labels:
+        |    app.kubernetes.io/name: victorialogs-backup
+        |spec:
+        |  ttlSecondsAfterFinished: 300
+        |  template:
+        |    spec:
+        |      restartPolicy: Never
+        |      hostNetwork: true
+        |      dnsPolicy: ClusterFirstWithHostNet
+        |      nodeSelector:
+        |        node-role.kubernetes.io/master: "true"
+        |      tolerations:
+        |        - key: node-role.kubernetes.io/master
+        |          operator: Exists
+        |          effect: NoSchedule
+        |      containers:
+        |        - name: aws-cli
+        |          image: amazon/aws-cli:latest
+        |          command:
+        |            - sh
+        |            - -c
+        |            - |
+        |              aws s3 sync $VL_DATA_PATH s3://$bucket/$s3Key --region $region
+        |          volumeMounts:
+        |            - name: data
+        |              mountPath: $VL_DATA_PATH
+        |              readOnly: true
+        |          resources:
+        |            requests:
+        |              memory: 128Mi
+        |              cpu: 100m
+        |            limits:
+        |              memory: 512Mi
+        |      volumes:
+        |        - name: data
+        |          hostPath:
+        |            path: $VL_DATA_PATH
+        |            type: Directory
+        """.trimMargin()
+
+    @Suppress("MagicNumber", "NestedBlockDepth")
+    private fun waitForJobCompletion(
+        controlHost: ClusterHost,
+        jobName: String,
+    ) {
+        log.info { "Waiting for backup job $jobName to complete..." }
+
+        val startTime = System.currentTimeMillis()
+        val timeoutMs = JOB_TIMEOUT_SECONDS * 1000L
+
+        while (System.currentTimeMillis() - startTime < timeoutMs) {
+            val labelValue =
+                if (jobName.startsWith("vm")) "victoriametrics-backup" else "victorialogs-backup"
+            val jobs =
+                k8sService
+                    .getJobsByLabel(
+                        controlHost,
+                        NAMESPACE,
+                        "app.kubernetes.io/name",
+                        labelValue,
+                    ).getOrThrow()
+
+            val job = jobs.find { it.name == jobName }
+            if (job != null) {
+                when (job.status) {
+                    "Completed" -> {
+                        log.info { "Backup job $jobName completed successfully" }
+                        return
+                    }
+                    "Failed" -> {
+                        // Get logs for debugging
+                        val pods = k8sService.getPodsForJob(controlHost, NAMESPACE, jobName).getOrElse { emptyList() }
+                        val podLogs =
+                            pods.firstOrNull()?.let { pod ->
+                                k8sService.getPodLogs(controlHost, NAMESPACE, pod.name).getOrElse { "No logs available" }
+                            } ?: "No pods found"
+                        error("Backup job $jobName failed. Pod logs:\n$podLogs")
+                    }
+                }
+            }
+
+            Thread.sleep(JOB_POLL_INTERVAL_MS)
+            outputHandler.handleMessage("Waiting for backup to complete...")
+        }
+
+        error("Backup job $jobName timed out after $JOB_TIMEOUT_SECONDS seconds")
+    }
+}

--- a/src/main/resources/com/rustyrazorblade/easydblab/commands/k8s/core/44-victoriametrics-deployment.yaml
+++ b/src/main/resources/com/rustyrazorblade/easydblab/commands/k8s/core/44-victoriametrics-deployment.yaml
@@ -57,4 +57,6 @@ spec:
             periodSeconds: 10
       volumes:
         - name: data
-          emptyDir: {}
+          hostPath:
+            path: /mnt/db1/victoriametrics
+            type: DirectoryOrCreate

--- a/src/main/resources/com/rustyrazorblade/easydblab/commands/k8s/core/45-victorialogs-deployment.yaml
+++ b/src/main/resources/com/rustyrazorblade/easydblab/commands/k8s/core/45-victorialogs-deployment.yaml
@@ -57,4 +57,6 @@ spec:
             periodSeconds: 10
       volumes:
         - name: data
-          emptyDir: {}
+          hostPath:
+            path: /mnt/db1/victorialogs
+            type: DirectoryOrCreate

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/commands/logs/LogsBackupTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/commands/logs/LogsBackupTest.kt
@@ -1,0 +1,174 @@
+package com.rustyrazorblade.easydblab.commands.logs
+
+import com.rustyrazorblade.easydblab.BaseKoinTest
+import com.rustyrazorblade.easydblab.configuration.ClusterHost
+import com.rustyrazorblade.easydblab.configuration.ClusterS3Path
+import com.rustyrazorblade.easydblab.configuration.ClusterState
+import com.rustyrazorblade.easydblab.configuration.ClusterStateManager
+import com.rustyrazorblade.easydblab.configuration.InitConfig
+import com.rustyrazorblade.easydblab.configuration.ServerType
+import com.rustyrazorblade.easydblab.output.BufferedOutputHandler
+import com.rustyrazorblade.easydblab.output.OutputHandler
+import com.rustyrazorblade.easydblab.services.VictoriaBackupResult
+import com.rustyrazorblade.easydblab.services.VictoriaBackupService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.koin.core.module.Module
+import org.koin.dsl.module
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.io.File
+
+/**
+ * Tests for the LogsBackup command.
+ */
+class LogsBackupTest : BaseKoinTest() {
+    private lateinit var mockVictoriaBackupService: VictoriaBackupService
+    private lateinit var mockClusterStateManager: ClusterStateManager
+    private lateinit var outputHandler: BufferedOutputHandler
+
+    private val testControlHost =
+        ClusterHost(
+            publicIp = "54.123.45.67",
+            privateIp = "10.0.1.5",
+            alias = "control0",
+            availabilityZone = "us-west-2a",
+            instanceId = "i-test123",
+        )
+
+    private val testClusterState =
+        ClusterState(
+            name = "test-cluster",
+            versions = mutableMapOf(),
+            s3Bucket = "easy-db-lab-test-bucket",
+            initConfig = InitConfig(region = "us-west-2"),
+            hosts =
+                mapOf(
+                    ServerType.Control to listOf(testControlHost),
+                ),
+        )
+
+    override fun additionalTestModules(): List<Module> =
+        listOf(
+            module {
+                single<VictoriaBackupService> { mockVictoriaBackupService }
+                single<ClusterStateManager> { mockClusterStateManager }
+            },
+        )
+
+    @BeforeEach
+    fun setupMocks() {
+        mockVictoriaBackupService = mock()
+        mockClusterStateManager = mock()
+        outputHandler = getKoin().get<OutputHandler>() as BufferedOutputHandler
+
+        // Write state file for ClusterStateManager
+        File(tempDir, "state.json").writeText(
+            """
+            {
+                "name": "test-cluster",
+                "versions": {},
+                "s3Bucket": "easy-db-lab-test-bucket",
+                "hosts": {
+                    "Control": [
+                        {
+                            "publicIp": "54.123.45.67",
+                            "privateIp": "10.0.1.5",
+                            "alias": "control0",
+                            "availabilityZone": "us-west-2a",
+                            "instanceId": "i-test123"
+                        }
+                    ]
+                },
+                "initConfig": {
+                    "region": "us-west-2"
+                }
+            }
+            """.trimIndent(),
+        )
+
+        whenever(mockClusterStateManager.load()).thenReturn(testClusterState)
+    }
+
+    @Test
+    fun `execute calls backup service with control host`() {
+        // Given
+        val backupResult =
+            VictoriaBackupResult(
+                s3Path = ClusterS3Path.root("test-bucket").victoriaLogs().resolve("20240101-120000"),
+                timestamp = "20240101-120000",
+            )
+        whenever(mockVictoriaBackupService.backupLogs(any(), any(), anyOrNull()))
+            .thenReturn(Result.success(backupResult))
+
+        val command = LogsBackup()
+
+        // When
+        command.call()
+
+        // Then
+        verify(mockVictoriaBackupService).backupLogs(any(), any(), anyOrNull())
+    }
+
+    @Test
+    fun `execute outputs success message on completion`() {
+        // Given
+        val backupResult =
+            VictoriaBackupResult(
+                s3Path = ClusterS3Path.root("test-bucket").victoriaLogs().resolve("20240101-120000"),
+                timestamp = "20240101-120000",
+            )
+        whenever(mockVictoriaBackupService.backupLogs(any(), any(), anyOrNull()))
+            .thenReturn(Result.success(backupResult))
+
+        val command = LogsBackup()
+
+        // When
+        command.call()
+
+        // Then
+        val output = outputHandler.messages.joinToString("\n")
+        assertThat(output).contains("backup completed successfully")
+        assertThat(output).contains("s3://test-bucket/victorialogs/20240101-120000")
+    }
+
+    @Test
+    fun `execute handles backup failure`() {
+        // Given
+        whenever(mockVictoriaBackupService.backupLogs(any(), any(), anyOrNull()))
+            .thenReturn(Result.failure(RuntimeException("Backup failed: S3 error")))
+
+        val command = LogsBackup()
+
+        // When
+        command.call()
+
+        // Then
+        val allOutput = outputHandler.messages.joinToString("\n") + outputHandler.errors.joinToString("\n") { it.first }
+        assertThat(allOutput).contains("backup failed")
+        assertThat(allOutput).contains("S3 error")
+    }
+
+    @Test
+    fun `execute handles missing control node`() {
+        // Given
+        val stateWithoutControl =
+            testClusterState.copy(
+                hosts = emptyMap(),
+            )
+        whenever(mockClusterStateManager.load()).thenReturn(stateWithoutControl)
+
+        val command = LogsBackup()
+
+        // When - Should handle error gracefully (not throw)
+        command.call()
+
+        // Then - Should output an error message
+        val errors = outputHandler.errors.joinToString("\n") { it.first }
+        assertThat(errors).contains("No control node found")
+    }
+}

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/commands/metrics/MetricsBackupTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/commands/metrics/MetricsBackupTest.kt
@@ -1,0 +1,174 @@
+package com.rustyrazorblade.easydblab.commands.metrics
+
+import com.rustyrazorblade.easydblab.BaseKoinTest
+import com.rustyrazorblade.easydblab.configuration.ClusterHost
+import com.rustyrazorblade.easydblab.configuration.ClusterS3Path
+import com.rustyrazorblade.easydblab.configuration.ClusterState
+import com.rustyrazorblade.easydblab.configuration.ClusterStateManager
+import com.rustyrazorblade.easydblab.configuration.InitConfig
+import com.rustyrazorblade.easydblab.configuration.ServerType
+import com.rustyrazorblade.easydblab.output.BufferedOutputHandler
+import com.rustyrazorblade.easydblab.output.OutputHandler
+import com.rustyrazorblade.easydblab.services.VictoriaBackupResult
+import com.rustyrazorblade.easydblab.services.VictoriaBackupService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.koin.core.module.Module
+import org.koin.dsl.module
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.io.File
+
+/**
+ * Tests for the MetricsBackup command.
+ */
+class MetricsBackupTest : BaseKoinTest() {
+    private lateinit var mockVictoriaBackupService: VictoriaBackupService
+    private lateinit var mockClusterStateManager: ClusterStateManager
+    private lateinit var outputHandler: BufferedOutputHandler
+
+    private val testControlHost =
+        ClusterHost(
+            publicIp = "54.123.45.67",
+            privateIp = "10.0.1.5",
+            alias = "control0",
+            availabilityZone = "us-west-2a",
+            instanceId = "i-test123",
+        )
+
+    private val testClusterState =
+        ClusterState(
+            name = "test-cluster",
+            versions = mutableMapOf(),
+            s3Bucket = "easy-db-lab-test-bucket",
+            initConfig = InitConfig(region = "us-west-2"),
+            hosts =
+                mapOf(
+                    ServerType.Control to listOf(testControlHost),
+                ),
+        )
+
+    override fun additionalTestModules(): List<Module> =
+        listOf(
+            module {
+                single<VictoriaBackupService> { mockVictoriaBackupService }
+                single<ClusterStateManager> { mockClusterStateManager }
+            },
+        )
+
+    @BeforeEach
+    fun setupMocks() {
+        mockVictoriaBackupService = mock()
+        mockClusterStateManager = mock()
+        outputHandler = getKoin().get<OutputHandler>() as BufferedOutputHandler
+
+        // Write state file for ClusterStateManager
+        File(tempDir, "state.json").writeText(
+            """
+            {
+                "name": "test-cluster",
+                "versions": {},
+                "s3Bucket": "easy-db-lab-test-bucket",
+                "hosts": {
+                    "Control": [
+                        {
+                            "publicIp": "54.123.45.67",
+                            "privateIp": "10.0.1.5",
+                            "alias": "control0",
+                            "availabilityZone": "us-west-2a",
+                            "instanceId": "i-test123"
+                        }
+                    ]
+                },
+                "initConfig": {
+                    "region": "us-west-2"
+                }
+            }
+            """.trimIndent(),
+        )
+
+        whenever(mockClusterStateManager.load()).thenReturn(testClusterState)
+    }
+
+    @Test
+    fun `execute calls backup service with control host`() {
+        // Given
+        val backupResult =
+            VictoriaBackupResult(
+                s3Path = ClusterS3Path.root("test-bucket").victoriaMetrics().resolve("20240101-120000"),
+                timestamp = "20240101-120000",
+            )
+        whenever(mockVictoriaBackupService.backupMetrics(any(), any(), anyOrNull()))
+            .thenReturn(Result.success(backupResult))
+
+        val command = MetricsBackup()
+
+        // When
+        command.call()
+
+        // Then
+        verify(mockVictoriaBackupService).backupMetrics(any(), any(), anyOrNull())
+    }
+
+    @Test
+    fun `execute outputs success message on completion`() {
+        // Given
+        val backupResult =
+            VictoriaBackupResult(
+                s3Path = ClusterS3Path.root("test-bucket").victoriaMetrics().resolve("20240101-120000"),
+                timestamp = "20240101-120000",
+            )
+        whenever(mockVictoriaBackupService.backupMetrics(any(), any(), anyOrNull()))
+            .thenReturn(Result.success(backupResult))
+
+        val command = MetricsBackup()
+
+        // When
+        command.call()
+
+        // Then
+        val output = outputHandler.messages.joinToString("\n")
+        assertThat(output).contains("backup completed successfully")
+        assertThat(output).contains("s3://test-bucket/victoriametrics/20240101-120000")
+    }
+
+    @Test
+    fun `execute handles backup failure`() {
+        // Given
+        whenever(mockVictoriaBackupService.backupMetrics(any(), any(), anyOrNull()))
+            .thenReturn(Result.failure(RuntimeException("Backup failed: K8s error")))
+
+        val command = MetricsBackup()
+
+        // When
+        command.call()
+
+        // Then
+        val allOutput = outputHandler.messages.joinToString("\n") + outputHandler.errors.joinToString("\n") { it.first }
+        assertThat(allOutput).contains("backup failed")
+        assertThat(allOutput).contains("K8s error")
+    }
+
+    @Test
+    fun `execute handles missing control node`() {
+        // Given
+        val stateWithoutControl =
+            testClusterState.copy(
+                hosts = emptyMap(),
+            )
+        whenever(mockClusterStateManager.load()).thenReturn(stateWithoutControl)
+
+        val command = MetricsBackup()
+
+        // When - Should handle error gracefully (not throw)
+        command.call()
+
+        // Then - Should output an error message
+        val errors = outputHandler.errors.joinToString("\n") { it.first }
+        assertThat(errors).contains("No control node found")
+    }
+}

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/configuration/ClusterS3PathTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/configuration/ClusterS3PathTest.kt
@@ -293,4 +293,40 @@ class ClusterS3PathTest {
         assertThat(setupInstanceScriptPath.toString())
             .isEqualTo("s3://my-bucket/config/setup_instance.sh")
     }
+
+    @Test
+    fun `victoriaMetrics returns correct path`() {
+        val path = ClusterS3Path.root("my-bucket")
+        val victoriaMetricsPath = path.victoriaMetrics()
+
+        assertThat(victoriaMetricsPath.toString())
+            .isEqualTo("s3://my-bucket/victoriametrics")
+    }
+
+    @Test
+    fun `victoriaLogs returns correct path`() {
+        val path = ClusterS3Path.root("my-bucket")
+        val victoriaLogsPath = path.victoriaLogs()
+
+        assertThat(victoriaLogsPath.toString())
+            .isEqualTo("s3://my-bucket/victorialogs")
+    }
+
+    @Test
+    fun `victoriaMetrics can be chained with resolve for timestamp`() {
+        val path = ClusterS3Path.root("my-bucket")
+        val backupPath = path.victoriaMetrics().resolve("20240101-120000")
+
+        assertThat(backupPath.toString())
+            .isEqualTo("s3://my-bucket/victoriametrics/20240101-120000")
+    }
+
+    @Test
+    fun `victoriaLogs can be chained with resolve for timestamp`() {
+        val path = ClusterS3Path.root("my-bucket")
+        val backupPath = path.victoriaLogs().resolve("20240101-120000")
+
+        assertThat(backupPath.toString())
+            .isEqualTo("s3://my-bucket/victorialogs/20240101-120000")
+    }
 }

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/services/VictoriaBackupServiceTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/services/VictoriaBackupServiceTest.kt
@@ -1,0 +1,382 @@
+package com.rustyrazorblade.easydblab.services
+
+import com.rustyrazorblade.easydblab.BaseKoinTest
+import com.rustyrazorblade.easydblab.configuration.ClusterHost
+import com.rustyrazorblade.easydblab.configuration.ClusterState
+import com.rustyrazorblade.easydblab.configuration.InitConfig
+import com.rustyrazorblade.easydblab.output.BufferedOutputHandler
+import com.rustyrazorblade.easydblab.output.OutputHandler
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.koin.core.module.Module
+import org.koin.dsl.module
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argThat
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.reset
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+/**
+ * Test suite for VictoriaBackupService.
+ *
+ * Tests backup operations for VictoriaMetrics and VictoriaLogs using mocked K8sService.
+ */
+class VictoriaBackupServiceTest : BaseKoinTest() {
+    // Initialize mock before Koin modules are loaded - this instance is shared
+    private val mockK8sService: K8sService = mock()
+    private lateinit var outputHandler: BufferedOutputHandler
+    private lateinit var victoriaBackupService: VictoriaBackupService
+
+    private val testControlHost =
+        ClusterHost(
+            publicIp = "54.123.45.67",
+            privateIp = "10.0.1.5",
+            alias = "control0",
+            availabilityZone = "us-west-2a",
+            instanceId = "i-test123",
+        )
+
+    private val testClusterState =
+        ClusterState(
+            name = "test-cluster",
+            versions = mutableMapOf(),
+            s3Bucket = "easy-db-lab-test-bucket",
+            initConfig =
+                InitConfig(
+                    region = "us-west-2",
+                ),
+        )
+
+    override fun additionalTestModules(): List<Module> =
+        listOf(
+            module {
+                single<K8sService> { mockK8sService }
+                factory<VictoriaBackupService> {
+                    DefaultVictoriaBackupService(get(), get())
+                }
+            },
+        )
+
+    @BeforeEach
+    fun setupMocks() {
+        // Reset mock expectations for each test
+        reset(mockK8sService)
+        outputHandler = getKoin().get<OutputHandler>() as BufferedOutputHandler
+        victoriaBackupService = getKoin().get()
+    }
+
+    // ========== METRICS BACKUP TESTS ==========
+
+    @Test
+    fun `backupMetrics creates K8s Job with correct spec`() {
+        // Given - mock createJob to fail early so we don't need job completion mocking
+        whenever(mockK8sService.createJob(any(), any(), any()))
+            .thenReturn(Result.failure(RuntimeException("Test: stop after createJob")))
+
+        // When
+        victoriaBackupService.backupMetrics(testControlHost, testClusterState)
+
+        // Then - Verify job was created with vmbackup image, correct args, and AWS_REGION env var
+        verify(mockK8sService).createJob(
+            eq(testControlHost),
+            eq("default"),
+            argThat { yaml ->
+                yaml.contains("victoriametrics/vmbackup:latest") &&
+                    yaml.contains("-storageDataPath=/mnt/db1/victoriametrics") &&
+                    yaml.contains("-snapshot.createURL=http://localhost:8428/snapshot/create") &&
+                    yaml.contains("s3://easy-db-lab-test-bucket/victoriametrics/") &&
+                    yaml.contains("AWS_REGION") &&
+                    yaml.contains("us-west-2")
+            },
+        )
+    }
+
+    @Test
+    fun `backupMetrics calls createJob with correct job spec`() {
+        // Given - mock createJob to fail early so we don't need full job completion mocking
+        whenever(mockK8sService.createJob(any(), any(), any()))
+            .thenReturn(Result.failure(RuntimeException("Test: stop after createJob")))
+
+        // When
+        victoriaBackupService.backupMetrics(testControlHost, testClusterState)
+
+        // Then - verify createJob was called (we already test YAML content in other tests)
+        verify(mockK8sService).createJob(
+            eq(testControlHost),
+            eq("default"),
+            argThat { yaml -> yaml.contains("victoriametrics/vmbackup:latest") },
+        )
+    }
+
+    @Test
+    fun `backupMetrics handles createJob failure`() {
+        // Given
+        whenever(mockK8sService.createJob(any(), any(), any()))
+            .thenReturn(Result.failure(RuntimeException("K8s API error")))
+
+        // When
+        val result = victoriaBackupService.backupMetrics(testControlHost, testClusterState)
+
+        // Then
+        assertThat(result.isFailure).isTrue()
+        assertThat(result.exceptionOrNull()?.message).contains("K8s API error")
+    }
+
+    @Test
+    fun `backupMetrics generates correct S3 path format`() {
+        // Given - capture the YAML to verify the S3 path format
+        var capturedYaml: String? = null
+        whenever(mockK8sService.createJob(any(), any(), any()))
+            .thenAnswer { invocation ->
+                capturedYaml = invocation.getArgument(2)
+                Result.failure<String>(RuntimeException("Test: stop after createJob"))
+            }
+
+        // When
+        victoriaBackupService.backupMetrics(testControlHost, testClusterState)
+
+        // Then - verify S3 path format in the job YAML
+        assertThat(capturedYaml).contains("s3://easy-db-lab-test-bucket/victoriametrics/")
+        // Verify timestamp format in job name (YYYYMMDD-HHMMSS)
+        assertThat(capturedYaml).containsPattern("name: vmbackup-\\d{8}-\\d{6}")
+    }
+
+    @Test
+    fun `backupMetrics fails when S3 bucket not configured`() {
+        // Given
+        val stateWithoutBucket = testClusterState.copy(s3Bucket = null)
+
+        // When
+        val result = victoriaBackupService.backupMetrics(testControlHost, stateWithoutBucket)
+
+        // Then
+        assertThat(result.isFailure).isTrue()
+        assertThat(result.exceptionOrNull()?.message).contains("S3 bucket not configured")
+    }
+
+    // ========== LOGS BACKUP TESTS ==========
+
+    @Test
+    fun `backupLogs creates K8s Job with aws-cli for S3 sync`() {
+        // Given - mock createJob to fail early so we don't need job completion mocking
+        whenever(mockK8sService.createJob(any(), any(), any()))
+            .thenReturn(Result.failure(RuntimeException("Test: stop after createJob")))
+
+        // When
+        victoriaBackupService.backupLogs(testControlHost, testClusterState)
+
+        // Then - Verify job uses aws-cli for S3 sync
+        verify(mockK8sService).createJob(
+            eq(testControlHost),
+            eq("default"),
+            argThat { yaml ->
+                yaml.contains("amazon/aws-cli:latest") &&
+                    yaml.contains("aws s3 sync") &&
+                    yaml.contains("/mnt/db1/victorialogs") &&
+                    yaml.contains("s3://easy-db-lab-test-bucket/victorialogs/")
+            },
+        )
+    }
+
+    @Test
+    fun `backupLogs generates correct S3 path format`() {
+        // Given - capture the YAML to verify the S3 path format
+        var capturedYaml: String? = null
+        whenever(mockK8sService.createJob(any(), any(), any()))
+            .thenAnswer { invocation ->
+                capturedYaml = invocation.getArgument(2)
+                Result.failure<String>(RuntimeException("Test: stop after createJob"))
+            }
+
+        // When
+        victoriaBackupService.backupLogs(testControlHost, testClusterState)
+
+        // Then - verify S3 path format in the job YAML
+        assertThat(capturedYaml).contains("s3://easy-db-lab-test-bucket/victorialogs/")
+        // Verify timestamp format in job name (YYYYMMDD-HHMMSS)
+        assertThat(capturedYaml).containsPattern("name: vlbackup-\\d{8}-\\d{6}")
+    }
+
+    @Test
+    fun `backupLogs calls createJob with aws-cli image`() {
+        // Given - mock createJob to fail early
+        whenever(mockK8sService.createJob(any(), any(), any()))
+            .thenReturn(Result.failure(RuntimeException("Test: stop after createJob")))
+
+        // When
+        victoriaBackupService.backupLogs(testControlHost, testClusterState)
+
+        // Then - verify createJob was called with correct image
+        verify(mockK8sService).createJob(
+            eq(testControlHost),
+            eq("default"),
+            argThat { yaml -> yaml.contains("amazon/aws-cli:latest") },
+        )
+    }
+
+    @Test
+    fun `backupLogs handles API errors gracefully`() {
+        // Given
+        whenever(mockK8sService.createJob(any(), any(), any()))
+            .thenReturn(Result.failure(RuntimeException("K8s API error")))
+
+        // When
+        val result = victoriaBackupService.backupLogs(testControlHost, testClusterState)
+
+        // Then
+        assertThat(result.isFailure).isTrue()
+        assertThat(result.exceptionOrNull()?.message).contains("K8s API error")
+    }
+
+    @Test
+    fun `backupLogs fails when S3 bucket not configured`() {
+        // Given
+        val stateWithoutBucket = testClusterState.copy(s3Bucket = null)
+
+        // When
+        val result = victoriaBackupService.backupLogs(testControlHost, stateWithoutBucket)
+
+        // Then
+        assertThat(result.isFailure).isTrue()
+        assertThat(result.exceptionOrNull()?.message).contains("S3 bucket not configured")
+    }
+
+    // ========== CUSTOM DESTINATION TESTS ==========
+
+    @Test
+    fun `backupMetrics uses custom destination when provided`() {
+        // Given - just mock createJob to capture the YAML
+        var capturedYaml: String? = null
+        whenever(mockK8sService.createJob(any(), any(), any()))
+            .thenAnswer { invocation ->
+                capturedYaml = invocation.getArgument(2)
+                Result.failure<String>(RuntimeException("Test: stop after createJob"))
+            }
+        val customDest = "s3://custom-backup-bucket/my-backups"
+
+        // When
+        victoriaBackupService.backupMetrics(testControlHost, testClusterState, customDest)
+
+        // Then - verify the YAML contains the custom destination
+        assertThat(capturedYaml).contains("s3://custom-backup-bucket/my-backups/")
+    }
+
+    @Test
+    fun `backupMetrics uses cluster bucket when dest is null`() {
+        // Given - just mock createJob to capture the YAML
+        var capturedYaml: String? = null
+        whenever(mockK8sService.createJob(any(), any(), any()))
+            .thenAnswer { invocation ->
+                capturedYaml = invocation.getArgument(2)
+                Result.failure<String>(RuntimeException("Test: stop after createJob"))
+            }
+
+        // When
+        victoriaBackupService.backupMetrics(testControlHost, testClusterState, null)
+
+        // Then - verify the YAML contains the cluster bucket
+        assertThat(capturedYaml).contains("s3://easy-db-lab-test-bucket/victoriametrics/")
+    }
+
+    @Test
+    fun `backupLogs uses custom destination when provided`() {
+        // Given - just mock createJob to capture the YAML
+        var capturedYaml: String? = null
+        whenever(mockK8sService.createJob(any(), any(), any()))
+            .thenAnswer { invocation ->
+                capturedYaml = invocation.getArgument(2)
+                Result.failure<String>(RuntimeException("Test: stop after createJob"))
+            }
+        val customDest = "s3://other-bucket/logs-backup"
+
+        // When
+        victoriaBackupService.backupLogs(testControlHost, testClusterState, customDest)
+
+        // Then - verify the YAML contains the custom destination
+        assertThat(capturedYaml).contains("s3://other-bucket/logs-backup/")
+    }
+
+    @Test
+    fun `backupLogs uses cluster bucket when dest is null`() {
+        // Given - just mock createJob to capture the YAML
+        var capturedYaml: String? = null
+        whenever(mockK8sService.createJob(any(), any(), any()))
+            .thenAnswer { invocation ->
+                capturedYaml = invocation.getArgument(2)
+                Result.failure<String>(RuntimeException("Test: stop after createJob"))
+            }
+
+        // When
+        victoriaBackupService.backupLogs(testControlHost, testClusterState, null)
+
+        // Then - verify the YAML contains the cluster bucket
+        assertThat(capturedYaml).contains("s3://easy-db-lab-test-bucket/victorialogs/")
+    }
+
+    // ========== PARSE S3 URI TESTS ==========
+
+    @Test
+    fun `parseS3Uri handles bucket-only URI`() {
+        // Given
+        val service = victoriaBackupService as DefaultVictoriaBackupService
+        val uri = "s3://my-bucket"
+        val timestamp = "20240101-120000"
+
+        // When
+        val (bucket, s3Path) = service.parseS3Uri(uri, timestamp)
+
+        // Then
+        assertThat(bucket).isEqualTo("my-bucket")
+        assertThat(s3Path.toString()).isEqualTo("s3://my-bucket/$timestamp")
+    }
+
+    @Test
+    fun `parseS3Uri handles bucket with path`() {
+        // Given
+        val service = victoriaBackupService as DefaultVictoriaBackupService
+        val uri = "s3://my-bucket/some/path"
+        val timestamp = "20240101-120000"
+
+        // When
+        val (bucket, s3Path) = service.parseS3Uri(uri, timestamp)
+
+        // Then
+        assertThat(bucket).isEqualTo("my-bucket")
+        assertThat(s3Path.toString()).isEqualTo("s3://my-bucket/some/path/$timestamp")
+    }
+
+    @Test
+    fun `parseS3Uri handles trailing slash in path`() {
+        // Given
+        val service = victoriaBackupService as DefaultVictoriaBackupService
+        val uri = "s3://my-bucket/some/path/"
+        val timestamp = "20240101-120000"
+
+        // When
+        val (bucket, s3Path) = service.parseS3Uri(uri, timestamp)
+
+        // Then
+        assertThat(bucket).isEqualTo("my-bucket")
+        assertThat(s3Path.toString()).isEqualTo("s3://my-bucket/some/path/$timestamp")
+    }
+
+    @Test
+    fun `parseS3Uri rejects non-S3 URI`() {
+        // Given
+        val service = victoriaBackupService as DefaultVictoriaBackupService
+        val uri = "https://example.com/bucket"
+        val timestamp = "20240101-120000"
+
+        // When/Then
+        val exception =
+            org.junit.jupiter.api.assertThrows<IllegalArgumentException> {
+                service.parseS3Uri(uri, timestamp)
+            }
+        assertThat(exception.message).contains("Destination must be an S3 URI")
+    }
+
+    // ========== HELPER METHODS ==========
+}


### PR DESCRIPTION
Add backup commands for VictoriaMetrics and VictoriaLogs that create Kubernetes Jobs to backup data to S3.

Features:
- `easy-db-lab metrics backup` - Backs up VictoriaMetrics using vmbackup
- `easy-db-lab logs backup` - Backs up VictoriaLogs using aws s3 sync
- Support for custom S3 destination via --dest flag
- Backups stored at s3://{bucket}/victoriametrics/{timestamp}/ and s3://{bucket}/victorialogs/{timestamp}/

Implementation:
- VictoriaBackupService with K8s Job-based backup execution
- ClusterS3Path extensions for Victoria paths
- Graceful error handling for missing control nodes
- AWS_REGION environment variable for proper S3 authentication

Also includes:
- Fix devcontainer Docker build issues
- Documentation updates for backup functionality