### PR TITLE
Add inspektor-gadget and Headlamp with inspektor-gadget plugin

### DIFF
--- a/src/main/kotlin/com/rustyrazorblade/easydblab/Constants.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/Constants.kt
@@ -206,6 +206,7 @@ object Constants {
         const val BEYLA_METRICS_PORT = 9400
         const val EBPF_EXPORTER_METRICS_PORT = 9435
         const val MAAC_METRICS_PORT = 9000
+        const val HEADLAMP_PORT = 4466
         const val OTEL_GRPC_PORT = 4317
         const val OTEL_HTTP_PORT = 4318
         const val OTEL_HEALTH_PORT = 13133

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/grafana/GrafanaUpdateConfig.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/grafana/GrafanaUpdateConfig.kt
@@ -7,6 +7,8 @@ import com.rustyrazorblade.easydblab.configuration.ClusterHost
 import com.rustyrazorblade.easydblab.configuration.ServerType
 import com.rustyrazorblade.easydblab.configuration.User
 import com.rustyrazorblade.easydblab.configuration.beyla.BeylaManifestBuilder
+import com.rustyrazorblade.easydblab.configuration.headlamp.HeadlampManifestBuilder
+import com.rustyrazorblade.easydblab.configuration.inspektorgadget.InspektorGadgetManifestBuilder
 import com.rustyrazorblade.easydblab.configuration.clusterPrefix
 import com.rustyrazorblade.easydblab.configuration.ebpfexporter.EbpfExporterManifestBuilder
 import com.rustyrazorblade.easydblab.configuration.otel.JournaldOtelManifestBuilder
@@ -40,6 +42,8 @@ import picocli.CommandLine.Command
  * - Beyla (L7 network eBPF metrics)
  * - ebpf_exporter (TCP, block I/O, VFS eBPF metrics)
  * - Pyroscope (continuous profiling server + eBPF agent)
+ * - inspektor-gadget (eBPF-based kernel tracing and inspection)
+ * - Headlamp (Kubernetes web UI with inspektor-gadget plugin, port 4466)
  * - Grafana with pre-configured dashboards
  * - Docker registry and S3 manager
  */
@@ -64,6 +68,8 @@ class GrafanaUpdateConfig : PicoBaseCommand() {
     private val beylaManifestBuilder: BeylaManifestBuilder by inject()
     private val pyroscopeManifestBuilder: PyroscopeManifestBuilder by inject()
     private val yaceManifestBuilder: YaceManifestBuilder by inject()
+    private val inspektorGadgetManifestBuilder: InspektorGadgetManifestBuilder by inject()
+    private val headlampManifestBuilder: HeadlampManifestBuilder by inject()
 
     companion object {
         private const val CLUSTER_CONFIG_NAME = "cluster-config"
@@ -92,6 +98,8 @@ class GrafanaUpdateConfig : PicoBaseCommand() {
         applyFabric8Resources("S3 Manager", controlNode, s3ManagerManifestBuilder.buildAllResources())
         applyFabric8Resources("Beyla", controlNode, beylaManifestBuilder.buildAllResources())
         applyFabric8Resources("YACE", controlNode, yaceManifestBuilder.buildAllResources())
+        applyFabric8Resources("inspektor-gadget", controlNode, inspektorGadgetManifestBuilder.buildAllResources())
+        applyFabric8Resources("Headlamp", controlNode, headlampManifestBuilder.buildAllResources())
 
         // Apply Pyroscope resources (requires directory setup via SSH first)
         applyPyroscopeResources(controlNode)
@@ -108,8 +116,8 @@ class GrafanaUpdateConfig : PicoBaseCommand() {
     private fun restartObservabilityWorkloads(controlNode: ClusterHost) {
         eventBus.emit(Event.Grafana.WorkloadsRestarting)
 
-        val deployments = listOf("victoria-metrics", "victoria-logs", "tempo", "pyroscope", "grafana")
-        val daemonSets = listOf("otel-collector", "fluent-bit-journald", "beyla", "ebpf-exporter", "pyroscope-ebpf")
+        val deployments = listOf("victoria-metrics", "victoria-logs", "tempo", "pyroscope", "grafana", "headlamp")
+        val daemonSets = listOf("otel-collector", "fluent-bit-journald", "beyla", "ebpf-exporter", "pyroscope-ebpf", "inspektor-gadget")
 
         for (name in deployments) {
             k8sService

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/CLAUDE.md
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/CLAUDE.md
@@ -231,3 +231,11 @@ See `spec/PYROSCOPE.md` for full architecture details and debugging steps.
 - **`YaceManifestBuilder`** — builds YACE (Yet Another CloudWatch Exporter) ConfigMap + Deployment. Runs on control plane, scrapes AWS CloudWatch metrics for S3, EBS, EC2, and OpenSearch services. Exposes Prometheus metrics on port 5001, scraped by OTel collector. (EMR metrics removed — replaced by direct OTel collection on Spark nodes.)
 - **Config resource** — `yace-config.yaml` stored in `resources/.../configuration/yace/` with `__AWS_REGION__` template variable for region substitution.
 - **Auto-discovery** — uses tag-based auto-discovery with the `easy_cass_lab=1` tag to find cluster resources in CloudWatch.
+
+## inspektor-gadget Subpackage (`inspektorgadget/`)
+
+- **`InspektorGadgetManifestBuilder`** — builds inspektor-gadget ServiceAccount, ClusterRole, ClusterRoleBinding, and DaemonSet. Runs on all nodes with hostNetwork/hostPID/privileged for eBPF kernel-level tracing. The `ig` daemon runs with `--runtimes=containerd` for K3s compatibility. RBAC grants read access to pods, nodes, namespaces, and full access to gadget.kinvolk.io CRDs. No TemplateService needed. Image: `ghcr.io/inspektor-gadget/inspektor-gadget`.
+
+## Headlamp Subpackage (`headlamp/`)
+
+- **`HeadlampManifestBuilder`** — builds Headlamp Kubernetes web UI with the inspektor-gadget plugin. Creates ServiceAccount, ClusterRole (read-only access to all K8s resources), ClusterRoleBinding, ClusterIP Service, and Deployment. Runs on the control plane (port 4466) with hostNetwork and Recreate strategy. An init container (`node:20-alpine`) installs the `@inspektor-gadget/headlamp-plugin` npm package via `npx @kinvolk/headlamp-plugin install` into a shared emptyDir volume at `/headlamp/plugins`. No TemplateService needed. Image: `ghcr.io/headlamp-k8s/headlamp`.

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/headlamp/HeadlampManifestBuilder.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/headlamp/HeadlampManifestBuilder.kt
@@ -1,0 +1,203 @@
+package com.rustyrazorblade.easydblab.configuration.headlamp
+
+import com.rustyrazorblade.easydblab.Constants
+import io.fabric8.kubernetes.api.model.EmptyDirVolumeSourceBuilder
+import io.fabric8.kubernetes.api.model.HasMetadata
+import io.fabric8.kubernetes.api.model.ServiceAccountBuilder
+import io.fabric8.kubernetes.api.model.ServiceBuilder
+import io.fabric8.kubernetes.api.model.VolumeMountBuilder
+import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder
+import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBindingBuilder
+import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBuilder
+
+/**
+ * Builds all Headlamp K8s resources as typed Fabric8 objects.
+ *
+ * Headlamp is a Kubernetes web UI that runs on the control plane.
+ * It includes the inspektor-gadget headlamp plugin, installed via an init container,
+ * which provides a UI for running eBPF gadgets directly from the browser.
+ *
+ * The init container installs the plugin from npm using the headlamp-plugin CLI,
+ * placing it in the shared plugins volume at /headlamp/plugins.
+ *
+ * Accessible at http://<control-node-ip>:4466
+ */
+class HeadlampManifestBuilder {
+    companion object {
+        private const val NAMESPACE = "default"
+        private const val APP_LABEL = "headlamp"
+        private const val IMAGE = "ghcr.io/headlamp-k8s/headlamp:v0.26.0"
+        private const val PLUGIN_INSTALLER_IMAGE = "node:20-alpine"
+        private const val SERVICE_ACCOUNT_NAME = "headlamp"
+        private const val CLUSTER_ROLE_NAME = "headlamp"
+        const val PORT = Constants.K8s.HEADLAMP_PORT
+        private const val PLUGINS_DIR = "/headlamp/plugins"
+        private const val INSPEKTOR_GADGET_PLUGIN = "@inspektor-gadget/headlamp-plugin"
+    }
+
+    /**
+     * Builds all Headlamp K8s resources in apply order.
+     *
+     * @return List of: ServiceAccount, ClusterRole, ClusterRoleBinding, Service, Deployment
+     */
+    fun buildAllResources(): List<HasMetadata> =
+        listOf(
+            buildServiceAccount(),
+            buildClusterRole(),
+            buildClusterRoleBinding(),
+            buildService(),
+            buildDeployment(),
+        )
+
+    /**
+     * Builds the ServiceAccount for Headlamp pods.
+     */
+    fun buildServiceAccount() =
+        ServiceAccountBuilder()
+            .withNewMetadata()
+            .withName(SERVICE_ACCOUNT_NAME)
+            .withNamespace(NAMESPACE)
+            .addToLabels("app.kubernetes.io/name", APP_LABEL)
+            .endMetadata()
+            .build()
+
+    /**
+     * Builds the ClusterRole granting Headlamp read access to all K8s resources.
+     * Required to display cluster resources in the Headlamp dashboard.
+     */
+    fun buildClusterRole() =
+        ClusterRoleBuilder()
+            .withNewMetadata()
+            .withName(CLUSTER_ROLE_NAME)
+            .addToLabels("app.kubernetes.io/name", APP_LABEL)
+            .endMetadata()
+            .addNewRule()
+            .withApiGroups("*")
+            .withResources("*")
+            .withVerbs("get", "list", "watch")
+            .endRule()
+            .build()
+
+    /**
+     * Builds the ClusterRoleBinding linking the ServiceAccount to the ClusterRole.
+     */
+    fun buildClusterRoleBinding() =
+        ClusterRoleBindingBuilder()
+            .withNewMetadata()
+            .withName(CLUSTER_ROLE_NAME)
+            .addToLabels("app.kubernetes.io/name", APP_LABEL)
+            .endMetadata()
+            .withNewRoleRef()
+            .withApiGroup("rbac.authorization.k8s.io")
+            .withKind("ClusterRole")
+            .withName(CLUSTER_ROLE_NAME)
+            .endRoleRef()
+            .addNewSubject()
+            .withKind("ServiceAccount")
+            .withName(SERVICE_ACCOUNT_NAME)
+            .withNamespace(NAMESPACE)
+            .endSubject()
+            .build()
+
+    /**
+     * Builds the Headlamp ClusterIP Service.
+     */
+    fun buildService() =
+        ServiceBuilder()
+            .withNewMetadata()
+            .withName(APP_LABEL)
+            .withNamespace(NAMESPACE)
+            .addToLabels("app.kubernetes.io/name", APP_LABEL)
+            .endMetadata()
+            .withNewSpec()
+            .withType("ClusterIP")
+            .addNewPort()
+            .withName("http")
+            .withPort(PORT)
+            .withNewTargetPort(PORT)
+            .withProtocol("TCP")
+            .endPort()
+            .addToSelector("app.kubernetes.io/name", APP_LABEL)
+            .endSpec()
+            .build()
+
+    /**
+     * Builds the Headlamp Deployment.
+     *
+     * Runs on the control plane with hostNetwork and Recreate strategy.
+     * An init container installs the inspektor-gadget headlamp plugin into a shared
+     * plugins volume, which the main container mounts at /headlamp/plugins.
+     */
+    @Suppress("LongMethod")
+    fun buildDeployment() =
+        DeploymentBuilder()
+            .withNewMetadata()
+            .withName(APP_LABEL)
+            .withNamespace(NAMESPACE)
+            .addToLabels("app.kubernetes.io/name", APP_LABEL)
+            .endMetadata()
+            .withNewSpec()
+            .withReplicas(1)
+            .withNewSelector()
+            .addToMatchLabels("app.kubernetes.io/name", APP_LABEL)
+            .endSelector()
+            .withNewStrategy()
+            .withType("Recreate")
+            .withRollingUpdate(null)
+            .endStrategy()
+            .withNewTemplate()
+            .withNewMetadata()
+            .addToLabels("app.kubernetes.io/name", APP_LABEL)
+            .endMetadata()
+            .withNewSpec()
+            .withServiceAccountName(SERVICE_ACCOUNT_NAME)
+            .withHostNetwork(true)
+            .withDnsPolicy("ClusterFirstWithHostNet")
+            .addToNodeSelector("node-role.kubernetes.io/control-plane", "true")
+            .addNewToleration()
+            .withKey("node-role.kubernetes.io/control-plane")
+            .withOperator("Exists")
+            .withEffect("NoSchedule")
+            .endToleration()
+            .addNewInitContainer()
+            .withName("install-plugins")
+            .withImage(PLUGIN_INSTALLER_IMAGE)
+            .withCommand("sh", "-c")
+            .withArgs(
+                "npx --yes @kinvolk/headlamp-plugin install $INSPEKTOR_GADGET_PLUGIN " +
+                    "--dest $PLUGINS_DIR",
+            ).addToVolumeMounts(
+                VolumeMountBuilder()
+                    .withName("plugins")
+                    .withMountPath(PLUGINS_DIR)
+                    .build(),
+            ).endInitContainer()
+            .addNewContainer()
+            .withName(APP_LABEL)
+            .withImage(IMAGE)
+            .withArgs(
+                "-in-cluster",
+                "-plugins-dir=$PLUGINS_DIR",
+                "-listen-addr=0.0.0.0:$PORT",
+            ).addNewPort()
+            .withContainerPort(PORT)
+            .withHostPort(PORT)
+            .withProtocol("TCP")
+            .withName("http")
+            .endPort()
+            .addToVolumeMounts(
+                VolumeMountBuilder()
+                    .withName("plugins")
+                    .withMountPath(PLUGINS_DIR)
+                    .withReadOnly(true)
+                    .build(),
+            ).endContainer()
+            .addNewVolume()
+            .withName("plugins")
+            .withEmptyDir(EmptyDirVolumeSourceBuilder().build())
+            .endVolume()
+            .endSpec()
+            .endTemplate()
+            .endSpec()
+            .build()
+}

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/inspektorgadget/InspektorGadgetManifestBuilder.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/inspektorgadget/InspektorGadgetManifestBuilder.kt
@@ -1,0 +1,220 @@
+package com.rustyrazorblade.easydblab.configuration.inspektorgadget
+
+import io.fabric8.kubernetes.api.model.HasMetadata
+import io.fabric8.kubernetes.api.model.HostPathVolumeSourceBuilder
+import io.fabric8.kubernetes.api.model.SecurityContextBuilder
+import io.fabric8.kubernetes.api.model.ServiceAccountBuilder
+import io.fabric8.kubernetes.api.model.VolumeMountBuilder
+import io.fabric8.kubernetes.api.model.apps.DaemonSetBuilder
+import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBindingBuilder
+import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBuilder
+
+/**
+ * Builds all inspektor-gadget K8s resources as typed Fabric8 objects.
+ *
+ * inspektor-gadget provides eBPF-based kernel-level tracing and inspection gadgets
+ * for Kubernetes pods and nodes. The `ig` daemon runs on every node and exposes
+ * gadget functionality via the K8s API using gadget.kinvolk.io CRDs.
+ *
+ * Requires privileged mode, hostPID, and hostNetwork for eBPF access.
+ */
+class InspektorGadgetManifestBuilder {
+    companion object {
+        private const val NAMESPACE = "default"
+        private const val APP_LABEL = "inspektor-gadget"
+        private const val IMAGE = "ghcr.io/inspektor-gadget/inspektor-gadget:v0.35.0"
+        private const val SERVICE_ACCOUNT_NAME = "inspektor-gadget"
+        private const val CLUSTER_ROLE_NAME = "inspektor-gadget"
+    }
+
+    /**
+     * Builds all inspektor-gadget K8s resources in apply order.
+     *
+     * @return List of: ServiceAccount, ClusterRole, ClusterRoleBinding, DaemonSet
+     */
+    fun buildAllResources(): List<HasMetadata> =
+        listOf(
+            buildServiceAccount(),
+            buildClusterRole(),
+            buildClusterRoleBinding(),
+            buildDaemonSet(),
+        )
+
+    /**
+     * Builds the ServiceAccount for inspektor-gadget pods.
+     */
+    fun buildServiceAccount() =
+        ServiceAccountBuilder()
+            .withNewMetadata()
+            .withName(SERVICE_ACCOUNT_NAME)
+            .withNamespace(NAMESPACE)
+            .addToLabels("app.kubernetes.io/name", APP_LABEL)
+            .endMetadata()
+            .build()
+
+    /**
+     * Builds the ClusterRole granting inspektor-gadget access to pods, nodes,
+     * namespaces, and gadget-related custom resources.
+     */
+    fun buildClusterRole() =
+        ClusterRoleBuilder()
+            .withNewMetadata()
+            .withName(CLUSTER_ROLE_NAME)
+            .addToLabels("app.kubernetes.io/name", APP_LABEL)
+            .endMetadata()
+            .addNewRule()
+            .withApiGroups("")
+            .withResources("pods", "nodes", "namespaces", "services", "endpoints")
+            .withVerbs("get", "watch", "list")
+            .endRule()
+            .addNewRule()
+            .withApiGroups("")
+            .withResources("events")
+            .withVerbs("get", "list", "watch", "create", "patch", "update")
+            .endRule()
+            .addNewRule()
+            .withApiGroups("gadget.kinvolk.io")
+            .withResources("*")
+            .withVerbs("get", "list", "watch", "create", "patch", "update", "delete")
+            .endRule()
+            .build()
+
+    /**
+     * Builds the ClusterRoleBinding linking the ServiceAccount to the ClusterRole.
+     */
+    fun buildClusterRoleBinding() =
+        ClusterRoleBindingBuilder()
+            .withNewMetadata()
+            .withName(CLUSTER_ROLE_NAME)
+            .addToLabels("app.kubernetes.io/name", APP_LABEL)
+            .endMetadata()
+            .withNewRoleRef()
+            .withApiGroup("rbac.authorization.k8s.io")
+            .withKind("ClusterRole")
+            .withName(CLUSTER_ROLE_NAME)
+            .endRoleRef()
+            .addNewSubject()
+            .withKind("ServiceAccount")
+            .withName(SERVICE_ACCOUNT_NAME)
+            .withNamespace(NAMESPACE)
+            .endSubject()
+            .build()
+
+    /**
+     * Builds the inspektor-gadget DaemonSet running the `ig` daemon.
+     *
+     * Runs on all nodes with hostNetwork, hostPID, and privileged mode for eBPF access.
+     * Mounts the BPF filesystem, container runtime socket, kernel debug, and proc directories.
+     */
+    @Suppress("LongMethod")
+    fun buildDaemonSet() =
+        DaemonSetBuilder()
+            .withNewMetadata()
+            .withName(APP_LABEL)
+            .withNamespace(NAMESPACE)
+            .addToLabels("app.kubernetes.io/name", APP_LABEL)
+            .endMetadata()
+            .withNewSpec()
+            .withNewSelector()
+            .addToMatchLabels("app.kubernetes.io/name", APP_LABEL)
+            .endSelector()
+            .withNewTemplate()
+            .withNewMetadata()
+            .addToLabels("app.kubernetes.io/name", APP_LABEL)
+            .endMetadata()
+            .withNewSpec()
+            .withServiceAccountName(SERVICE_ACCOUNT_NAME)
+            .withHostNetwork(true)
+            .withHostPID(true)
+            .withDnsPolicy("ClusterFirstWithHostNet")
+            .addNewToleration()
+            .withOperator("Exists")
+            .endToleration()
+            .addNewContainer()
+            .withName(APP_LABEL)
+            .withImage(IMAGE)
+            .withArgs("daemon", "--host", "--runtimes=containerd")
+            .withSecurityContext(
+                SecurityContextBuilder()
+                    .withPrivileged(true)
+                    .withRunAsUser(0L)
+                    .withRunAsGroup(0L)
+                    .build(),
+            ).addToVolumeMounts(
+                VolumeMountBuilder()
+                    .withName("sys-fs-bpf")
+                    .withMountPath("/sys/fs/bpf")
+                    .build(),
+                VolumeMountBuilder()
+                    .withName("sys-kernel-debug")
+                    .withMountPath("/sys/kernel/debug")
+                    .build(),
+                VolumeMountBuilder()
+                    .withName("proc")
+                    .withMountPath("/proc")
+                    .withReadOnly(true)
+                    .build(),
+                VolumeMountBuilder()
+                    .withName("modules")
+                    .withMountPath("/lib/modules")
+                    .withReadOnly(true)
+                    .build(),
+                VolumeMountBuilder()
+                    .withName("containerd-sock")
+                    .withMountPath("/run/containerd/containerd.sock")
+                    .build(),
+                VolumeMountBuilder()
+                    .withName("run")
+                    .withMountPath("/run")
+                    .build(),
+            ).endContainer()
+            .addNewVolume()
+            .withName("sys-fs-bpf")
+            .withHostPath(
+                HostPathVolumeSourceBuilder()
+                    .withPath("/sys/fs/bpf")
+                    .withType("DirectoryOrCreate")
+                    .build(),
+            ).endVolume()
+            .addNewVolume()
+            .withName("sys-kernel-debug")
+            .withHostPath(
+                HostPathVolumeSourceBuilder()
+                    .withPath("/sys/kernel/debug")
+                    .withType("DirectoryOrCreate")
+                    .build(),
+            ).endVolume()
+            .addNewVolume()
+            .withName("proc")
+            .withHostPath(
+                HostPathVolumeSourceBuilder()
+                    .withPath("/proc")
+                    .build(),
+            ).endVolume()
+            .addNewVolume()
+            .withName("modules")
+            .withHostPath(
+                HostPathVolumeSourceBuilder()
+                    .withPath("/lib/modules")
+                    .build(),
+            ).endVolume()
+            .addNewVolume()
+            .withName("containerd-sock")
+            .withHostPath(
+                HostPathVolumeSourceBuilder()
+                    .withPath("/run/containerd/containerd.sock")
+                    .withType("Socket")
+                    .build(),
+            ).endVolume()
+            .addNewVolume()
+            .withName("run")
+            .withHostPath(
+                HostPathVolumeSourceBuilder()
+                    .withPath("/run")
+                    .build(),
+            ).endVolume()
+            .endSpec()
+            .endTemplate()
+            .endSpec()
+            .build()
+}

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/ServicesModule.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/ServicesModule.kt
@@ -5,6 +5,8 @@ import com.rustyrazorblade.easydblab.configuration.ClusterStateManager
 import com.rustyrazorblade.easydblab.configuration.User
 import com.rustyrazorblade.easydblab.configuration.UserConfigProvider
 import com.rustyrazorblade.easydblab.configuration.beyla.BeylaManifestBuilder
+import com.rustyrazorblade.easydblab.configuration.headlamp.HeadlampManifestBuilder
+import com.rustyrazorblade.easydblab.configuration.inspektorgadget.InspektorGadgetManifestBuilder
 import com.rustyrazorblade.easydblab.configuration.clickhouse.ClickHouseManifestBuilder
 import com.rustyrazorblade.easydblab.configuration.ebpfexporter.EbpfExporterManifestBuilder
 import com.rustyrazorblade.easydblab.configuration.grafana.GrafanaManifestBuilder
@@ -59,6 +61,8 @@ val servicesModule =
         factoryOf(::ClickHouseManifestBuilder)
         factoryOf(::BeylaManifestBuilder)
         factoryOf(::EbpfExporterManifestBuilder)
+        factoryOf(::HeadlampManifestBuilder)
+        factoryOf(::InspektorGadgetManifestBuilder)
         factoryOf(::GrafanaManifestBuilder)
         factoryOf(::JournaldOtelManifestBuilder)
         factoryOf(::OtelManifestBuilder)

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/services/K8sServiceIntegrationTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/services/K8sServiceIntegrationTest.kt
@@ -7,6 +7,8 @@ import com.rustyrazorblade.easydblab.configuration.ClusterStateManager
 import com.rustyrazorblade.easydblab.configuration.User
 import com.rustyrazorblade.easydblab.configuration.beyla.BeylaManifestBuilder
 import com.rustyrazorblade.easydblab.configuration.clickhouse.ClickHouseManifestBuilder
+import com.rustyrazorblade.easydblab.configuration.headlamp.HeadlampManifestBuilder
+import com.rustyrazorblade.easydblab.configuration.inspektorgadget.InspektorGadgetManifestBuilder
 import com.rustyrazorblade.easydblab.configuration.ebpfexporter.EbpfExporterManifestBuilder
 import com.rustyrazorblade.easydblab.configuration.grafana.GrafanaDashboard
 import com.rustyrazorblade.easydblab.configuration.grafana.GrafanaManifestBuilder
@@ -324,6 +326,31 @@ class K8sServiceIntegrationTest {
 
         assertConfigMapExists("yace-config", "yace-config.yaml")
         assertDeploymentExists("yace")
+    }
+
+    @Test
+    @Order(20)
+    fun `should apply inspektor-gadget resources`() {
+        val resources = InspektorGadgetManifestBuilder().buildAllResources()
+        applyAndVerify(resources)
+
+        assertServiceAccountExists("inspektor-gadget")
+        assertClusterRoleExists("inspektor-gadget")
+        assertClusterRoleBindingExists("inspektor-gadget")
+        assertDaemonSetExists("inspektor-gadget")
+    }
+
+    @Test
+    @Order(23)
+    fun `should apply Headlamp resources`() {
+        val resources = HeadlampManifestBuilder().buildAllResources()
+        applyAndVerify(resources)
+
+        assertServiceAccountExists("headlamp")
+        assertClusterRoleExists("headlamp")
+        assertClusterRoleBindingExists("headlamp")
+        assertServiceExists("headlamp")
+        assertDeploymentExists("headlamp")
     }
 
     @Test
@@ -745,6 +772,8 @@ class K8sServiceIntegrationTest {
             BeylaManifestBuilder(templateService).buildAllResources() +
             PyroscopeManifestBuilder(templateService).buildAllResources() +
             YaceManifestBuilder(templateService).buildAllResources() +
+            InspektorGadgetManifestBuilder().buildAllResources() +
+            HeadlampManifestBuilder().buildAllResources() +
             GrafanaManifestBuilder(templateService).buildAllResources() +
             ClickHouseManifestBuilder(DefaultClickHouseConfigService()).buildAllResources(
                 totalReplicas = 3,


### PR DESCRIPTION
Closes #384

Adds inspektor-gadget eBPF tracing daemon and Headlamp Kubernetes web UI with the inspektor-gadget plugin.

## Changes

- `InspektorGadgetManifestBuilder`: deploys `ig` daemon as a privileged DaemonSet on all cluster nodes with RBAC and eBPF host mounts
- `HeadlampManifestBuilder`: deploys Headlamp K8s web UI on the control plane (port 4466) with an init container that installs the @inspektor-gadget/headlamp-plugin via npx
- Both builders registered in ServicesModule, wired into GrafanaUpdateConfig, and covered by K8s integration tests

Generated with [Claude Code](https://claude.ai/code)