### PR TITLE
Add Grafana Image Renderer sidecar for server-side panel rendering

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -266,6 +266,8 @@ User documentation is in `docs/` (mdbook format). When making user-facing change
 
 Product specifications live in `openspec/specs/` and are managed via the **OpenSpec workflow** (skills: `openspec-propose`, `openspec-explore`, `openspec-apply-change`, `openspec-archive-change`). Use OpenSpec to propose, implement, and track changes against specs. Specs are the source of truth for product decisions — consult them when making changes to determine if there are conflicts, and plan spec updates before moving on to implementation.
 
+After running `openspec-apply-change`, use the `simplify` skill to review and improve the code quality of the changes.
+
 If I refer to Kubernetes configs or k8 configs, I am referring to these: `src/main/resources/com/rustyrazorblade/easydblab/commands/k8s/` by default.
 
 ## Observability

--- a/openspec/changes/archive/2026-03-06-grafana-image-renderer/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-06-grafana-image-renderer/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-06

--- a/openspec/changes/archive/2026-03-06-grafana-image-renderer/design.md
+++ b/openspec/changes/archive/2026-03-06-grafana-image-renderer/design.md
@@ -1,0 +1,39 @@
+## Context
+
+Grafana runs as a single-container pod on the control node with `hostNetwork: true`. The `GrafanaManifestBuilder` builds the deployment using Fabric8. The image renderer is a separate process that Grafana calls via HTTP to render panels as PNG images. Grafana officially supports this via the `grafana/grafana-image-renderer` Docker image running as a sidecar.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Deploy the Grafana Image Renderer as a sidecar container in the existing Grafana pod
+- Configure Grafana to use the renderer for server-side image rendering
+- Ensure the renderer is included in integration tests
+
+**Non-Goals:**
+- Adding new CLI commands or MCP tools to consume rendered images
+- Customizing renderer settings beyond defaults (Chrome flags, timeouts, etc.)
+
+## Decisions
+
+### Sidecar container in the Grafana pod (not a separate deployment)
+
+The renderer needs fast, low-latency communication with Grafana. Running it in the same pod means they share the host network and communicate over localhost. This avoids needing a separate K8s Service or DNS resolution. It also ensures the renderer lifecycle is tied to Grafana's.
+
+Alternative: Separate Deployment + Service. Rejected because it adds unnecessary complexity for a component that only serves Grafana.
+
+### Communication via localhost on port 8081
+
+Since the pod uses `hostNetwork: true`, both containers bind to the host's network stack. Grafana connects to the renderer at `http://localhost:8081`. The renderer's default port is 8081, which doesn't conflict with any existing service on the control node.
+
+Grafana is configured via:
+- `GF_RENDERING_SERVER_URL=http://localhost:8081/render`
+- `GF_RENDERING_CALLBACK_URL=http://localhost:3000/`
+
+### No resource limits
+
+Consistent with the project's no-resource-limits policy. The control node has sufficient memory for Chromium rendering.
+
+## Risks / Trade-offs
+
+- **Chromium memory usage** — The renderer runs headless Chromium, which can use significant memory for complex dashboards. Mitigation: control nodes are sized for observability workloads, and no resource limits are set per project policy.
+- **Startup time** — Chromium takes a few seconds to initialize. Mitigation: the renderer has its own readiness state; Grafana will retry if rendering fails during startup.

--- a/openspec/changes/archive/2026-03-06-grafana-image-renderer/proposal.md
+++ b/openspec/changes/archive/2026-03-06-grafana-image-renderer/proposal.md
@@ -1,0 +1,22 @@
+## Why
+
+The observability stack includes Grafana dashboards for monitoring cluster health, but there's no way to programmatically retrieve dashboard panel images. Adding the Grafana Image Renderer enables server-side rendering of panel snapshots via Grafana's rendering API, which is a prerequisite for features like alerting with embedded images and direct link sharing of panel screenshots.
+
+## What Changes
+
+- Deploy `grafana/grafana-image-renderer` as a sidecar container alongside Grafana in the same pod
+- Configure Grafana to use the image renderer plugin via environment variables
+
+## Capabilities
+
+### New Capabilities
+- `grafana-image-rendering`: Server-side rendering of Grafana dashboard panels as PNG images, including the renderer sidecar deployment and Grafana configuration to use it
+
+### Modified Capabilities
+- `observability`: Grafana deployment now includes an image renderer sidecar container
+
+## Impact
+
+- `GrafanaManifestBuilder` — add renderer sidecar container to the Grafana pod
+- `GrafanaUpdateConfig` command — renderer deploys automatically with Grafana (no new command needed)
+- K8s integration tests — updated to cover the new container

