### PR TITLE
Add spark stop command to cancel running EMR jobs

### DIFF
--- a/bin/spark-bulk-write
+++ b/bin/spark-bulk-write
@@ -23,6 +23,7 @@
 #   --compaction <name>   Compaction strategy (e.g., LeveledCompactionStrategy)
 #   --skip-ddl            Skip keyspace/table creation
 #   --s3-bucket <bucket>  S3 bucket for S3 job type (default: from cluster config)
+#   --concurrent-writes <num>  Concurrent writes per executor (connector only, default: Spark Cassandra Connector default)
 #   --no-wait             Don't wait for job completion
 #   --build               Force rebuild of bulk-writer JAR
 #
@@ -52,6 +53,7 @@ PARALLELISM="10"
 PARTITION_COUNT="10000"
 REPLICATION_FACTOR="1"
 COMPACTION=""
+CONCURRENT_WRITES=""
 SKIP_DDL="false"
 S3_BUCKET=""
 WAIT="--wait"
@@ -96,6 +98,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --compaction)
             COMPACTION="$2"
+            shift 2
+            ;;
+        --concurrent-writes)
+            CONCURRENT_WRITES="$2"
             shift 2
             ;;
         --skip-ddl)
@@ -269,6 +275,7 @@ echo "  Parallelism: $PARALLELISM"
 echo "  Partition Count: $PARTITION_COUNT"
 echo "  Replication Factor: $REPLICATION_FACTOR"
 echo "  Compaction: ${COMPACTION:-default}"
+echo "  Concurrent Writes: ${CONCURRENT_WRITES:-(not set)}"
 echo "  Skip DDL: $SKIP_DDL"
 
 # Build conf options based on job type
@@ -315,6 +322,10 @@ fi
 
 if [ -n "$COMPACTION" ]; then
     CONF_OPTS="$CONF_OPTS --conf spark.easydblab.compaction=$COMPACTION"
+fi
+
+if [ -n "$CONCURRENT_WRITES" ]; then
+    CONF_OPTS="$CONF_OPTS --conf spark.cassandra.output.concurrent.writes=$CONCURRENT_WRITES"
 fi
 
 echo ""

--- a/docs/user-guide/spark.md
+++ b/docs/user-guide/spark.md
@@ -102,6 +102,22 @@ easy-db-lab spark submit \
 
 This skips the upload step entirely, which is useful for large JARs or when resubmitting the same job.
 
+## Cancelling a Job
+
+Cancel a running or pending Spark job without terminating the cluster:
+
+```bash
+easy-db-lab spark stop
+```
+
+Without `--step-id`, this cancels the most recent job. To cancel a specific job:
+
+```bash
+easy-db-lab spark stop --step-id <step-id>
+```
+
+The cancellation uses EMR's `TERMINATE_PROCESS` strategy (SIGKILL). The API is asynchronous — use `spark status` to confirm the job has been cancelled.
+
 ## Checking Job Status
 
 ### View Recent Jobs

--- a/openspec/changes/spark-stop-job/.openspec.yaml
+++ b/openspec/changes/spark-stop-job/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-06

