### PR TITLE
Fix VPC restore crash and add instance type to /status nodes

### DIFF
--- a/src/main/kotlin/com/rustyrazorblade/easydblab/mcp/StatusCache.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/mcp/StatusCache.kt
@@ -273,6 +273,7 @@ class StatusCache(
                 privateIp = host.privateIp,
                 availabilityZone = host.availabilityZone,
                 state = instanceStates[host.instanceId]?.state?.uppercase(),
+                instanceType = instanceStates[host.instanceId]?.instanceType,
             )
         }
 

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/mcp/StatusResponse.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/mcp/StatusResponse.kt
@@ -36,6 +36,7 @@ data class NodeInfo(
     val privateIp: String,
     val availabilityZone: String,
     val state: String? = null,
+    val instanceType: String? = null,
 )
 
 @Serializable

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/providers/aws/EC2InstanceService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/providers/aws/EC2InstanceService.kt
@@ -329,6 +329,7 @@ class EC2InstanceService(
                     publicIp = instance.publicIpAddress(),
                     privateIp = instance.privateIpAddress(),
                     availabilityZone = instance.placement().availabilityZone(),
+                    instanceType = instance.instanceType()?.toString(),
                 )
             }
         }

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/providers/aws/InstanceTypes.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/providers/aws/InstanceTypes.kt
@@ -78,6 +78,7 @@ data class CreatedInstance(
  * @property publicIp Public IP address (may be null if stopped)
  * @property privateIp Private IP address (may be null if terminated)
  * @property availabilityZone AWS availability zone
+ * @property instanceType EC2 instance type (e.g., "r3.2xlarge")
  */
 data class InstanceDetails(
     val instanceId: InstanceId,
@@ -85,6 +86,7 @@ data class InstanceDetails(
     val publicIp: String?,
     val privateIp: String?,
     val availabilityZone: String,
+    val instanceType: String? = null,
 )
 
 /**

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/commands/StatusTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/commands/StatusTest.kt
@@ -454,6 +454,7 @@ class StatusTest : BaseKoinTest() {
                     publicIp = "54.1.2.3",
                     privateIp = "10.0.1.100",
                     availabilityZone = "us-west-2a",
+                    instanceType = "r3.2xlarge",
                 ),
                 InstanceDetails(
                     instanceId = "i-db1",
@@ -461,6 +462,7 @@ class StatusTest : BaseKoinTest() {
                     publicIp = "54.1.2.4",
                     privateIp = "10.0.1.101",
                     availabilityZone = "us-west-2b",
+                    instanceType = "r3.2xlarge",
                 ),
                 InstanceDetails(
                     instanceId = "i-app0",
@@ -468,6 +470,7 @@ class StatusTest : BaseKoinTest() {
                     publicIp = "54.2.3.4",
                     privateIp = "10.0.2.100",
                     availabilityZone = "us-west-2a",
+                    instanceType = "m5.xlarge",
                 ),
                 InstanceDetails(
                     instanceId = "i-control0",
@@ -475,6 +478,7 @@ class StatusTest : BaseKoinTest() {
                     publicIp = "54.3.4.5",
                     privateIp = "10.0.3.100",
                     availabilityZone = "us-west-2a",
+                    instanceType = "m5.xlarge",
                 ),
             )
 

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/mcp/StatusCacheTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/mcp/StatusCacheTest.kt
@@ -117,6 +117,7 @@ class StatusCacheTest : BaseKoinTest() {
                     publicIp = "54.1.2.3",
                     privateIp = "10.0.1.100",
                     availabilityZone = "us-west-2a",
+                    instanceType = "r3.2xlarge",
                 ),
                 InstanceDetails(
                     instanceId = "i-control0",
@@ -124,6 +125,7 @@ class StatusCacheTest : BaseKoinTest() {
                     publicIp = "54.1.2.4",
                     privateIp = "10.0.1.200",
                     availabilityZone = "us-west-2a",
+                    instanceType = "m5.xlarge",
                 ),
             ),
         )
@@ -215,6 +217,20 @@ class StatusCacheTest : BaseKoinTest() {
     }
 
     @Test
+    fun `node instanceType is populated from EC2`() {
+        statusCache = StatusCache(refreshIntervalSeconds = 3600)
+        statusCache.forceRefresh()
+
+        val result = statusCache.getStatus("nodes")
+        val nodes = Json.parseToJsonElement(result!!).jsonObject
+        val dbNodes = nodes["database"]!!.toString()
+        val controlNodes = nodes["control"]!!.toString()
+
+        assertThat(dbNodes).contains("r3.2xlarge")
+        assertThat(controlNodes).contains("m5.xlarge")
+    }
+
+    @Test
     fun `networking section contains infrastructure data`() {
         statusCache = StatusCache(refreshIntervalSeconds = 3600)
         statusCache.forceRefresh()
@@ -301,6 +317,7 @@ class StatusCacheTest : BaseKoinTest() {
                     publicIp = null,
                     privateIp = "10.0.1.100",
                     availabilityZone = "us-west-2a",
+                    instanceType = "r3.2xlarge",
                 ),
                 InstanceDetails(
                     instanceId = "i-control0",
@@ -308,6 +325,7 @@ class StatusCacheTest : BaseKoinTest() {
                     publicIp = null,
                     privateIp = "10.0.1.200",
                     availabilityZone = "us-west-2a",
+                    instanceType = "m5.xlarge",
                 ),
             ),
         )


### PR DESCRIPTION
Handle FileAlreadyExistsException in S3ObjectStore.downloadFile() by catching SdkClientException and walking the cause chain. When the target file already exists, return the existing file info instead of crashing.

Add instanceType field to InstanceDetails, NodeInfo, and wire it through EC2InstanceService.describeInstances() and StatusCache.buildNodeList() so the /status endpoint includes EC2 instance type per node.