--- a/openspec/changes/archive/2026-03-06-grafana-image-renderer/specs/grafana-image-rendering/spec.md
+++ b/openspec/changes/archive/2026-03-06-grafana-image-renderer/specs/grafana-image-rendering/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: Grafana Image Renderer Sidecar
+
+The system SHALL deploy the `grafana/grafana-image-renderer` container as a sidecar in the Grafana pod, enabling server-side rendering of dashboard panels as PNG images.
+
+#### Scenario: Renderer container runs alongside Grafana
+
+- **WHEN** the Grafana deployment is applied to the cluster
+- **THEN** the pod SHALL contain a `grafana-image-renderer` container using the `grafana/grafana-image-renderer:latest` image
+- **AND** the renderer SHALL listen on port 8081
+
+#### Scenario: Grafana is configured to use the renderer
+
+- **WHEN** the Grafana container starts
+- **THEN** the environment variable `GF_RENDERING_SERVER_URL` SHALL be set to `http://localhost:8081/render`
+- **AND** the environment variable `GF_RENDERING_CALLBACK_URL` SHALL be set to `http://localhost:3000/`
+
+#### Scenario: Panel image rendering via Grafana API
+
+- **WHEN** a client requests a panel render via Grafana's `/render/d-solo/` HTTP API
+- **THEN** Grafana SHALL delegate rendering to the sidecar and return a PNG image

--- a/openspec/changes/archive/2026-03-06-grafana-image-renderer/specs/observability/spec.md
+++ b/openspec/changes/archive/2026-03-06-grafana-image-renderer/specs/observability/spec.md
@@ -1,0 +1,31 @@
+## MODIFIED Requirements
+
+### Requirement: Grafana Dashboards
+
+The system MUST provide pre-configured Grafana dashboards for all supported databases and infrastructure. Dashboard titles MUST use simple descriptive names without cluster name prefixes. The Grafana pod SHALL include an image renderer sidecar for server-side panel rendering.
+
+#### Scenario: Dashboard titles use descriptive names
+
+- **WHEN** the user views the Grafana dashboard list
+- **THEN** each dashboard title is a simple descriptive name (e.g., "System Overview", "EMR Overview", "Profiling") without any cluster name prefix
+
+#### Scenario: EMR dashboard shows OTel host metrics
+
+- **WHEN** the user views the EMR dashboard in Grafana
+- **THEN** the dashboard displays CPU, memory, disk, and network metrics from OTel host metrics collected on Spark/EMR nodes
+
+#### Scenario: EMR dashboard shows Spark JVM metrics
+
+- **WHEN** the user views the EMR dashboard in Grafana
+- **THEN** the dashboard displays JVM heap usage, GC activity, and thread metrics from the OTel Java agent on Spark driver/executors
+
+#### Scenario: System Overview dashboard hostname filter includes all node types
+
+- **WHEN** the user views the System Overview dashboard in Grafana
+- **THEN** the hostname filter SHALL list hosts from all node types: db, app, control, and spark
+- **AND** the service filter SHALL list all node_role values present in metrics
+
+#### Scenario: Grafana pod includes image renderer sidecar
+
+- **WHEN** the Grafana deployment is applied
+- **THEN** the pod SHALL contain both the Grafana container and a `grafana-image-renderer` sidecar container

--- a/openspec/changes/archive/2026-03-06-grafana-image-renderer/tasks.md
+++ b/openspec/changes/archive/2026-03-06-grafana-image-renderer/tasks.md
@@ -1,0 +1,14 @@
+## 1. Add Image Renderer Sidecar to GrafanaManifestBuilder
+
+- [x] 1.1 Add `grafana/grafana-image-renderer:latest` image constant to GrafanaManifestBuilder
+- [x] 1.2 Add renderer sidecar container to the Grafana pod in `buildDeployment()` — port 8081, no resource limits
+- [x] 1.3 Add `GF_RENDERING_SERVER_URL` and `GF_RENDERING_CALLBACK_URL` environment variables to the Grafana container
+
+## 2. Testing
+
+- [x] 2.1 Update GrafanaManifestBuilder unit test to verify the deployment has two containers and the renderer env vars are set
+- [x] 2.2 Update K8sServiceIntegrationTest to include an image pull test for `grafana/grafana-image-renderer:latest`
+
+## 3. Documentation
+
+- [x] 3.1 Update `configuration/CLAUDE.md` to mention the image renderer sidecar in the Grafana section