--- a/openspec/changes/spark-stop-job/design.md
+++ b/openspec/changes/spark-stop-job/design.md
@@ -1,0 +1,44 @@
+## Context
+
+The `spark` command group currently supports job submission (`submit`), monitoring (`status`, `jobs`), log viewing (`logs`), cluster init/teardown (`init`, `down`), but has no way to cancel individual jobs. Users must terminate the entire EMR cluster to stop a running job.
+
+AWS EMR provides the `CancelSteps` API (available since EMR 5.28.0) which can cancel PENDING or RUNNING steps without affecting the cluster.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Allow users to cancel a specific Spark job by step ID
+- Default to cancelling the most recent job (matching `spark status` pattern)
+- Provide clear feedback on cancellation result
+
+**Non-Goals:**
+- Bulk cancellation of multiple jobs at once
+- Automatic cancellation on CLI interrupt/SIGINT
+- Waiting for the cancellation to fully complete (the API is async)
+
+## Decisions
+
+### 1. Command name: `spark stop`
+
+Use `spark stop` rather than `spark cancel` or `spark kill`. The codebase already uses "stop" for lifecycle operations (e.g., `cassandra stop`, `stress stop`), and it aligns with the existing naming convention.
+
+**Alternative**: `spark cancel` — more technically accurate to the EMR API name, but inconsistent with the rest of the CLI.
+
+### 2. Cancellation strategy: TERMINATE_PROCESS
+
+Use `TERMINATE_PROCESS` (SIGKILL) rather than `SEND_INTERRUPT` (SIGTERM). Spark jobs that are bulk-writing data are unlikely to have graceful shutdown handlers, so a SIGTERM would just add delay before eventually being killed anyway.
+
+**Alternative**: `SEND_INTERRUPT` — more graceful, but in practice Spark Cassandra Connector and cassandra-analytics writers don't implement graceful shutdown, so this would just add a timeout delay.
+
+### 3. Service interface: add `cancelJob()` to `SparkService`
+
+Add a single method `cancelJob(clusterId: String, stepId: String): Result<CancelJobResult>` to the existing `SparkService` interface. The result includes the step ID and the cancel status returned by EMR (e.g., `SUBMITTED`, `FAILED`).
+
+### 4. Default to most recent job
+
+Follow the same pattern as `SparkStatus`: if no `--step-id` is provided, cancel the most recent job. This is convenient for the common case of "I just submitted a job and want to stop it."
+
+## Risks / Trade-offs
+
+- **[Async cancellation]** → The EMR API is async — the step may not be cancelled immediately. The command will report the API response status, not the final step state. Users can check with `spark status` afterward.
+- **[Already-completed jobs]** → Cancelling a completed/failed job returns a non-error status from EMR (it just reports it can't be cancelled). We'll relay this information to the user.

--- a/openspec/changes/spark-stop-job/proposal.md
+++ b/openspec/changes/spark-stop-job/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+Running Spark jobs on EMR can take a long time (hours for large bulk writes). There is currently no way to cancel a running or pending job from the CLI — the only option is to terminate the entire EMR cluster (`spark down`), which is destructive and wasteful. AWS EMR provides a `CancelSteps` API that allows cancelling individual steps without affecting the cluster.
+
+## What Changes
+
+- Add a `spark stop` command that cancels a running or pending EMR step by step ID
+- Add `cancelJob()` to the `SparkService` interface and implement it in `EMRSparkService` using the AWS `CancelSteps` API
+- If no step ID is provided, cancel the most recent step (matching the pattern used by `spark status`)
+- Add corresponding domain events to `Event.Emr` for user feedback
+- Update user documentation for the `spark` command group
+
+## Capabilities
+
+### New Capabilities
+- `spark-job-cancellation`: Ability to cancel running or pending Spark jobs on EMR without terminating the cluster
+
+### Modified Capabilities
+- `spark-emr`: Add cancellation as a supported job lifecycle operation
+
+## Impact
+
+- **Commands**: New `SparkStop` command in `commands/spark/`
+- **Services**: New method on `SparkService` interface and `EMRSparkService` implementation
+- **Events**: New event types in `Event.Emr` for cancellation feedback
+- **AWS API**: Uses `EmrClient.cancelSteps()` — no new dependencies needed (already in the EMR SDK)
+- **Docs**: Update `docs/` spark command reference

--- a/openspec/changes/spark-stop-job/specs/spark-emr/spec.md
+++ b/openspec/changes/spark-stop-job/specs/spark-emr/spec.md
@@ -1,0 +1,36 @@
+## MODIFIED Requirements
+
+### Requirement: Spark Job Submission
+
+The system MUST support submitting, monitoring, and cancelling Spark jobs on EMR.
+
+#### Scenario: Spark submit includes OTel and Pyroscope Java agents
+
+- **WHEN** a Spark job is submitted via `EMRSparkService`
+- **THEN** `spark.driver.extraJavaOptions` and `spark.executor.extraJavaOptions` include both `-javaagent:/opt/otel/opentelemetry-javaagent.jar` and `-javaagent:/opt/pyroscope/pyroscope.jar` with appropriate system properties
+
+#### Scenario: OTel environment variables exclude endpoint override
+
+- **WHEN** a Spark job is submitted via `EMRSparkService`
+- **THEN** the following environment variables are set on driver and executor JVMs:
+  - `OTEL_LOGS_EXPORTER=otlp`
+  - `OTEL_METRICS_EXPORTER=otlp`
+  - `OTEL_TRACES_EXPORTER=otlp`
+  - `OTEL_SERVICE_NAME=spark-<job-name>`
+- **AND** `OTEL_EXPORTER_OTLP_ENDPOINT` is NOT set (Java agent defaults to localhost:4317)
+
+#### Scenario: Spark logs available via OTel and S3
+
+- **WHEN** a Spark job completes or fails
+- **THEN** logs are available both via OTel (VictoriaLogs, queryable by `service.name`) and via S3 log download (existing fallback mechanism)
+
+#### Scenario: Bootstrap actions include control node IP
+
+- **WHEN** `EMRService.createCluster()` is called
+- **THEN** bootstrap actions from `EMRClusterConfig.bootstrapActions` are attached to the `RunJobFlowRequest` with the control node IP as a script argument
+
+#### Scenario: SparkService supports job cancellation
+
+- **WHEN** `cancelJob()` is called on the `SparkService` interface
+- **THEN** the implementation MUST call the EMR `CancelSteps` API with `TERMINATE_PROCESS` strategy
+- **AND** return the cancellation status for the step

--- a/openspec/changes/spark-stop-job/specs/spark-job-cancellation/spec.md
+++ b/openspec/changes/spark-stop-job/specs/spark-job-cancellation/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: Cancel a running or pending Spark job
+
+The system SHALL provide a `spark stop` CLI command that cancels a running or pending EMR step without terminating the cluster.
+
+#### Scenario: Cancel a specific job by step ID
+
+- **WHEN** the user runs `spark stop --step-id s-XXXXX`
+- **THEN** the system MUST call the EMR `CancelSteps` API with `TERMINATE_PROCESS` strategy for that step
+- **AND** emit an event with the step ID and the cancellation status returned by EMR
+
+#### Scenario: Cancel the most recent job
+
+- **WHEN** the user runs `spark stop` without a `--step-id`
+- **THEN** the system MUST resolve the most recent step on the cluster (same as `spark status` default)
+- **AND** cancel that step using the EMR `CancelSteps` API
+
+#### Scenario: Cluster validation before cancellation
+
+- **WHEN** the user runs `spark stop`
+- **THEN** the system MUST validate the EMR cluster exists and is accessible before attempting cancellation
+- **AND** fail with an error if the cluster is not found or in an invalid state
+
+#### Scenario: Report cancellation result
+
+- **WHEN** the EMR `CancelSteps` API returns a response
+- **THEN** the system MUST display the step ID and the cancel status (e.g., `SUBMITTED`, `FAILED`)
+- **AND** display the reason if the cancellation failed (e.g., step already completed)

--- a/openspec/changes/spark-stop-job/tasks.md
+++ b/openspec/changes/spark-stop-job/tasks.md
@@ -1,0 +1,25 @@
+## 1. Service Layer
+
+- [x] 1.1 Add `CancelJobResult` data class to `SparkService` (stepId, status, reason)
+- [x] 1.2 Add `cancelJob(clusterId: String, stepId: String): Result<CancelJobResult>` to `SparkService` interface
+- [x] 1.3 Implement `cancelJob()` in `EMRSparkService` using `EmrClient.cancelSteps()` with `TERMINATE_PROCESS` strategy and resilience4j retry
+
+## 2. Events
+
+- [x] 2.1 Add `Event.Emr.JobCancelling(stepId)` event
+- [x] 2.2 Add `Event.Emr.JobCancelled(stepId, status, reason)` event
+
+## 3. Command
+
+- [x] 3.1 Create `SparkStop` command with `--step-id` option (defaults to most recent job, following `SparkStatus` pattern)
+- [x] 3.2 Register `SparkStop` in `Spark.kt` parent command subcommands list
+- [x] 3.3 Update `Spark.kt` KDoc to include `stop` in the available sub-commands list
+
+## 4. Tests
+
+- [x] 4.1 Unit test `SparkStop` command (validates cluster, resolves most recent step when no step-id provided, calls cancelJob)
+- [x] 4.2 Unit test `EMRSparkService.cancelJob()` (correct API call construction, result mapping)
+
+## 5. Documentation
+
+- [x] 5.1 Update spark command documentation in `docs/` to include `spark stop`

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/spark/Spark.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/spark/Spark.kt
@@ -8,13 +8,14 @@ import picocli.CommandLine.Spec
  * Parent command for Spark EMR cluster operations.
  *
  * This command serves as a container for Spark-related sub-commands including
- * cluster provisioning, job submission, status checking, and job listing.
+ * cluster provisioning, job submission, cancellation, status checking, and job listing.
  * When invoked without a sub-command, it displays usage help.
  *
  * Available sub-commands:
  * - init: Provision a Spark EMR cluster on an existing environment
  * - down: Terminate the Spark EMR cluster
  * - submit: Submit a Spark job to the EMR cluster
+ * - stop: Cancel a running or pending Spark job
  * - status: Check the status of a Spark job (defaults to most recent)
  * - jobs: List recent Spark jobs on the cluster
  * - logs: View logs from a Spark job
@@ -27,6 +28,7 @@ import picocli.CommandLine.Spec
         SparkInit::class,
         SparkDown::class,
         SparkSubmit::class,
+        SparkStop::class,
         SparkStatus::class,
         SparkJobs::class,
         SparkLogs::class,

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/spark/SparkStop.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/spark/SparkStop.kt
@@ -1,0 +1,74 @@
+package com.rustyrazorblade.easydblab.commands.spark
+
+import com.rustyrazorblade.easydblab.annotations.McpCommand
+import com.rustyrazorblade.easydblab.annotations.RequireProfileSetup
+import com.rustyrazorblade.easydblab.commands.PicoBaseCommand
+import com.rustyrazorblade.easydblab.events.Event
+import com.rustyrazorblade.easydblab.services.SparkService
+import org.koin.core.component.inject
+import picocli.CommandLine.Command
+import picocli.CommandLine.Option
+
+/**
+ * Cancel a running or pending Spark job on the EMR cluster.
+ *
+ * This command cancels an EMR step using the CancelSteps API with TERMINATE_PROCESS
+ * strategy. If no step ID is provided, it cancels the most recent job.
+ *
+ * Usage:
+ * - `spark stop` - Cancels the most recent job
+ * - `spark stop --step-id s-XXXXX` - Cancels a specific job
+ */
+@McpCommand
+@RequireProfileSetup
+@Command(
+    name = "stop",
+    description = ["Cancel a running or pending Spark job"],
+)
+class SparkStop : PicoBaseCommand() {
+    private val sparkService: SparkService by inject()
+
+    @Option(
+        names = ["--step-id"],
+        description = ["EMR step ID (defaults to most recent job)"],
+    )
+    var stepId: String? = null
+
+    override fun execute() {
+        val clusterInfo =
+            sparkService
+                .validateCluster()
+                .getOrElse { error ->
+                    error(error.message ?: "Failed to validate EMR cluster")
+                }
+
+        val targetStepId =
+            stepId ?: getMostRecentStepId(clusterInfo.clusterId)
+
+        eventBus.emit(Event.Emr.JobCancelling(targetStepId))
+
+        val result =
+            sparkService
+                .cancelJob(clusterInfo.clusterId, targetStepId)
+                .getOrElse { error ->
+                    error(error.message ?: "Failed to cancel job")
+                }
+
+        eventBus.emit(Event.Emr.JobCancelled(result.stepId, result.status, result.reason))
+    }
+
+    private fun getMostRecentStepId(clusterId: String): String {
+        val jobs =
+            sparkService
+                .listJobs(clusterId, limit = 1)
+                .getOrElse { error ->
+                    error(error.message ?: "Failed to list jobs")
+                }
+
+        if (jobs.isEmpty()) {
+            error("No jobs found on cluster $clusterId")
+        }
+
+        return jobs.first().stepId
+    }
+}

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/events/Event.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/events/Event.kt
@@ -1126,6 +1126,28 @@ sealed interface Event {
         }
 
         @Serializable
+        @SerialName("Emr.JobCancelling")
+        data class JobCancelling(
+            val stepId: String,
+        ) : Emr {
+            override fun toDisplayString(): String = "Cancelling job: $stepId..."
+        }
+
+        @Serializable
+        @SerialName("Emr.JobCancelled")
+        data class JobCancelled(
+            val stepId: String,
+            val status: String,
+            val reason: String? = null,
+        ) : Emr {
+            override fun toDisplayString(): String =
+                buildString {
+                    append("Cancel result for $stepId: $status")
+                    reason?.let { append(" ($it)") }
+                }
+        }
+
+        @Serializable
         @SerialName("Emr.SparkStepDetails")
         data class SparkStepDetails(
             val stepId: String,

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/SparkService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/SparkService.kt
@@ -301,6 +301,34 @@ interface SparkService {
         CONTROLLER("controller.gz"),
     }
 
+    /**
+     * Cancels a running or pending Spark job step on the EMR cluster.
+     *
+     * This uses the EMR CancelSteps API with TERMINATE_PROCESS strategy.
+     * The API is asynchronous — the step may not be cancelled immediately.
+     *
+     * @param clusterId The EMR cluster ID
+     * @param stepId The EMR step ID to cancel
+     * @return Result containing the CancelJobResult with status and reason
+     */
+    fun cancelJob(
+        clusterId: String,
+        stepId: String,
+    ): Result<CancelJobResult>
+
+    /**
+     * Result of a job cancellation request.
+     *
+     * @property stepId The EMR step ID that was targeted
+     * @property status The cancel status (e.g., SUBMITTED, FAILED)
+     * @property reason Optional reason if cancellation failed
+     */
+    data class CancelJobResult(
+        val stepId: String,
+        val status: String,
+        val reason: String? = null,
+    )
+
     companion object {
         const val DEFAULT_JOB_LIST_LIMIT = 10
     }

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/aws/EMRSparkService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/aws/EMRSparkService.kt
@@ -15,9 +15,11 @@ import io.github.resilience4j.retry.Retry
 import software.amazon.awssdk.services.emr.EmrClient
 import software.amazon.awssdk.services.emr.model.ActionOnFailure
 import software.amazon.awssdk.services.emr.model.AddJobFlowStepsRequest
+import software.amazon.awssdk.services.emr.model.CancelStepsRequest
 import software.amazon.awssdk.services.emr.model.DescribeStepRequest
 import software.amazon.awssdk.services.emr.model.HadoopJarStepConfig
 import software.amazon.awssdk.services.emr.model.ListStepsRequest
+import software.amazon.awssdk.services.emr.model.StepCancellationOption
 import software.amazon.awssdk.services.emr.model.StepConfig
 import software.amazon.awssdk.services.emr.model.StepState
 import java.nio.file.Files
@@ -411,6 +413,36 @@ class EMRSparkService(
                         )
                     }
             }