--- a/openspec/specs/grafana-image-rendering/spec.md
+++ b/openspec/specs/grafana-image-rendering/spec.md
@@ -1,0 +1,20 @@
+### Requirement: Grafana Image Renderer Sidecar
+
+The system SHALL deploy the `grafana/grafana-image-renderer` container as a sidecar in the Grafana pod, enabling server-side rendering of dashboard panels as PNG images.
+
+#### Scenario: Renderer container runs alongside Grafana
+
+- **WHEN** the Grafana deployment is applied to the cluster
+- **THEN** the pod SHALL contain a `grafana-image-renderer` container using the `grafana/grafana-image-renderer:latest` image
+- **AND** the renderer SHALL listen on port 8081
+
+#### Scenario: Grafana is configured to use the renderer
+
+- **WHEN** the Grafana container starts
+- **THEN** the environment variable `GF_RENDERING_SERVER_URL` SHALL be set to `http://localhost:8081/render`
+- **AND** the environment variable `GF_RENDERING_CALLBACK_URL` SHALL be set to `http://localhost:3000/`
+
+#### Scenario: Panel image rendering via Grafana API
+
+- **WHEN** a client requests a panel render via Grafana's `/render/d-solo/` HTTP API
+- **THEN** Grafana SHALL delegate rendering to the sidecar and return a PNG image

--- a/openspec/specs/observability/spec.md
+++ b/openspec/specs/observability/spec.md
@@ -43,7 +43,7 @@ The system MUST support continuous profiling for cluster workloads including Spa
 
 ### Requirement: Grafana Dashboards
 
-The system MUST provide pre-configured Grafana dashboards for all supported databases and infrastructure. Dashboard titles MUST use simple descriptive names without cluster name prefixes.
+The system MUST provide pre-configured Grafana dashboards for all supported databases and infrastructure. Dashboard titles MUST use simple descriptive names without cluster name prefixes. The Grafana pod SHALL include an image renderer sidecar for server-side panel rendering.
 
 #### Scenario: Dashboard titles use descriptive names
 
@@ -65,6 +65,11 @@ The system MUST provide pre-configured Grafana dashboards for all supported data
 - **WHEN** the user views the System Overview dashboard in Grafana
 - **THEN** the hostname filter SHALL list hosts from all node types: db, app, control, and spark
 - **AND** the service filter SHALL list all node_role values present in metrics
+
+#### Scenario: Grafana pod includes image renderer sidecar
+
+- **WHEN** the Grafana deployment is applied
+- **THEN** the pod SHALL contain both the Grafana container and a `grafana-image-renderer` sidecar container
 
 ## ADDED Requirements
 

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/CLAUDE.md
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/CLAUDE.md
@@ -165,7 +165,7 @@ val result = template.substitute(mapOf("EXTRA" to "value"))  // extra vars overr
 All Grafana K8s resources are built programmatically using Fabric8:
 
 - **`GrafanaDashboard`** — enum registry of all dashboards. Single source of truth for dashboard metadata (configMapName, volumeName, mountPath, resourcePath, optional flag). Adding a new dashboard = add an enum entry + drop a JSON file.
-- **`GrafanaManifestBuilder`** — builds all Grafana K8s resources (provisioning ConfigMap, dashboard ConfigMaps, Deployment) as typed Fabric8 objects. Uses `TemplateService` for `__KEY__` variable substitution in dashboard JSON.
+- **`GrafanaManifestBuilder`** — builds all Grafana K8s resources (provisioning ConfigMap, dashboard ConfigMaps, Deployment) as typed Fabric8 objects. Uses `TemplateService` for `__KEY__` variable substitution in dashboard JSON. The Deployment includes a `grafana-image-renderer` sidecar container (port 8081) for server-side panel rendering.
 - **`GrafanaDatasourceConfig`** — datasource provisioning YAML generation.
 - **Dashboard JSON files** — stored in `resources/.../configuration/grafana/dashboards/*.json`. Raw JSON with `__KEY__` template placeholders.
 

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/grafana/GrafanaManifestBuilder.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/grafana/GrafanaManifestBuilder.kt
@@ -34,7 +34,9 @@ class GrafanaManifestBuilder(
         private const val NAMESPACE = "default"
         private const val APP_LABEL = "grafana"
         private const val GRAFANA_IMAGE = "grafana/grafana:latest"
+        private const val IMAGE_RENDERER_IMAGE = "grafana/grafana-image-renderer:latest"
         private const val GRAFANA_PORT = 3000
+        private const val IMAGE_RENDERER_PORT = 8081
         private const val PROVISIONING_CONFIGMAP_NAME = "grafana-dashboards-config"
         private const val DATASOURCES_VOLUME = "datasources"
         private const val DASHBOARDS_CONFIG_VOLUME = "dashboards-config"
@@ -156,7 +158,7 @@ class GrafanaManifestBuilder(
                     .withFsGroup(FS_GROUP)
                     .withRunAsUser(RUN_AS_USER)
                     .build(),
-            ).withContainers(buildGrafanaContainer(clusterName))
+            ).withContainers(buildGrafanaContainer(clusterName), buildImageRendererContainer())
             .withVolumes(buildVolumes())
             .endSpec()
             .endTemplate()
@@ -201,6 +203,16 @@ class GrafanaManifestBuilder(
             .withInitialDelaySeconds(READINESS_INITIAL_DELAY)
             .withPeriodSeconds(READINESS_PERIOD)
             .endReadinessProbe()
+            .build()
+
+    private fun buildImageRendererContainer(): Container =
+        ContainerBuilder()
+            .withName("grafana-image-renderer")
+            .withImage(IMAGE_RENDERER_IMAGE)
+            .addNewPort()
+            .withContainerPort(IMAGE_RENDERER_PORT)
+            .withProtocol("TCP")
+            .endPort()
             .build()
 
     private fun buildVolumeMounts(): List<VolumeMount> {
@@ -286,6 +298,8 @@ class GrafanaManifestBuilder(
                 "GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH",
                 "${GrafanaDashboard.SYSTEM.mountPath}/${GrafanaDashboard.SYSTEM.jsonFileName}",
             ),
+            envVar("GF_RENDERING_SERVER_URL", "http://localhost:$IMAGE_RENDERER_PORT/render"),
+            envVar("GF_RENDERING_CALLBACK_URL", "http://localhost:$GRAFANA_PORT/"),
         )
 
     private fun envVar(

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/configuration/grafana/GrafanaManifestBuilderTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/configuration/grafana/GrafanaManifestBuilderTest.kt
@@ -75,6 +75,30 @@ class GrafanaManifestBuilderTest : BaseKoinTest() {
     }
 
     @Test
+    fun `buildDeployment includes grafana and image renderer containers`() {
+        val deployment = builder.buildDeployment()
+        val containers = deployment.spec.template.spec.containers
+
+        assertThat(containers).hasSize(2)
+        assertThat(containers.map { it.name }).containsExactly("grafana", "grafana-image-renderer")
+    }
+
+    @Test
+    fun `buildDeployment rendering env vars reference correct ports`() {
+        val deployment = builder.buildDeployment()
+        val containers = deployment.spec.template.spec.containers
+        val grafanaContainer = containers.first { it.name == "grafana" }
+        val rendererContainer = containers.first { it.name == "grafana-image-renderer" }
+
+        val rendererPort = rendererContainer.ports.first().containerPort
+        val grafanaPort = grafanaContainer.ports.first().containerPort
+        val envMap = grafanaContainer.env.associate { it.name to it.value }
+
+        assertThat(envMap["GF_RENDERING_SERVER_URL"]).contains(":$rendererPort/")
+        assertThat(envMap["GF_RENDERING_CALLBACK_URL"]).contains(":$grafanaPort/")
+    }
+
+    @Test
     fun `buildDeployment includes volume mounts for all dashboards`() {
         val deployment = builder.buildDeployment()
         val container =


### PR DESCRIPTION
Deploy grafana/grafana-image-renderer as a sidecar container in the Grafana pod, enabling server-side rendering of dashboard panels as PNG images via Grafana's rendering API.