+        }
+
+    override fun cancelJob(
+        clusterId: String,
+        stepId: String,
+    ): Result<SparkService.CancelJobResult> =
+        runCatching {
+            val request =
+                CancelStepsRequest
+                    .builder()
+                    .clusterId(clusterId)
+                    .stepIds(stepId)
+                    .stepCancellationOption(StepCancellationOption.TERMINATE_PROCESS)
+                    .build()
+
+            val cancelInfo =
+                executeWithRetry("emr-cancel-step") {
+                    val response = emrClient.cancelSteps(request)
+                    val results = response.cancelStepsInfoList()
+                    require(results.isNotEmpty()) {
+                        "EMR returned no cancellation results for step $stepId"
+                    }
+                    results.first()
+                }
+
+            SparkService.CancelJobResult(
+                stepId = cancelInfo.stepId(),
+                status = cancelInfo.status()?.toString() ?: "UNKNOWN",
+                reason = cancelInfo.reason(),
+            )
         }
 
     override fun getStepLogs(

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/commands/spark/SparkStopTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/commands/spark/SparkStopTest.kt
@@ -1,0 +1,147 @@
+package com.rustyrazorblade.easydblab.commands.spark
+
+import com.rustyrazorblade.easydblab.BaseKoinTest
+import com.rustyrazorblade.easydblab.configuration.EMRClusterInfo
+import com.rustyrazorblade.easydblab.services.SparkService
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.koin.core.module.Module
+import org.koin.dsl.module
+import org.koin.test.get
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import software.amazon.awssdk.services.emr.model.StepState
+import java.time.Instant
+
+class SparkStopTest : BaseKoinTest() {
+    private lateinit var mockSparkService: SparkService
+
+    override fun additionalTestModules(): List<Module> =
+        listOf(
+            module {
+                single {
+                    mock<SparkService>().also {
+                        mockSparkService = it
+                    }
+                }
+            },
+        )
+
+    private fun initMocks() {
+        get<SparkService>()
+    }
+
+    private val validClusterInfo =
+        EMRClusterInfo(
+            clusterId = "j-TEST123",
+            name = "test-cluster",
+            masterPublicDns = "master.example.com",
+            state = "WAITING",
+        )
+
+    @Test
+    fun `execute should fail when cluster validation fails`() {
+        initMocks()
+
+        val command = SparkStop()
+
+        whenever(mockSparkService.validateCluster())
+            .thenReturn(Result.failure(IllegalStateException("No EMR cluster found")))
+
+        assertThatThrownBy { command.execute() }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("No EMR cluster found")
+    }
+
+    @Test
+    fun `execute with explicit step-id should cancel that step`() {
+        initMocks()
+
+        val command = SparkStop()
+        command.stepId = "s-EXPLICIT123"
+
+        val cancelResult =
+            SparkService.CancelJobResult(
+                stepId = "s-EXPLICIT123",
+                status = "SUBMITTED",
+            )
+
+        whenever(mockSparkService.validateCluster()).thenReturn(Result.success(validClusterInfo))
+        whenever(mockSparkService.cancelJob(eq("j-TEST123"), eq("s-EXPLICIT123")))
+            .thenReturn(Result.success(cancelResult))
+
+        command.execute()
+
+        verify(mockSparkService, never()).listJobs(any(), any())
+        verify(mockSparkService).cancelJob(eq("j-TEST123"), eq("s-EXPLICIT123"))
+    }
+
+    @Test
+    fun `execute without step-id should cancel most recent job`() {
+        initMocks()
+
+        val command = SparkStop()
+        command.stepId = null
+
+        val jobs =
+            listOf(
+                SparkService.JobInfo(
+                    stepId = "s-RECENT123",
+                    name = "Most Recent Job",
+                    state = StepState.RUNNING,
+                    startTime = Instant.now(),
+                ),
+            )
+
+        val cancelResult =
+            SparkService.CancelJobResult(
+                stepId = "s-RECENT123",
+                status = "SUBMITTED",
+            )
+
+        whenever(mockSparkService.validateCluster()).thenReturn(Result.success(validClusterInfo))
+        whenever(mockSparkService.listJobs(eq("j-TEST123"), eq(1))).thenReturn(Result.success(jobs))
+        whenever(mockSparkService.cancelJob(eq("j-TEST123"), eq("s-RECENT123")))
+            .thenReturn(Result.success(cancelResult))
+
+        command.execute()
+
+        verify(mockSparkService).listJobs(eq("j-TEST123"), eq(1))
+        verify(mockSparkService).cancelJob(eq("j-TEST123"), eq("s-RECENT123"))
+    }
+
+    @Test
+    fun `execute without step-id should fail when no jobs exist`() {
+        initMocks()
+
+        val command = SparkStop()
+        command.stepId = null
+
+        whenever(mockSparkService.validateCluster()).thenReturn(Result.success(validClusterInfo))
+        whenever(mockSparkService.listJobs(eq("j-TEST123"), eq(1))).thenReturn(Result.success(emptyList()))
+
+        assertThatThrownBy { command.execute() }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("No jobs found")
+    }
+
+    @Test
+    fun `execute should fail when cancelJob fails`() {
+        initMocks()
+
+        val command = SparkStop()
+        command.stepId = "s-STEP123"
+
+        whenever(mockSparkService.validateCluster()).thenReturn(Result.success(validClusterInfo))
+        whenever(mockSparkService.cancelJob(any(), any()))
+            .thenReturn(Result.failure(RuntimeException("Cancel failed")))
+
+        assertThatThrownBy { command.execute() }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("Cancel failed")
+    }
+}

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/services/EMRSparkServiceTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/services/EMRSparkServiceTest.kt
@@ -21,11 +21,16 @@ import org.mockito.kotlin.whenever
 import software.amazon.awssdk.services.emr.EmrClient
 import software.amazon.awssdk.services.emr.model.AddJobFlowStepsRequest
 import software.amazon.awssdk.services.emr.model.AddJobFlowStepsResponse
+import software.amazon.awssdk.services.emr.model.CancelStepsInfo
+import software.amazon.awssdk.services.emr.model.CancelStepsRequest
+import software.amazon.awssdk.services.emr.model.CancelStepsRequestStatus
+import software.amazon.awssdk.services.emr.model.CancelStepsResponse
 import software.amazon.awssdk.services.emr.model.DescribeStepRequest
 import software.amazon.awssdk.services.emr.model.DescribeStepResponse
 import software.amazon.awssdk.services.emr.model.EmrException
 import software.amazon.awssdk.services.emr.model.FailureDetails
 import software.amazon.awssdk.services.emr.model.Step
+import software.amazon.awssdk.services.emr.model.StepCancellationOption
 import software.amazon.awssdk.services.emr.model.StepState
 import software.amazon.awssdk.services.emr.model.StepStateChangeReason
 import software.amazon.awssdk.services.emr.model.StepStatus
@@ -579,6 +584,92 @@ class EMRSparkServiceTest : BaseKoinTest() {
         // Then
         assertThat(result.isSuccess).isTrue()
         assertThat(result.getOrNull()?.state).isEqualTo(StepState.COMPLETED)
+    }
+
+    // ========== CANCEL JOB TESTS ==========
+
+    @Test
+    fun `cancelJob should call CancelSteps API with TERMINATE_PROCESS and return result`() {
+        // Given
+        val cancelInfo =
+            CancelStepsInfo
+                .builder()
+                .stepId(testStepId)
+                .status(CancelStepsRequestStatus.SUBMITTED)
+                .build()
+
+        val cancelResponse =
+            CancelStepsResponse
+                .builder()
+                .cancelStepsInfoList(cancelInfo)
+                .build()
+
+        val captor = argumentCaptor<CancelStepsRequest>()
+        whenever(mockEmrClient.cancelSteps(captor.capture())).thenReturn(cancelResponse)
+
+        // When
+        val result = sparkService.cancelJob(testClusterId, testStepId)
+
+        // Then
+        assertThat(result.isSuccess).isTrue()
+        val cancelResult = result.getOrNull()!!
+        assertThat(cancelResult.stepId).isEqualTo(testStepId)
+        assertThat(cancelResult.status).isEqualTo("SUBMITTED")
+
+        // Verify the request used TERMINATE_PROCESS strategy
+        val request = captor.firstValue
+        assertThat(request.clusterId()).isEqualTo(testClusterId)
+        assertThat(request.stepIds()).containsExactly(testStepId)
+        assertThat(request.stepCancellationOption()).isEqualTo(StepCancellationOption.TERMINATE_PROCESS)
+    }
+
+    @Test
+    fun `cancelJob should return failure reason when step cannot be cancelled`() {
+        // Given
+        val cancelInfo =
+            CancelStepsInfo
+                .builder()
+                .stepId(testStepId)
+                .status(CancelStepsRequestStatus.FAILED)
+                .reason("Step is already completed")
+                .build()
+
+        val cancelResponse =
+            CancelStepsResponse
+                .builder()
+                .cancelStepsInfoList(cancelInfo)
+                .build()
+
+        whenever(mockEmrClient.cancelSteps(any<CancelStepsRequest>())).thenReturn(cancelResponse)
+
+        // When
+        val result = sparkService.cancelJob(testClusterId, testStepId)
+
+        // Then
+        assertThat(result.isSuccess).isTrue()
+        val cancelResult = result.getOrNull()!!
+        assertThat(cancelResult.status).isEqualTo("FAILED")
+        assertThat(cancelResult.reason).isEqualTo("Step is already completed")
+    }
+
+    @Test
+    fun `cancelJob should return failure when EMR API throws exception`() {
+        // Given
+        whenever(mockEmrClient.cancelSteps(any<CancelStepsRequest>()))
+            .thenThrow(
+                EmrException
+                    .builder()
+                    .message("Cluster not found")
+                    .statusCode(404)
+                    .build(),
+            )
+
+        // When
+        val result = sparkService.cancelJob(testClusterId, testStepId)
+
+        // Then
+        assertThat(result.isFailure).isTrue()
+        assertThat(result.exceptionOrNull()).isInstanceOf(EmrException::class.java)
     }
 
     // ========== EMR API ERROR TESTS ==========


### PR DESCRIPTION
Add `spark stop` command that cancels running or pending EMR steps using the CancelSteps API with TERMINATE_PROCESS strategy, without terminating the cluster. Defaults to cancelling the most recent job.

Also adds --concurrent-writes option to spark-bulk-write script for passing spark.cassandra.output.concurrent.writes to connector jobs.