### PR TITLE
feat: OpenSpec proposal for bcache support (#562)

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -92,6 +92,8 @@ easy-db-lab init [cluster-name] [options]
 | `--vpc` | Use existing VPC ID | - |
 | `--up` | Auto-provision after init | false |
 | `--clean` | Remove existing config first | false |
+| `--bcache` | Enable bcache NVMe caching in front of EBS (requires `--ebs.type` and an instance type with local NVMe) | false |
+| `--bcache.mode` | bcache cache mode: `writethrough` (safe) or `writeback` (higher write performance) | writethrough |
 
 ### up
 

--- a/docs/user-guide/cluster-setup.md
+++ b/docs/user-guide/cluster-setup.md
@@ -56,6 +56,36 @@ If the selected instance type has no instance store and `--ebs.type` is not spec
 easy-db-lab init my-cluster --instance c5.2xlarge --ebs.type gp3 --ebs.size 200
 ```
 
+### bcache: NVMe-Accelerated EBS Storage
+
+The `--bcache` flag configures Linux bcache to use the local NVMe instance store as a transparent cache in front of the EBS volume. This gives you EBS-level persistence with NVMe-level I/O performance for hot data.
+
+**Prerequisites:**
+
+- The database instance type must have local NVMe instance store (e.g., `i3.xlarge`, `i4i.xlarge`, `m5d.2xlarge`).
+- `--ebs.type` must be set to a non-NONE value — EBS is the backing device.
+
+```bash
+easy-db-lab init my-cluster --instance i4i.xlarge --ebs.type gp3 --ebs.size 500 --bcache
+```
+
+**Cache modes:**
+
+| Mode | Description | When to use |
+|------|-------------|-------------|
+| `writethrough` (default) | Writes go to both NVMe and EBS before acknowledgement. No data loss risk. | Most workloads |
+| `writeback` | Writes acknowledged after NVMe cache only, flushed to EBS asynchronously. Higher write throughput. | Maximum write performance, ephemeral test data |
+
+```bash
+# High-performance writeback mode
+easy-db-lab init my-cluster --instance i4i.xlarge --ebs.type gp3 --ebs.size 500 --bcache --bcache.mode=writeback
+```
+
+**Caveats:**
+
+- bcache configuration is **not persistent across reboots**. If a cluster node is rebooted, bcache devices will not be re-registered automatically. Test clusters are typically not rebooted, so this is rarely an issue.
+- In `writeback` mode, a small window of unacknowledged writes may be lost if an instance is terminated unexpectedly before dirty cache lines are flushed to EBS.
+
 ## Launch
 
 The `up` command provisions all AWS infrastructure:

--- a/openspec/changes/bcache-support/.openspec.yaml
+++ b/openspec/changes/bcache-support/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-13

--- a/openspec/changes/bcache-support/design.md
+++ b/openspec/changes/bcache-support/design.md
@@ -1,0 +1,69 @@
+## Context
+
+The current `setup_instance.sh` detects the first unpartitioned disk from a fixed list (`nvme0n1`, `nvme1n1`, `xvdb`), formats it with XFS if needed, and mounts it to `/mnt/db1`. It has no concept of layered block devices. The script is extracted from the classpath as-is by `Init.extractResourceFile()` with no template substitution — the same static file is written regardless of how the cluster was configured.
+
+`InitConfig` already tracks EBS parameters (`ebsType`, `ebsSize`, `ebsIops`, `ebsThroughput`, `ebsOptimized`). Storage validation is done in `DefaultInstanceSpecFactory.createInstanceSpecs()`, which calls `EC2InstanceService.hasInstanceStore()` using the AWS `DescribeInstanceTypes` API.
+
+bcache requires:
+- A **cache device**: a fast local NVMe (`/dev/nvme0n1` or similar)
+- A **backing device**: a slower persistent EBS volume (`/dev/xvdf` or whatever device name the EBS is attached as)
+- Both devices must be **unformatted** when bcache registers them
+- The resulting virtual device (`/dev/bcache0`) is then formatted with XFS and mounted
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add `--bcache` flag to `init`, stored in `InitConfig`.
+- Validate at init time: `--bcache` requires `--ebs.type != NONE` AND instance type has local instance store. Fail fast if either is absent.
+- Generate `setup_instance.sh` with bcache-awareness by injecting `BCACHE_ENABLED` (true/false) via TemplateService template substitution.
+- In the bcache path of `setup_instance.sh`: make NVMe the cache device, EBS the backing device, set writeback mode, format and mount `/dev/bcache0`.
+- Add `bcache-tools` to the Packer AMI build so `make-bcache` is available.
+
+**Non-Goals:**
+- Supporting bcache with multiple EBS volumes or multiple NVMe devices beyond the primary pair.
+- Choosing cache mode (writethrough vs writeback) at runtime — writeback is fixed as the default.
+- Persisting bcache configuration across reboots (test clusters are ephemeral; bcache must be re-registered on reboot, which is out of scope for now).
+- Migrating existing clusters to bcache after init.
+
+## Decisions
+
+### 1. Inject bcache flag into setup_instance.sh via TemplateService
+
+**Rationale:** `setup_instance.sh` is a static classpath resource. The bcache path needs to know whether bcache is enabled before it runs. The cleanest mechanism is to convert the static extraction to a TemplateService-based generation that replaces a `__BCACHE_ENABLED__` placeholder with `true` or `false`. This keeps the bcache logic inside the script (where it belongs) while allowing Init to configure it.
+
+`Init.extractResourceFiles()` currently calls `extractResourceFile(...)` to copy the script verbatim. This method will be updated to read the script as a template string and write the substituted version.
+
+**Alternative considered:** Pass `BCACHE_ENABLED=true` as an environment variable prefix when invoking the script (e.g., `sudo BCACHE_ENABLED=true bash setup_instance.sh`). Rejected because it would require modifying `SetupInstance.kt` to read from cluster state, adding coupling between the command and the bcache feature at runtime.
+
+**Alternative considered:** Generate a separate `setup_bcache.sh` script that runs before the main script. Rejected as unnecessary complexity — a single script with a conditional is simpler.
+
+### 2. Validate bcache prerequisites in InstanceSpecFactory
+
+**Rationale:** `DefaultInstanceSpecFactory.createInstanceSpecs()` already enforces the rule "no instance store AND no EBS = fail". bcache adds a new combination constraint: "bcache enabled AND no EBS = fail" and "bcache enabled AND no instance store = fail". The factory already has access to EBS config and instance store detection — it's the right place.
+
+**Alternative considered:** Validate in the `Init` command directly. Rejected; validation belongs in the service layer per the architecture principles.
+
+### 3. bcache device detection in setup_instance.sh
+
+The script needs to identify two devices:
+- **NVMe (cache):** The local instance store. Currently `nvme0n1` on most instance types. On instances with multiple NVMe drives, the script uses the first unpartitioned one.
+- **EBS (backing):** Attached at `/dev/xvdf` by default (as set in `EBSConfig.deviceName`).
+
+In the bcache path, the device detection logic is inverted: instead of using the first available disk as the single data disk, the script explicitly identifies each role:
+- Cache device = first unpartitioned NVMe (`nvme0n1`)
+- Backing device = EBS device (`xvdf`, which appears as `/dev/xvdf` or `/dev/nvme1n1` depending on NVMe translation)
+
+A robust detection approach for the EBS device: scan `lsblk` for devices that are EBS-backed (kernel name `xvd*` or the second NVMe device when instance store occupies `nvme0n1`). Since EBS devices attached at `/dev/xvdf` appear as `/dev/xvdf` on Xen-based instances and `/dev/nvme1n1` on Nitro-based instances, the script will use the device name from the `EBSConfig.deviceName` (`/dev/xvdf`) and let the OS resolve it via symlinks (Nitro instances create `/dev/xvdf → /dev/nvme1n1` symlinks via udev rules).
+
+### 4. bcache-tools in Packer AMI
+
+The `make-bcache` utility (from `bcache-tools`) must be available on the instance at setup time. The Packer base provisioning script (`packer/base/install/`) should install `bcache-tools` unconditionally — it's a small package and doesn't hurt instances that don't use bcache.
+
+The `bcache` kernel module is included in the standard Ubuntu kernel (`linux-modules-extra-*`) and must be loaded before use. The setup script will run `modprobe bcache` before any bcache operations.
+
+## Risks / Trade-offs
+
+- **bcache data loss on instance restart:** bcache is a kernel feature that requires re-registration after reboot. Test clusters are typically not rebooted, but if they are, the bcache device will not be available until re-setup. This is documented as a known limitation.
+- **Device name variability on Nitro:** EBS devices on Nitro instances appear as `nvme1n1` (not `xvdf`). The udev symlink (`/dev/xvdf → /dev/nvme1n1`) created by the AWS NVMe driver resolves this, but depends on the driver being active. This is standard AWS behavior and reliable in practice.
+- **bcache kernel module availability:** bcache is included in `linux-modules-extra-aws` on Ubuntu. The Packer AMI must ensure this package is installed. If missing, `modprobe bcache` will fail with a clear error.
+- **No bcache support without both devices:** If a user specifies `--bcache` but chooses an instance type without NVMe (e.g., `c5.large`), the error must be clear at `init` time, not at `up` time.

--- a/openspec/changes/bcache-support/design.md
+++ b/openspec/changes/bcache-support/design.md
@@ -14,24 +14,25 @@ bcache requires:
 
 **Goals:**
 - Add `--bcache` flag to `init`, stored in `InitConfig`.
+- Add `--bcache.mode` flag to `init` (values: `writethrough`, `writeback`; default: `writethrough`), stored in `InitConfig`. Writethrough is the default because it is safe for all workloads — writes are committed to both the NVMe cache and the EBS backing device before being acknowledged. Users who need maximum write performance can opt into `writeback`.
 - Validate at init time: `--bcache` requires `--ebs.type != NONE` AND instance type has local instance store. Fail fast if either is absent.
-- Generate `setup_instance.sh` with bcache-awareness by injecting `BCACHE_ENABLED` (true/false) via TemplateService template substitution.
-- In the bcache path of `setup_instance.sh`: make NVMe the cache device, EBS the backing device, set writeback mode, format and mount `/dev/bcache0`.
+- Generate `setup_instance.sh` with bcache-awareness by injecting `BCACHE_ENABLED` (true/false) and `BCACHE_MODE` (writethrough/writeback) via TemplateService template substitution.
+- In the bcache path of `setup_instance.sh`: make NVMe the cache device, EBS the backing device, set the configured cache mode, format and mount `/dev/bcache0`.
 - Add `bcache-tools` to the Packer AMI build so `make-bcache` is available.
 
 **Non-Goals:**
 - Supporting bcache with multiple EBS volumes or multiple NVMe devices beyond the primary pair.
-- Choosing cache mode (writethrough vs writeback) at runtime — writeback is fixed as the default.
+- Supporting cache modes other than `writethrough` and `writeback`.
 - Persisting bcache configuration across reboots (test clusters are ephemeral; bcache must be re-registered on reboot, which is out of scope for now).
 - Migrating existing clusters to bcache after init.
 
 ## Decisions
 
-### 1. Inject bcache flag into setup_instance.sh via TemplateService
+### 1. Inject bcache flags into setup_instance.sh via TemplateService
 
-**Rationale:** `setup_instance.sh` is a static classpath resource. The bcache path needs to know whether bcache is enabled before it runs. The cleanest mechanism is to convert the static extraction to a TemplateService-based generation that replaces a `__BCACHE_ENABLED__` placeholder with `true` or `false`. This keeps the bcache logic inside the script (where it belongs) while allowing Init to configure it.
+**Rationale:** `setup_instance.sh` is a static classpath resource. The bcache path needs to know whether bcache is enabled and which cache mode to use before it runs. The cleanest mechanism is to convert the static extraction to a TemplateService-based generation that replaces `__BCACHE_ENABLED__` with `true` or `false` and `__BCACHE_MODE__` with `writethrough` or `writeback`. This keeps the bcache logic inside the script (where it belongs) while allowing Init to configure it.
 
-`Init.extractResourceFiles()` currently calls `extractResourceFile(...)` to copy the script verbatim. This method will be updated to read the script as a template string and write the substituted version.
+`Init.extractResourceFiles()` currently calls `extractResourceFile(...)` to copy the script verbatim. This method will be updated to read the script as a template string and write the substituted version, replacing both `__BCACHE_ENABLED__` and `__BCACHE_MODE__` placeholders.
 
 **Alternative considered:** Pass `BCACHE_ENABLED=true` as an environment variable prefix when invoking the script (e.g., `sudo BCACHE_ENABLED=true bash setup_instance.sh`). Rejected because it would require modifying `SetupInstance.kt` to read from cluster state, adding coupling between the command and the bcache feature at runtime.
 

--- a/openspec/changes/bcache-support/proposal.md
+++ b/openspec/changes/bcache-support/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+Database performance on AWS is a constant tradeoff: EBS volumes provide durable, persistent storage that survives instance termination, but they are limited by network throughput and latency. Local NVMe instance store drives are orders of magnitude faster for random I/O, but their data is lost when the instance stops. For test workloads — where data persistence between runs is not required — the performance difference is significant.
+
+bcache is a Linux kernel block-layer caching mechanism that allows a fast SSD (the cache device) to transparently accelerate a slower block device (the backing device). By using local NVMe as a write-back cache in front of an EBS volume, the cluster gets EBS-level persistence with NVMe-level I/O performance for hot data. This is particularly useful for database workloads that have active working sets smaller than the NVMe device, and where test reruns can tolerate cache misses on cold start.
+
+## What Changes
+
+- Add `--bcache` flag to the `init` command. When enabled, configures the local NVMe instance store as a write-back bcache cache device in front of the EBS volume.
+- Validate at init time that `--bcache` requires both `--ebs.type` (not NONE) and an instance type with local NVMe instance store. Fail fast with a clear error if either condition is missing.
+- Modify `setup_instance.sh` generation to support bcache configuration: detect the NVMe device (cache) and the EBS device (backing), register them with bcache, and expose the resulting `/dev/bcache0` device for XFS formatting and mounting to `/mnt/db1`.
+- Store `bcache: Boolean` in `InitConfig` (persisted to `state.json`) so the cluster's storage topology is part of its saved configuration.
+
+## Capabilities
+
+### New Capabilities
+
+- `bcache`: Configure Linux bcache write-back caching using local NVMe as cache and EBS as backing device, exposed as a single `/dev/bcacheN` virtual block device.
+
+### Modified Capabilities
+
+- `instance-storage-validation`: Add validation scenarios for the `--bcache` flag — it requires both EBS and local instance store to be present.
+
+## Impact
+
+- **Init command**: New `--bcache` boolean flag.
+- **InitConfig**: New `bcache: Boolean = false` field.
+- **InstanceSpecFactory**: Additional validation when `bcache = true`.
+- **setup_instance.sh**: New bcache setup path (NVMe → cache device, EBS → backing device, mount `/dev/bcache0`).
+- **Script generation in Init**: Use TemplateService to inject `BCACHE_ENABLED` into the script, replacing the static `extractResourceFile` call.
+- **Packer AMI**: The `bcache-tools` package must be installed so `make-bcache` is available on instance start.
+- **Docs**: New section on `--bcache` flag with prerequisites, use cases, and caveats.
+- **Tests**: Unit tests for InstanceSpecFactory bcache validation; packer script test for bcache setup path.

--- a/openspec/changes/bcache-support/proposal.md
+++ b/openspec/changes/bcache-support/proposal.md
@@ -6,16 +6,17 @@ bcache is a Linux kernel block-layer caching mechanism that allows a fast SSD (t
 
 ## What Changes
 
-- Add `--bcache` flag to the `init` command. When enabled, configures the local NVMe instance store as a write-back bcache cache device in front of the EBS volume.
+- Add `--bcache` flag to the `init` command. When enabled, configures the local NVMe instance store as a bcache cache device in front of the EBS volume.
+- Add `--bcache.mode` flag to select the bcache cache mode (`writethrough` or `writeback`), defaulting to `writethrough`. Writethrough is the safer default — writes go to both cache and backing device before being acknowledged. Writeback maximises write performance but risks a small window of data loss on instance termination.
 - Validate at init time that `--bcache` requires both `--ebs.type` (not NONE) and an instance type with local NVMe instance store. Fail fast with a clear error if either condition is missing.
-- Modify `setup_instance.sh` generation to support bcache configuration: detect the NVMe device (cache) and the EBS device (backing), register them with bcache, and expose the resulting `/dev/bcache0` device for XFS formatting and mounting to `/mnt/db1`.
-- Store `bcache: Boolean` in `InitConfig` (persisted to `state.json`) so the cluster's storage topology is part of its saved configuration.
+- Modify `setup_instance.sh` generation to support bcache configuration: detect the NVMe device (cache) and the EBS device (backing), register them with bcache, set the requested cache mode, and expose the resulting `/dev/bcache0` device for XFS formatting and mounting to `/mnt/db1`.
+- Store `bcache: Boolean` and `bcacheMode: String` in `InitConfig` (persisted to `state.json`) so the cluster's storage topology is part of its saved configuration.
 
 ## Capabilities
 
 ### New Capabilities
 
-- `bcache`: Configure Linux bcache write-back caching using local NVMe as cache and EBS as backing device, exposed as a single `/dev/bcacheN` virtual block device.
+- `bcache`: Configure Linux bcache caching using local NVMe as cache and EBS as backing device, exposed as a single `/dev/bcacheN` virtual block device. Supports `writethrough` (default, safe) and `writeback` (high performance) cache modes.
 
 ### Modified Capabilities
 
@@ -23,11 +24,11 @@ bcache is a Linux kernel block-layer caching mechanism that allows a fast SSD (t
 
 ## Impact
 
-- **Init command**: New `--bcache` boolean flag.
-- **InitConfig**: New `bcache: Boolean = false` field.
+- **Init command**: New `--bcache` boolean flag and `--bcache.mode` flag (default: `writethrough`).
+- **InitConfig**: New `bcache: Boolean = false` and `bcacheMode: String = "writethrough"` fields.
 - **InstanceSpecFactory**: Additional validation when `bcache = true`.
-- **setup_instance.sh**: New bcache setup path (NVMe → cache device, EBS → backing device, mount `/dev/bcache0`).
-- **Script generation in Init**: Use TemplateService to inject `BCACHE_ENABLED` into the script, replacing the static `extractResourceFile` call.
+- **setup_instance.sh**: New bcache setup path (NVMe → cache device, EBS → backing device, configurable cache mode, mount `/dev/bcache0`).
+- **Script generation in Init**: Use TemplateService to inject `BCACHE_ENABLED` and `BCACHE_MODE` into the script, replacing the static `extractResourceFile` call.
 - **Packer AMI**: The `bcache-tools` package must be installed so `make-bcache` is available on instance start.
 - **Docs**: New section on `--bcache` flag with prerequisites, use cases, and caveats.
 - **Tests**: Unit tests for InstanceSpecFactory bcache validation; packer script test for bcache setup path.

--- a/openspec/changes/bcache-support/specs/bcache/spec.md
+++ b/openspec/changes/bcache-support/specs/bcache/spec.md
@@ -1,0 +1,41 @@
+### Requirement: bcache write-back caching for database nodes
+
+The system SHALL support an optional bcache write-back caching configuration for database nodes, enabled by passing `--bcache` to the `init` command. When enabled, the local NVMe instance store SHALL be configured as the bcache cache device and the EBS volume SHALL be configured as the backing device. The resulting `/dev/bcache0` virtual block device SHALL be formatted with XFS and mounted to `/mnt/db1`, replacing the direct EBS or NVMe mount.
+
+bcache is disabled by default (`--bcache` is a boolean flag, default `false`).
+
+#### Scenario: bcache disabled (default)
+
+- **WHEN** the user runs `init` without `--bcache`
+- **THEN** the system SHALL use the existing storage setup logic (NVMe or EBS directly, no caching layer)
+
+#### Scenario: bcache enabled with valid prerequisites
+
+- **WHEN** the user runs `init` with `--bcache`, an instance type that has local NVMe instance store, and `--ebs.type` set to a non-NONE value
+- **THEN** the system SHALL store `bcache = true` in `InitConfig`
+- **AND** the generated `setup_instance.sh` SHALL configure NVMe as the bcache cache device and EBS as the bcache backing device
+- **AND** the database SHALL be stored on `/dev/bcache0` mounted at `/mnt/db1`
+- **AND** the bcache cache mode SHALL be set to writeback
+
+### Requirement: bcache cache mode
+
+The system SHALL configure bcache in **writeback** mode. In writeback mode, writes are acknowledged after being stored in the NVMe cache, and flushed to the EBS backing device asynchronously. This maximises write performance at the cost of a small window of data loss if the instance is terminated before dirty cache lines are flushed.
+
+This risk is acceptable for test workloads where data durability between test runs is not required.
+
+### Requirement: bcache device detection
+
+The system SHALL identify the cache and backing devices as follows:
+
+- **Cache device (NVMe):** The first local NVMe device available on the instance (typically `/dev/nvme0n1`). This is the same device the non-bcache path uses as the primary data disk on instance-store instances.
+- **Backing device (EBS):** The EBS volume attached at the device path specified in `EBSConfig.deviceName` (default `/dev/xvdf`). On Nitro-based instances, the AWS NVMe driver creates a udev symlink from `/dev/xvdf` to the actual NVMe device name (`/dev/nvme1n1`). The system SHALL use `/dev/xvdf` as the canonical path and rely on this symlink for resolution.
+
+### Requirement: bcache kernel module and tooling
+
+The system SHALL load the `bcache` kernel module (`modprobe bcache`) before any bcache operations. The `make-bcache` utility (from the `bcache-tools` package) SHALL be available on the instance at setup time. The Packer base AMI build SHALL install `bcache-tools` and ensure the `bcache` kernel module is available (via `linux-modules-extra-aws` or equivalent).
+
+### Requirement: bcache is not persistent across reboots
+
+The bcache configuration performed by `setup_instance.sh` is **not** persisted across instance reboots. If the instance is rebooted, bcache devices will not be re-registered automatically. This is a known limitation for test cluster use cases.
+
+The system SHALL NOT attempt to persist or restore bcache configuration across reboots.

--- a/openspec/changes/bcache-support/specs/bcache/spec.md
+++ b/openspec/changes/bcache-support/specs/bcache/spec.md
@@ -1,6 +1,6 @@
-### Requirement: bcache write-back caching for database nodes
+### Requirement: bcache caching for database nodes
 
-The system SHALL support an optional bcache write-back caching configuration for database nodes, enabled by passing `--bcache` to the `init` command. When enabled, the local NVMe instance store SHALL be configured as the bcache cache device and the EBS volume SHALL be configured as the backing device. The resulting `/dev/bcache0` virtual block device SHALL be formatted with XFS and mounted to `/mnt/db1`, replacing the direct EBS or NVMe mount.
+The system SHALL support an optional bcache caching configuration for database nodes, enabled by passing `--bcache` to the `init` command. When enabled, the local NVMe instance store SHALL be configured as the bcache cache device and the EBS volume SHALL be configured as the backing device. The resulting `/dev/bcache0` virtual block device SHALL be formatted with XFS and mounted to `/mnt/db1`, replacing the direct EBS or NVMe mount.
 
 bcache is disabled by default (`--bcache` is a boolean flag, default `false`).
 
@@ -9,19 +9,35 @@ bcache is disabled by default (`--bcache` is a boolean flag, default `false`).
 - **WHEN** the user runs `init` without `--bcache`
 - **THEN** the system SHALL use the existing storage setup logic (NVMe or EBS directly, no caching layer)
 
-#### Scenario: bcache enabled with valid prerequisites
+#### Scenario: bcache enabled with valid prerequisites (default mode)
 
-- **WHEN** the user runs `init` with `--bcache`, an instance type that has local NVMe instance store, and `--ebs.type` set to a non-NONE value
-- **THEN** the system SHALL store `bcache = true` in `InitConfig`
+- **WHEN** the user runs `init` with `--bcache` and no `--bcache.mode` flag, an instance type that has local NVMe instance store, and `--ebs.type` set to a non-NONE value
+- **THEN** the system SHALL store `bcache = true` and `bcacheMode = "writethrough"` in `InitConfig`
 - **AND** the generated `setup_instance.sh` SHALL configure NVMe as the bcache cache device and EBS as the bcache backing device
 - **AND** the database SHALL be stored on `/dev/bcache0` mounted at `/mnt/db1`
-- **AND** the bcache cache mode SHALL be set to writeback
+- **AND** the bcache cache mode SHALL be set to `writethrough`
+
+#### Scenario: bcache enabled in writeback mode
+
+- **WHEN** the user runs `init` with `--bcache --bcache.mode=writeback`, an instance type that has local NVMe instance store, and `--ebs.type` set to a non-NONE value
+- **THEN** the system SHALL store `bcache = true` and `bcacheMode = "writeback"` in `InitConfig`
+- **AND** the generated `setup_instance.sh` SHALL configure the bcache cache mode as `writeback`
 
 ### Requirement: bcache cache mode
 
-The system SHALL configure bcache in **writeback** mode. In writeback mode, writes are acknowledged after being stored in the NVMe cache, and flushed to the EBS backing device asynchronously. This maximises write performance at the cost of a small window of data loss if the instance is terminated before dirty cache lines are flushed.
+The system SHALL support two bcache cache modes, selectable via `--bcache.mode`:
 
-This risk is acceptable for test workloads where data durability between test runs is not required.
+- **`writethrough`** (default): Writes are committed to both the NVMe cache and the EBS backing device before being acknowledged. This is the safe default — there is no risk of data loss on instance termination. Write performance is bounded by EBS throughput.
+- **`writeback`**: Writes are acknowledged after being stored in the NVMe cache, and flushed to the EBS backing device asynchronously. This maximises write performance at the cost of a small window of data loss if the instance is terminated before dirty cache lines are flushed.
+
+`writethrough` is the default because it is the safer option. Users who need maximum write performance and accept the durability trade-off should pass `--bcache.mode=writeback`.
+
+The system SHALL reject any value for `--bcache.mode` other than `writethrough` or `writeback` with a clear error message at init time.
+
+#### Scenario: invalid cache mode
+
+- **WHEN** the user runs `init` with `--bcache --bcache.mode=<invalid>`
+- **THEN** the system SHALL fail with a clear error message listing the accepted values (`writethrough`, `writeback`)
 
 ### Requirement: bcache device detection
 

--- a/openspec/changes/bcache-support/specs/instance-storage-validation/spec.md
+++ b/openspec/changes/bcache-support/specs/instance-storage-validation/spec.md
@@ -1,0 +1,55 @@
+### Requirement: Database instance storage validation at init time
+
+The system SHALL validate that the database instance type has adequate storage before provisioning. An instance type MUST either have local instance store (NVMe) or the user MUST specify `--ebs.type` with a value other than `NONE`. If neither condition is met, the system SHALL fail with a clear error message and NOT proceed with instance creation.
+
+This validation applies only to database (db) nodes. Stress and control nodes do not require data disks.
+
+#### Scenario: Instance type with instance store and no EBS
+
+- **WHEN** the user runs init with an instance type that has instance store (e.g., `i3.xlarge`) and `--ebs.type` is `NONE`
+- **THEN** the system SHALL proceed normally (instance store provides the data disk)
+
+#### Scenario: Instance type without instance store and EBS specified
+
+- **WHEN** the user runs init with an instance type that has no instance store (e.g., `c5.2xlarge`) and `--ebs.type` is `gp3`
+- **THEN** the system SHALL proceed normally (EBS provides the data disk)
+
+#### Scenario: Instance type without instance store and no EBS
+
+- **WHEN** the user runs init with an instance type that has no instance store (e.g., `c5.2xlarge`) and `--ebs.type` is `NONE`
+- **THEN** the system SHALL fail with an error message indicating that the instance type has no local storage and `--ebs.type` must be specified
+- **AND** the system SHALL NOT create any EC2 instances
+
+### Requirement: Instance store detection via AWS API
+
+The system SHALL use the AWS `DescribeInstanceTypes` API to determine whether an instance type has local instance store. The system SHALL NOT use hardcoded lists or pattern-matching on instance type names.
+
+#### Scenario: Querying instance type capabilities
+
+- **WHEN** the system needs to validate an instance type's storage capabilities
+- **THEN** the system SHALL call `DescribeInstanceTypes` with the instance type name
+- **AND** the system SHALL check the `instanceStorageSupported` field to determine if instance store is available
+
+### Requirement: bcache validation requires both EBS and instance store
+
+When the `--bcache` flag is enabled, the system SHALL enforce that BOTH of the following conditions are true at init time. If either condition is not met, the system SHALL fail with a clear error message and NOT proceed.
+
+1. The database instance type MUST have local NVMe instance store (required as the bcache cache device).
+2. `--ebs.type` MUST NOT be `NONE` (required as the bcache backing device).
+
+#### Scenario: --bcache with EBS and instance store (valid)
+
+- **WHEN** the user runs init with `--bcache`, an instance type that has local NVMe instance store (e.g., `i3.xlarge`), and `--ebs.type gp3`
+- **THEN** the system SHALL proceed normally
+
+#### Scenario: --bcache without EBS
+
+- **WHEN** the user runs init with `--bcache`, an instance type that has instance store, but `--ebs.type` is `NONE`
+- **THEN** the system SHALL fail with an error indicating that `--bcache` requires `--ebs.type` to be specified
+- **AND** the system SHALL NOT create any EC2 instances
+
+#### Scenario: --bcache without instance store
+
+- **WHEN** the user runs init with `--bcache`, `--ebs.type gp3`, but an instance type that has no local instance store (e.g., `c5.2xlarge`)
+- **THEN** the system SHALL fail with an error indicating that `--bcache` requires an instance type with local NVMe instance store
+- **AND** the system SHALL NOT create any EC2 instances

--- a/openspec/changes/bcache-support/tasks.md
+++ b/openspec/changes/bcache-support/tasks.md
@@ -1,16 +1,16 @@
 ## 1. CLI and Configuration
 
-- [ ] 1.1 Add `--bcache` boolean flag (default: `false`) to `Init.kt`
-- [ ] 1.2 Add `--bcache.mode` string flag (default: `"writethrough"`, allowed values: `writethrough`, `writeback`) to `Init.kt`; validate the value is one of the two allowed options at parse time
-- [ ] 1.3 Add `bcache: Boolean = false` and `bcacheMode: String = "writethrough"` fields to `InitConfig` in `ClusterState.kt`
-- [ ] 1.4 Update `InitConfig.fromInit()` to populate `bcache` and `bcacheMode` from the flags
+- [x] 1.1 Add `--bcache` boolean flag (default: `false`) to `Init.kt`
+- [x] 1.2 Add `--bcache.mode` string flag (default: `"writethrough"`, allowed values: `writethrough`, `writeback`) to `Init.kt`; validate the value is one of the two allowed options at parse time
+- [x] 1.3 Add `bcache: Boolean = false` and `bcacheMode: String = "writethrough"` fields to `InitConfig` in `ClusterState.kt`
+- [x] 1.4 Update `InitConfig.fromInit()` to populate `bcache` and `bcacheMode` from the flags
 
 ## 2. Validation
 
-- [ ] 2.1 Add bcache prerequisite validation to `DefaultInstanceSpecFactory.createInstanceSpecs()`:
+- [x] 2.1 Add bcache prerequisite validation to `DefaultInstanceSpecFactory.createInstanceSpecs()`:
   - If `bcache = true` and `ebsType == "NONE"`: throw `IllegalArgumentException` with message indicating that `--bcache` requires `--ebs.type` to be set
   - If `bcache = true` and instance type has no instance store: throw `IllegalArgumentException` with message indicating that `--bcache` requires an instance type with local NVMe instance store
-- [ ] 2.2 Write unit tests for the new validation scenarios:
+- [x] 2.2 Write unit tests for the new validation scenarios:
   - `--bcache` + EBS + instance store → passes (writethrough default)
   - `--bcache` + EBS + instance store + `--bcache.mode=writeback` → passes
   - `--bcache` + EBS + instance store + `--bcache.mode=writethrough` → passes
@@ -21,12 +21,12 @@
 
 ## 3. Script Generation
 
-- [ ] 3.1 Convert `setup_instance.sh` to a TemplateService template by adding `__BCACHE_ENABLED__` and `__BCACHE_MODE__` placeholders in the CONFIGURATION block (e.g., `export BCACHE_ENABLED=__BCACHE_ENABLED__` and `export BCACHE_MODE=__BCACHE_MODE__`)
-- [ ] 3.2 Update `Init.extractResourceFiles()` to use `TemplateService` for script generation, substituting:
+- [x] 3.1 Convert `setup_instance.sh` to a TemplateService template by adding `__BCACHE_ENABLED__` and `__BCACHE_MODE__` placeholders in the CONFIGURATION block (e.g., `export BCACHE_ENABLED=__BCACHE_ENABLED__` and `export BCACHE_MODE=__BCACHE_MODE__`)
+- [x] 3.2 Update `Init.extractResourceFiles()` to use `TemplateService` for script generation, substituting:
   - `__BCACHE_ENABLED__` with `"true"` or `"false"` based on `InitConfig.bcache`
   - `__BCACHE_MODE__` with the value of `InitConfig.bcacheMode` (`writethrough` or `writeback`)
   - `__EBS_DEVICE__` with the value of `EBSConfig.deviceName` (e.g., `/dev/xvdf`) so the script never hardcodes the device path
-- [ ] 3.3 Add bcache setup logic to `setup_instance.sh` in a clearly delineated bcache section:
+- [x] 3.3 Add bcache setup logic to `setup_instance.sh` in a clearly delineated bcache section:
   - `modprobe bcache`
   - Identify cache device (first local NVMe, e.g., `/dev/nvme0n1`)
   - Identify backing device from `$EBS_DEVICE` (resolved via udev symlink on Nitro instances)
@@ -36,19 +36,19 @@
   - Attach cache to backing: `echo $CSET_UUID > /sys/block/bcache0/bcache/attach`
   - Set cache mode from config: `echo $BCACHE_MODE > /sys/block/bcache0/bcache/cache_mode`
   - Set `DISK=/dev/bcache0` for the subsequent format and mount steps
-- [ ] 3.4 Verify the non-bcache path in `setup_instance.sh` is unaffected when `BCACHE_ENABLED=false`
+- [x] 3.4 Verify the non-bcache path in `setup_instance.sh` is unaffected when `BCACHE_ENABLED=false`
 
 ## 4. AMI / Packer
 
-- [ ] 4.1 Add `bcache-tools` and `linux-modules-extra-aws` (if not already present) to the Packer base install script
+- [x] 4.1 Add `bcache-tools` and `linux-modules-extra-aws` (if not already present) to the Packer base install script
 - [ ] 4.2 Verify the packer test infrastructure (`testPackerBase`) still passes with the added packages
 
 ## 5. Documentation
 
-- [ ] 5.1 Add a `--bcache` section to the `docs/` init command reference (prerequisites, use case, caveats about bcache not surviving reboots)
-- [ ] 5.2 Note the instance type requirements (must have local NVMe instance store) and EBS requirement
+- [x] 5.1 Add a `--bcache` section to the `docs/` init command reference (prerequisites, use case, caveats about bcache not surviving reboots)
+- [x] 5.2 Note the instance type requirements (must have local NVMe instance store) and EBS requirement
 
 ## 6. Specs
 
-- [ ] 6.1 Create `openspec/specs/bcache/spec.md` with formal requirements for bcache support
-- [ ] 6.2 Update `openspec/specs/instance-storage-validation/spec.md` to add bcache validation scenarios
+- [x] 6.1 Create `openspec/specs/bcache/spec.md` with formal requirements for bcache support
+- [x] 6.2 Update `openspec/specs/instance-storage-validation/spec.md` to add bcache validation scenarios

--- a/openspec/changes/bcache-support/tasks.md
+++ b/openspec/changes/bcache-support/tasks.md
@@ -1,8 +1,9 @@
 ## 1. CLI and Configuration
 
 - [ ] 1.1 Add `--bcache` boolean flag (default: `false`) to `Init.kt`
-- [ ] 1.2 Add `bcache: Boolean = false` field to `InitConfig` in `ClusterState.kt`
-- [ ] 1.3 Update `InitConfig.fromInit()` to populate `bcache` from the flag
+- [ ] 1.2 Add `--bcache.mode` string flag (default: `"writethrough"`, allowed values: `writethrough`, `writeback`) to `Init.kt`; validate the value is one of the two allowed options at parse time
+- [ ] 1.3 Add `bcache: Boolean = false` and `bcacheMode: String = "writethrough"` fields to `InitConfig` in `ClusterState.kt`
+- [ ] 1.4 Update `InitConfig.fromInit()` to populate `bcache` and `bcacheMode` from the flags
 
 ## 2. Validation
 
@@ -10,22 +11,30 @@
   - If `bcache = true` and `ebsType == "NONE"`: throw `IllegalArgumentException` with message indicating that `--bcache` requires `--ebs.type` to be set
   - If `bcache = true` and instance type has no instance store: throw `IllegalArgumentException` with message indicating that `--bcache` requires an instance type with local NVMe instance store
 - [ ] 2.2 Write unit tests for the new validation scenarios:
-  - `--bcache` + EBS + instance store → passes
+  - `--bcache` + EBS + instance store → passes (writethrough default)
+  - `--bcache` + EBS + instance store + `--bcache.mode=writeback` → passes
+  - `--bcache` + EBS + instance store + `--bcache.mode=writethrough` → passes
   - `--bcache` + no EBS → fails with clear error
   - `--bcache` + no instance store → fails with clear error
+  - `--bcache` + invalid mode value → fails with clear error listing accepted values
   - `--bcache` disabled (default) → existing validation unchanged
 
 ## 3. Script Generation
 
-- [ ] 3.1 Convert `setup_instance.sh` to a TemplateService template by adding a `__BCACHE_ENABLED__` placeholder in the CONFIGURATION block (e.g., `export BCACHE_ENABLED=__BCACHE_ENABLED__`)
-- [ ] 3.2 Update `Init.extractResourceFiles()` to use `TemplateService` for script generation, substituting `BCACHE_ENABLED` with `"true"` or `"false"` based on `InitConfig.bcache`
+- [ ] 3.1 Convert `setup_instance.sh` to a TemplateService template by adding `__BCACHE_ENABLED__` and `__BCACHE_MODE__` placeholders in the CONFIGURATION block (e.g., `export BCACHE_ENABLED=__BCACHE_ENABLED__` and `export BCACHE_MODE=__BCACHE_MODE__`)
+- [ ] 3.2 Update `Init.extractResourceFiles()` to use `TemplateService` for script generation, substituting:
+  - `__BCACHE_ENABLED__` with `"true"` or `"false"` based on `InitConfig.bcache`
+  - `__BCACHE_MODE__` with the value of `InitConfig.bcacheMode` (`writethrough` or `writeback`)
+  - `__EBS_DEVICE__` with the value of `EBSConfig.deviceName` (e.g., `/dev/xvdf`) so the script never hardcodes the device path
 - [ ] 3.3 Add bcache setup logic to `setup_instance.sh` in a clearly delineated bcache section:
   - `modprobe bcache`
   - Identify cache device (first local NVMe, e.g., `/dev/nvme0n1`)
-  - Identify backing device (EBS device path from config, e.g., `/dev/xvdf`)
-  - Run `make-bcache -C <cache_device>` and `make-bcache -B <backing_device>`
-  - Attach cache to backing: `echo <cset_uuid> > /sys/block/bcache0/bcache/attach`
-  - Set writeback mode: `echo writeback > /sys/block/bcache0/bcache/cache_mode`
+  - Identify backing device from `$EBS_DEVICE` (resolved via udev symlink on Nitro instances)
+  - Check for existing bcache superblock on both devices (via `bcache-super-show` or `wipefs`) and wipe if present to ensure idempotency
+  - Run `make-bcache -C <cache_device>` (register cache set) and `make-bcache -B <backing_device>` (register backing device)
+  - Read cset_uuid from `/sys/fs/bcache/` (e.g., `CSET_UUID=$(ls /sys/fs/bcache/)`) after registering the cache device
+  - Attach cache to backing: `echo $CSET_UUID > /sys/block/bcache0/bcache/attach`
+  - Set cache mode from config: `echo $BCACHE_MODE > /sys/block/bcache0/bcache/cache_mode`
   - Set `DISK=/dev/bcache0` for the subsequent format and mount steps
 - [ ] 3.4 Verify the non-bcache path in `setup_instance.sh` is unaffected when `BCACHE_ENABLED=false`
 

--- a/openspec/changes/bcache-support/tasks.md
+++ b/openspec/changes/bcache-support/tasks.md
@@ -1,0 +1,45 @@
+## 1. CLI and Configuration
+
+- [ ] 1.1 Add `--bcache` boolean flag (default: `false`) to `Init.kt`
+- [ ] 1.2 Add `bcache: Boolean = false` field to `InitConfig` in `ClusterState.kt`
+- [ ] 1.3 Update `InitConfig.fromInit()` to populate `bcache` from the flag
+
+## 2. Validation
+
+- [ ] 2.1 Add bcache prerequisite validation to `DefaultInstanceSpecFactory.createInstanceSpecs()`:
+  - If `bcache = true` and `ebsType == "NONE"`: throw `IllegalArgumentException` with message indicating that `--bcache` requires `--ebs.type` to be set
+  - If `bcache = true` and instance type has no instance store: throw `IllegalArgumentException` with message indicating that `--bcache` requires an instance type with local NVMe instance store
+- [ ] 2.2 Write unit tests for the new validation scenarios:
+  - `--bcache` + EBS + instance store → passes
+  - `--bcache` + no EBS → fails with clear error
+  - `--bcache` + no instance store → fails with clear error
+  - `--bcache` disabled (default) → existing validation unchanged
+
+## 3. Script Generation
+
+- [ ] 3.1 Convert `setup_instance.sh` to a TemplateService template by adding a `__BCACHE_ENABLED__` placeholder in the CONFIGURATION block (e.g., `export BCACHE_ENABLED=__BCACHE_ENABLED__`)
+- [ ] 3.2 Update `Init.extractResourceFiles()` to use `TemplateService` for script generation, substituting `BCACHE_ENABLED` with `"true"` or `"false"` based on `InitConfig.bcache`
+- [ ] 3.3 Add bcache setup logic to `setup_instance.sh` in a clearly delineated bcache section:
+  - `modprobe bcache`
+  - Identify cache device (first local NVMe, e.g., `/dev/nvme0n1`)
+  - Identify backing device (EBS device path from config, e.g., `/dev/xvdf`)
+  - Run `make-bcache -C <cache_device>` and `make-bcache -B <backing_device>`
+  - Attach cache to backing: `echo <cset_uuid> > /sys/block/bcache0/bcache/attach`
+  - Set writeback mode: `echo writeback > /sys/block/bcache0/bcache/cache_mode`
+  - Set `DISK=/dev/bcache0` for the subsequent format and mount steps
+- [ ] 3.4 Verify the non-bcache path in `setup_instance.sh` is unaffected when `BCACHE_ENABLED=false`
+
+## 4. AMI / Packer
+
+- [ ] 4.1 Add `bcache-tools` and `linux-modules-extra-aws` (if not already present) to the Packer base install script
+- [ ] 4.2 Verify the packer test infrastructure (`testPackerBase`) still passes with the added packages
+
+## 5. Documentation
+
+- [ ] 5.1 Add a `--bcache` section to the `docs/` init command reference (prerequisites, use case, caveats about bcache not surviving reboots)
+- [ ] 5.2 Note the instance type requirements (must have local NVMe instance store) and EBS requirement
+
+## 6. Specs
+
+- [ ] 6.1 Create `openspec/specs/bcache/spec.md` with formal requirements for bcache support
+- [ ] 6.2 Update `openspec/specs/instance-storage-validation/spec.md` to add bcache validation scenarios

--- a/openspec/specs/bcache/spec.md
+++ b/openspec/specs/bcache/spec.md
@@ -1,0 +1,57 @@
+### Requirement: bcache caching for database nodes
+
+The system SHALL support an optional bcache caching configuration for database nodes, enabled by passing `--bcache` to the `init` command. When enabled, the local NVMe instance store SHALL be configured as the bcache cache device and the EBS volume SHALL be configured as the backing device. The resulting `/dev/bcache0` virtual block device SHALL be formatted with XFS and mounted to `/mnt/db1`, replacing the direct EBS or NVMe mount.
+
+bcache is disabled by default (`--bcache` is a boolean flag, default `false`).
+
+#### Scenario: bcache disabled (default)
+
+- **WHEN** the user runs `init` without `--bcache`
+- **THEN** the system SHALL use the existing storage setup logic (NVMe or EBS directly, no caching layer)
+
+#### Scenario: bcache enabled with valid prerequisites (default mode)
+
+- **WHEN** the user runs `init` with `--bcache` and no `--bcache.mode` flag, an instance type that has local NVMe instance store, and `--ebs.type` set to a non-NONE value
+- **THEN** the system SHALL store `bcache = true` and `bcacheMode = "writethrough"` in `InitConfig`
+- **AND** the generated `setup_instance.sh` SHALL configure NVMe as the bcache cache device and EBS as the bcache backing device
+- **AND** the database SHALL be stored on `/dev/bcache0` mounted at `/mnt/db1`
+- **AND** the bcache cache mode SHALL be set to `writethrough`
+
+#### Scenario: bcache enabled in writeback mode
+
+- **WHEN** the user runs `init` with `--bcache --bcache.mode=writeback`, an instance type that has local NVMe instance store, and `--ebs.type` set to a non-NONE value
+- **THEN** the system SHALL store `bcache = true` and `bcacheMode = "writeback"` in `InitConfig`
+- **AND** the generated `setup_instance.sh` SHALL configure the bcache cache mode as `writeback`
+
+### Requirement: bcache cache mode
+
+The system SHALL support two bcache cache modes, selectable via `--bcache.mode`:
+
+- **`writethrough`** (default): Writes are committed to both the NVMe cache and the EBS backing device before being acknowledged. This is the safe default — there is no risk of data loss on instance termination. Write performance is bounded by EBS throughput.
+- **`writeback`**: Writes are acknowledged after being stored in the NVMe cache, and flushed to the EBS backing device asynchronously. This maximises write performance at the cost of a small window of data loss if the instance is terminated before dirty cache lines are flushed.
+
+`writethrough` is the default because it is the safer option. Users who need maximum write performance and accept the durability trade-off should pass `--bcache.mode=writeback`.
+
+The system SHALL reject any value for `--bcache.mode` other than `writethrough` or `writeback` with a clear error message at init time.
+
+#### Scenario: invalid cache mode
+
+- **WHEN** the user runs `init` with `--bcache --bcache.mode=<invalid>`
+- **THEN** the system SHALL fail with a clear error message listing the accepted values (`writethrough`, `writeback`)
+
+### Requirement: bcache device detection
+
+The system SHALL identify the cache and backing devices as follows:
+
+- **Cache device (NVMe):** The first local NVMe device available on the instance (typically `/dev/nvme0n1`). This is the same device the non-bcache path uses as the primary data disk on instance-store instances.
+- **Backing device (EBS):** The EBS volume attached at the device path specified in `EBSConfig.deviceName` (default `/dev/xvdf`). On Nitro-based instances, the AWS NVMe driver creates a udev symlink from `/dev/xvdf` to the actual NVMe device name (`/dev/nvme1n1`). The system SHALL use `/dev/xvdf` as the canonical path and rely on this symlink for resolution.
+
+### Requirement: bcache kernel module and tooling
+
+The system SHALL load the `bcache` kernel module (`modprobe bcache`) before any bcache operations. The `make-bcache` utility (from the `bcache-tools` package) SHALL be available on the instance at setup time. The Packer base AMI build SHALL install `bcache-tools` and ensure the `bcache` kernel module is available (via `linux-modules-extra-aws` or equivalent).
+
+### Requirement: bcache is not persistent across reboots
+
+The bcache configuration performed by `setup_instance.sh` is **not** persisted across instance reboots. If the instance is rebooted, bcache devices will not be re-registered automatically. This is a known limitation for test cluster use cases.
+
+The system SHALL NOT attempt to persist or restore bcache configuration across reboots.

--- a/openspec/specs/instance-storage-validation/spec.md
+++ b/openspec/specs/instance-storage-validation/spec.md
@@ -29,3 +29,27 @@ The system SHALL use the AWS `DescribeInstanceTypes` API to determine whether an
 - **WHEN** the system needs to validate an instance type's storage capabilities
 - **THEN** the system SHALL call `DescribeInstanceTypes` with the instance type name
 - **AND** the system SHALL check the `instanceStorageSupported` field to determine if instance store is available
+
+### Requirement: bcache validation requires both EBS and instance store
+
+When the `--bcache` flag is enabled, the system SHALL enforce that BOTH of the following conditions are true at init time. If either condition is not met, the system SHALL fail with a clear error message and NOT proceed.
+
+1. The database instance type MUST have local NVMe instance store (required as the bcache cache device).
+2. `--ebs.type` MUST NOT be `NONE` (required as the bcache backing device).
+
+#### Scenario: --bcache with EBS and instance store (valid)
+
+- **WHEN** the user runs init with `--bcache`, an instance type that has local NVMe instance store (e.g., `i3.xlarge`), and `--ebs.type gp3`
+- **THEN** the system SHALL proceed normally
+
+#### Scenario: --bcache without EBS
+
+- **WHEN** the user runs init with `--bcache`, an instance type that has instance store, but `--ebs.type` is `NONE`
+- **THEN** the system SHALL fail with an error indicating that `--bcache` requires `--ebs.type` to be specified
+- **AND** the system SHALL NOT create any EC2 instances
+
+#### Scenario: --bcache without instance store
+
+- **WHEN** the user runs init with `--bcache`, `--ebs.type gp3`, but an instance type that has no local instance store (e.g., `c5.2xlarge`)
+- **THEN** the system SHALL fail with an error indicating that `--bcache` requires an instance type with local NVMe instance store
+- **AND** the system SHALL NOT create any EC2 instances

--- a/packer/base/base.pkr.hcl
+++ b/packer/base/base.pkr.hcl
@@ -109,6 +109,11 @@ build {
     script = "install/install_fio.sh"
   }
 
+  # install bcache-tools for optional bcache caching support
+  provisioner "shell" {
+    script = "install/install_bcache.sh"
+  }
+
   # install async profiler
   provisioner "shell" {
     script = "install/install_async_profiler.sh"

--- a/packer/base/install/install_bcache.sh
+++ b/packer/base/install/install_bcache.sh
@@ -12,10 +12,10 @@ if command -v make-bcache &> /dev/null; then
     exit 0
 fi
 
-echo "Installing bcache-tools and linux-modules-extra-aws..."
+echo "Installing bcache-tools, linux-modules-extra-aws, and nvme-cli..."
 
 sudo DEBIAN_FRONTEND=noninteractive apt update
-sudo DEBIAN_FRONTEND=noninteractive apt install -y bcache-tools linux-modules-extra-aws
+sudo DEBIAN_FRONTEND=noninteractive apt install -y bcache-tools linux-modules-extra-aws nvme-cli
 
 # Verify installation
 echo "Verifying bcache-tools installation..."

--- a/packer/base/install/install_bcache.sh
+++ b/packer/base/install/install_bcache.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "=== Running: install_bcache.sh ==="
+
+# Ensure non-interactive mode for apt
+export DEBIAN_FRONTEND=noninteractive
+
+# Check if bcache-tools is already installed
+if command -v make-bcache &> /dev/null; then
+    echo "bcache-tools already installed, skipping installation"
+    exit 0
+fi
+
+echo "Installing bcache-tools and linux-modules-extra-aws..."
+
+sudo DEBIAN_FRONTEND=noninteractive apt update
+sudo DEBIAN_FRONTEND=noninteractive apt install -y bcache-tools linux-modules-extra-aws
+
+# Verify installation
+echo "Verifying bcache-tools installation..."
+if ! command -v make-bcache &> /dev/null; then
+    echo "ERROR: make-bcache command not found after installation"
+    exit 1
+fi
+
+echo "bcache-tools installed successfully"
+echo "✓ install_bcache.sh completed successfully"

--- a/packer/docker-compose.yml
+++ b/packer/docker-compose.yml
@@ -61,3 +61,23 @@ services:
       bash /packer/cassandra/install/install_cassandra_easy_stress.sh &&
       echo 'Cassandra provisioning complete!'
       "
+
+  # Test bcache installation script
+  test-bcache:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: easy-db-lab-packer-test
+    volumes:
+      - ./:/packer:ro
+      - /var/run/docker.sock:/var/run/docker.sock
+    working_dir: /home/ubuntu
+    user: ubuntu
+    environment:
+      - DEBIAN_FRONTEND=noninteractive
+    command: >
+      bash -c "
+      echo 'Running bcache installation script...' &&
+      bash /packer/base/install/install_bcache.sh &&
+      echo 'bcache installation complete!'
+      "

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/Constants.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/Constants.kt
@@ -321,12 +321,6 @@ object Constants {
         const val S3_CERT_PATH = "registry/ca.crt"
     }
 
-    // EBS configuration
-    object EBS {
-        /** Default EBS device name used on AWS EC2 instances */
-        const val DEFAULT_DEVICE_NAME = "/dev/xvdf"
-    }
-
     // VPC and tagging configuration
     object Vpc {
         /** Default VPC CIDR block */

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/Constants.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/Constants.kt
@@ -321,6 +321,12 @@ object Constants {
         const val S3_CERT_PATH = "registry/ca.crt"
     }
 
+    // EBS configuration
+    object EBS {
+        /** Default EBS device name used on AWS EC2 instances */
+        const val DEFAULT_DEVICE_NAME = "/dev/xvdf"
+    }
+
     // VPC and tagging configuration
     object Vpc {
         /** Default VPC CIDR block */

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Init.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Init.kt
@@ -312,7 +312,7 @@ class Init : PicoBaseCommand() {
                     mapOf(
                         "BCACHE_ENABLED" to bcache.toString(),
                         "BCACHE_MODE" to bcacheMode,
-                        "EBS_DEVICE" to "/dev/xvdf",
+                        "EBS_DEVICE" to Constants.EBS.DEFAULT_DEVICE_NAME,
                     ),
                 )
         File("setup_instance.sh").writeText(script)

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Init.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Init.kt
@@ -312,7 +312,6 @@ class Init : PicoBaseCommand() {
                     mapOf(
                         "BCACHE_ENABLED" to bcache.toString(),
                         "BCACHE_MODE" to bcacheMode,
-                        "EBS_DEVICE" to Constants.EBS.DEFAULT_DEVICE_NAME,
                     ),
                 )
         File("setup_instance.sh").writeText(script)

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Init.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Init.kt
@@ -15,6 +15,7 @@ import com.rustyrazorblade.easydblab.configuration.User
 import com.rustyrazorblade.easydblab.events.Event
 import com.rustyrazorblade.easydblab.network.CidrBlock
 import com.rustyrazorblade.easydblab.services.CommandExecutor
+import com.rustyrazorblade.easydblab.services.TemplateService
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.koin.core.component.inject
 import picocli.CommandLine.Command
@@ -59,6 +60,7 @@ import kotlin.system.exitProcess
 class Init : PicoBaseCommand() {
     private val userConfig: User by inject()
     private val commandExecutor: CommandExecutor by inject()
+    private val templateService: TemplateService by inject()
 
     companion object {
         private const val DEFAULT_CASSANDRA_INSTANCE_COUNT = 3
@@ -197,6 +199,18 @@ class Init : PicoBaseCommand() {
     )
     var cidr: String = Constants.Vpc.DEFAULT_CIDR
 
+    @Option(
+        names = ["--bcache"],
+        description = ["Enable bcache: use local NVMe as cache device in front of the EBS backing device. Requires --ebs.type and an instance type with local NVMe instance store."],
+    )
+    var bcache = false
+
+    @Option(
+        names = ["--bcache.mode"],
+        description = ["bcache cache mode: writethrough (default, safe) or writeback (higher write performance, small risk of data loss on instance termination)."],
+    )
+    var bcacheMode = "writethrough"
+
     override fun execute() {
         validateParameters()
 
@@ -237,6 +251,10 @@ class Init : PicoBaseCommand() {
         require(ebsThroughput >= 0) { "EBS throughput cannot be negative" }
         // Validate CIDR block format and prefix length
         CidrBlock(cidr)
+        // Validate bcache mode value
+        require(bcacheMode in listOf("writethrough", "writeback")) {
+            "--bcache.mode must be one of: writethrough, writeback (got: $bcacheMode)"
+        }
     }
 
     private fun checkExistingFiles() {
@@ -279,11 +297,25 @@ class Init : PicoBaseCommand() {
 
     private fun extractResourceFiles() {
         eventBus.emit(Event.Setup.WritingSetupScript)
-        extractResourceFile("setup_instance.sh", "setup_instance.sh")
+        extractSetupScript()
 
         eventBus.emit(Event.Setup.CreatingCassandraDir)
         File("cassandra").mkdirs()
         extractResourceFile("cassandra-sidecar.yaml", "cassandra/cassandra-sidecar.yaml")
+    }
+
+    private fun extractSetupScript() {
+        val script =
+            templateService
+                .fromResource(this::class.java, "setup_instance.sh")
+                .substitute(
+                    mapOf(
+                        "BCACHE_ENABLED" to bcache.toString(),
+                        "BCACHE_MODE" to bcacheMode,
+                        "EBS_DEVICE" to "/dev/xvdf",
+                    ),
+                )
+        File("setup_instance.sh").writeText(script)
     }
 
     private fun extractResourceFile(

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/ClusterState.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/ClusterState.kt
@@ -102,6 +102,8 @@ data class InitConfig(
     val opensearchVersion: String = "2.11",
     val opensearchEbsSize: Int = 100,
     val cidr: String = Constants.Vpc.DEFAULT_CIDR,
+    val bcache: Boolean = false,
+    val bcacheMode: String = "writethrough",
 ) {
     companion object {
         /**
@@ -145,6 +147,8 @@ data class InitConfig(
                 opensearchVersion = init.opensearch.version,
                 opensearchEbsSize = init.opensearch.ebsSize,
                 cidr = init.cidr,
+                bcache = init.bcache,
+                bcacheMode = init.bcacheMode,
             )
     }
 }

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/aws/InstanceSpecFactory.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/aws/InstanceSpecFactory.kt
@@ -81,6 +81,20 @@ class DefaultInstanceSpecFactory : InstanceSpecFactory {
             )
         }
 
+        if (initConfig.bcache && ebsConfig == null) {
+            throw IllegalArgumentException(
+                "--bcache requires an EBS volume for the backing device. " +
+                    "Specify --ebs.type (e.g., --ebs.type gp3) to attach an EBS volume.",
+            )
+        }
+
+        if (initConfig.bcache && !dbHasInstanceStore) {
+            throw IllegalArgumentException(
+                "--bcache requires an instance type with local NVMe instance store as the cache device. " +
+                    "Instance type ${initConfig.instanceType} has no local instance store.",
+            )
+        }
+
         val existingCassandraCount = existingInstances[ServerType.Cassandra]?.size ?: 0
         val existingStressCount = existingInstances[ServerType.Stress]?.size ?: 0
         val existingControlCount = existingInstances[ServerType.Control]?.size ?: 0

--- a/src/main/resources/com/rustyrazorblade/easydblab/commands/setup_instance.sh
+++ b/src/main/resources/com/rustyrazorblade/easydblab/commands/setup_instance.sh
@@ -6,23 +6,14 @@
 
 export READAHEAD=8
 
+# bcache configuration — injected by easy-db-lab at init time
+export BCACHE_ENABLED=__BCACHE_ENABLED__
+export BCACHE_MODE=__BCACHE_MODE__
+export EBS_DEVICE=__EBS_DEVICE__
+
 DISK=""
 
-for VOL in nvme0n1 nvme1n1 xvdb; do
-  export VOL
-  echo "Checking $VOL"
-  TMP=$(lsblk -o NAME,MOUNTPOINTS -J | yq '.blockdevices[] | select(.name == env(VOL)) | has("children")')
-  echo $TMP
-
-  if [[ "${TMP}" == "false" ]]; then
-    DISK="/dev/$VOL"
-    break
-  fi
-done
-
-echo "Using disk: $DISK"
-
-## END CONFIGURATION ###
+###### END CONFIGURATION ###
 ###########################
 
 ###### SYSTEM SETTINGS // OS TUNINGS #####
@@ -52,6 +43,90 @@ sudo sysctl -p /etc/sysctl.d/60-cassandra.conf
 ########
 
 sudo mkdir -p /mnt/db1
+
+if [[ "${BCACHE_ENABLED}" == "true" ]]; then
+  ###### BCACHE SETUP ######
+  # Configure local NVMe as bcache cache device in front of the EBS backing device.
+  # The resulting /dev/bcache0 virtual device is then formatted and mounted at /mnt/db1.
+
+  echo "Setting up bcache: cache=NVMe, backing=${EBS_DEVICE}, mode=${BCACHE_MODE}"
+
+  # Load the bcache kernel module
+  sudo modprobe bcache
+
+  # Identify the local NVMe cache device (first unpartitioned NVMe)
+  CACHE_DEVICE=""
+  for VOL in nvme0n1 nvme1n1; do
+    export VOL
+    TMP=$(lsblk -o NAME,MOUNTPOINTS -J | yq '.blockdevices[] | select(.name == env(VOL)) | has("children")')
+    if [[ "${TMP}" == "false" ]]; then
+      CACHE_DEVICE="/dev/$VOL"
+      break
+    fi
+  done
+
+  if [[ -z "${CACHE_DEVICE}" ]]; then
+    echo "ERROR: No unpartitioned local NVMe device found for bcache cache. Aborting." >&2
+    exit 1
+  fi
+
+  echo "bcache cache device: ${CACHE_DEVICE}"
+  echo "bcache backing device: ${EBS_DEVICE}"
+
+  # Wipe any existing bcache superblocks for idempotency
+  sudo wipefs -a "${CACHE_DEVICE}" || true
+  sudo wipefs -a "${EBS_DEVICE}" || true
+
+  # Register the cache device (NVMe)
+  sudo make-bcache -C "${CACHE_DEVICE}"
+
+  # Obtain the cache set UUID
+  CSET_UUID=$(ls /sys/fs/bcache/)
+
+  # Register the backing device (EBS)
+  sudo make-bcache -B "${EBS_DEVICE}"
+
+  # Wait for bcache0 to appear
+  for i in $(seq 1 30); do
+    if [[ -b /dev/bcache0 ]]; then
+      break
+    fi
+    echo "Waiting for /dev/bcache0 to appear (attempt $i)..."
+    sleep 1
+  done
+
+  if [[ ! -b /dev/bcache0 ]]; then
+    echo "ERROR: /dev/bcache0 did not appear after registering backing device." >&2
+    exit 1
+  fi
+
+  # Attach cache set to the backing device
+  echo "${CSET_UUID}" | sudo tee /sys/block/bcache0/bcache/attach
+
+  # Set the requested cache mode
+  echo "${BCACHE_MODE}" | sudo tee /sys/block/bcache0/bcache/cache_mode
+
+  DISK=/dev/bcache0
+  echo "bcache setup complete. Using ${DISK} (mode: ${BCACHE_MODE})"
+  ###### END BCACHE SETUP ######
+
+else
+  ###### STANDARD DISK DETECTION ######
+  for VOL in nvme0n1 nvme1n1 xvdb; do
+    export VOL
+    echo "Checking $VOL"
+    TMP=$(lsblk -o NAME,MOUNTPOINTS -J | yq '.blockdevices[] | select(.name == env(VOL)) | has("children")')
+    echo $TMP
+
+    if [[ "${TMP}" == "false" ]]; then
+      DISK="/dev/$VOL"
+      break
+    fi
+  done
+  ###### END STANDARD DISK DETECTION ######
+fi
+
+echo "Using disk: $DISK"
 
 if [[ -n "$DISK" ]]; then
   FS_TYPE=$(sudo blkid -o value -s TYPE $DISK )

--- a/src/main/resources/com/rustyrazorblade/easydblab/commands/setup_instance.sh
+++ b/src/main/resources/com/rustyrazorblade/easydblab/commands/setup_instance.sh
@@ -9,7 +9,6 @@ export READAHEAD=8
 # bcache configuration — injected by easy-db-lab at init time
 export BCACHE_ENABLED=__BCACHE_ENABLED__
 export BCACHE_MODE=__BCACHE_MODE__
-export EBS_DEVICE=__EBS_DEVICE__
 
 DISK=""
 
@@ -44,47 +43,72 @@ sudo sysctl -p /etc/sysctl.d/60-cassandra.conf
 
 sudo mkdir -p /mnt/db1
 
+###### NVMe DEVICE DISCOVERY ######
+# Use nvme id-ctrl to identify each NVMe device by its model string:
+#   "Amazon EC2 NVMe Instance Storage" -> local instance store (cache device for bcache)
+#   "Amazon Elastic Block Store"       -> EBS volume (backing device for bcache)
+CACHE_DEVICES=()
+EBS_DEVICES=()
+
+for DEV in /dev/nvme*n1; do
+  [[ -b "$DEV" ]] || continue
+  MODEL=$(sudo nvme id-ctrl "$DEV" 2>/dev/null | grep "^mn" | cut -d: -f2 | xargs)
+  case "$MODEL" in
+    "Amazon EC2 NVMe Instance Storage")
+      CACHE_DEVICES+=("$DEV")
+      ;;
+    "Amazon Elastic Block Store")
+      EBS_DEVICES+=("$DEV")
+      ;;
+    *)
+      echo "Unknown NVMe device model on $DEV: '$MODEL', skipping"
+      ;;
+  esac
+done
+
+echo "Discovered ${#CACHE_DEVICES[@]} instance store device(s): ${CACHE_DEVICES[*]:-none}"
+echo "Discovered ${#EBS_DEVICES[@]} EBS device(s): ${EBS_DEVICES[*]:-none}"
+###### END NVMe DEVICE DISCOVERY ######
+
 if [[ "${BCACHE_ENABLED}" == "true" ]]; then
   ###### BCACHE SETUP ######
-  # Configure local NVMe as bcache cache device in front of the EBS backing device.
-  # The resulting /dev/bcache0 virtual device is then formatted and mounted at /mnt/db1.
+  # Configure local NVMe instance store(s) as a bcache cache set in front of an EBS backing device.
+  # Multiple cache devices are combined into a single bcache cache set.
+  # The resulting /dev/bcache0 virtual device is formatted and mounted at /mnt/db1.
 
-  echo "Setting up bcache: cache=NVMe, backing=${EBS_DEVICE}, mode=${BCACHE_MODE}"
+  if [[ ${#CACHE_DEVICES[@]} -eq 0 ]]; then
+    echo "ERROR: No local NVMe instance store devices found. bcache requires instance storage." >&2
+    exit 1
+  fi
+
+  if [[ ${#EBS_DEVICES[@]} -eq 0 ]]; then
+    echo "ERROR: No EBS NVMe devices found. bcache requires an EBS backing device." >&2
+    exit 1
+  fi
+
+  BACKING_DEVICE="${EBS_DEVICES[0]}"
+  if [[ ${#EBS_DEVICES[@]} -gt 1 ]]; then
+    echo "Multiple EBS devices found (${EBS_DEVICES[*]}). Using ${BACKING_DEVICE} as bcache backing device."
+  fi
+
+  echo "Setting up bcache: cache=${CACHE_DEVICES[*]}, backing=${BACKING_DEVICE}, mode=${BCACHE_MODE}"
 
   # Load the bcache kernel module
   sudo modprobe bcache
 
-  # Identify the local NVMe cache device (first unpartitioned NVMe)
-  CACHE_DEVICE=""
-  for VOL in nvme0n1 nvme1n1; do
-    export VOL
-    TMP=$(lsblk -o NAME,MOUNTPOINTS -J | yq '.blockdevices[] | select(.name == env(VOL)) | has("children")')
-    if [[ "${TMP}" == "false" ]]; then
-      CACHE_DEVICE="/dev/$VOL"
-      break
-    fi
+  # Wipe any existing bcache superblocks for idempotency
+  for DEV in "${CACHE_DEVICES[@]}" "${BACKING_DEVICE}"; do
+    sudo wipefs -a "$DEV" || true
   done
 
-  if [[ -z "${CACHE_DEVICE}" ]]; then
-    echo "ERROR: No unpartitioned local NVMe device found for bcache cache. Aborting." >&2
-    exit 1
-  fi
-
-  echo "bcache cache device: ${CACHE_DEVICE}"
-  echo "bcache backing device: ${EBS_DEVICE}"
-
-  # Wipe any existing bcache superblocks for idempotency
-  sudo wipefs -a "${CACHE_DEVICE}" || true
-  sudo wipefs -a "${EBS_DEVICE}" || true
-
-  # Register the cache device (NVMe)
-  sudo make-bcache -C "${CACHE_DEVICE}"
+  # Register all cache devices in a single cache set (bcache supports multiple cache devices)
+  sudo make-bcache -C "${CACHE_DEVICES[@]}"
 
   # Obtain the cache set UUID
   CSET_UUID=$(ls /sys/fs/bcache/)
 
   # Register the backing device (EBS)
-  sudo make-bcache -B "${EBS_DEVICE}"
+  sudo make-bcache -B "${BACKING_DEVICE}"
 
   # Wait for bcache0 to appear
   for i in $(seq 1 30); do
@@ -107,22 +131,25 @@ if [[ "${BCACHE_ENABLED}" == "true" ]]; then
   echo "${BCACHE_MODE}" | sudo tee /sys/block/bcache0/bcache/cache_mode
 
   DISK=/dev/bcache0
-  echo "bcache setup complete. Using ${DISK} (mode: ${BCACHE_MODE})"
+  echo "bcache setup complete. Using ${DISK} (${#CACHE_DEVICES[@]} cache device(s), mode: ${BCACHE_MODE})"
   ###### END BCACHE SETUP ######
 
 else
   ###### STANDARD DISK DETECTION ######
-  for VOL in nvme0n1 nvme1n1 xvdb; do
-    export VOL
-    echo "Checking $VOL"
-    TMP=$(lsblk -o NAME,MOUNTPOINTS -J | yq '.blockdevices[] | select(.name == env(VOL)) | has("children")')
-    echo $TMP
-
-    if [[ "${TMP}" == "false" ]]; then
-      DISK="/dev/$VOL"
-      break
-    fi
-  done
+  # Prefer local instance store NVMe, fall back to EBS NVMe, then xvdb for non-Nitro instances.
+  if [[ ${#CACHE_DEVICES[@]} -gt 0 ]]; then
+    DISK="${CACHE_DEVICES[0]}"
+  elif [[ ${#EBS_DEVICES[@]} -gt 0 ]]; then
+    DISK="${EBS_DEVICES[0]}"
+  else
+    # Fallback for non-Nitro instances with legacy device names
+    for VOL in xvdb xvdc; do
+      if [[ -b "/dev/$VOL" ]]; then
+        DISK="/dev/$VOL"
+        break
+      fi
+    done
+  fi
   ###### END STANDARD DISK DETECTION ######
 fi
 

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/commands/InitTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/commands/InitTest.kt
@@ -1,7 +1,6 @@
 package com.rustyrazorblade.easydblab.commands
 
 import com.rustyrazorblade.easydblab.BaseKoinTest
-import com.rustyrazorblade.easydblab.Constants
 import com.rustyrazorblade.easydblab.configuration.ClusterState
 import com.rustyrazorblade.easydblab.configuration.ClusterStateManager
 import com.rustyrazorblade.easydblab.output.BufferedOutputHandler
@@ -262,7 +261,6 @@ class InitTest : BaseKoinTest() {
             val scriptContent = File("setup_instance.sh").readText()
             assertThat(scriptContent).contains("BCACHE_ENABLED=true")
             assertThat(scriptContent).contains("BCACHE_MODE=writeback")
-            assertThat(scriptContent).contains("EBS_DEVICE=${Constants.EBS.DEFAULT_DEVICE_NAME}")
         }
 
         @Test
@@ -274,7 +272,6 @@ class InitTest : BaseKoinTest() {
             val scriptContent = File("setup_instance.sh").readText()
             assertThat(scriptContent).contains("BCACHE_ENABLED=false")
             assertThat(scriptContent).contains("BCACHE_MODE=writethrough")
-            assertThat(scriptContent).contains("EBS_DEVICE=${Constants.EBS.DEFAULT_DEVICE_NAME}")
         }
 
         @Test
@@ -288,7 +285,6 @@ class InitTest : BaseKoinTest() {
             val scriptContent = File("setup_instance.sh").readText()
             assertThat(scriptContent).doesNotContain("__BCACHE_ENABLED__")
             assertThat(scriptContent).doesNotContain("__BCACHE_MODE__")
-            assertThat(scriptContent).doesNotContain("__EBS_DEVICE__")
         }
     }
 }

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/commands/InitTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/commands/InitTest.kt
@@ -1,6 +1,7 @@
 package com.rustyrazorblade.easydblab.commands
 
 import com.rustyrazorblade.easydblab.BaseKoinTest
+import com.rustyrazorblade.easydblab.configuration.ClusterState
 import com.rustyrazorblade.easydblab.configuration.ClusterStateManager
 import com.rustyrazorblade.easydblab.output.BufferedOutputHandler
 import com.rustyrazorblade.easydblab.output.OutputHandler
@@ -38,6 +39,10 @@ class InitTest : BaseKoinTest() {
         outputHandler = getKoin().get<OutputHandler>() as BufferedOutputHandler
 
         whenever(mockClusterStateManager.exists()).thenReturn(false)
+        // TemplateService calls load() when generating setup_instance.sh
+        whenever(mockClusterStateManager.load()).thenReturn(
+            ClusterState(name = "test", versions = mutableMapOf()),
+        )
     }
 
     @AfterEach
@@ -199,6 +204,50 @@ class InitTest : BaseKoinTest() {
             assertThatThrownBy { command.execute() }
                 .isInstanceOf(IllegalArgumentException::class.java)
                 .hasMessageContaining("negative")
+        }
+    }
+
+    @Nested
+    inner class BcacheOptions {
+        @Test
+        fun `execute fails with invalid bcache mode`() {
+            val command = Init()
+            command.clean = true
+            command.bcacheMode = "invalid-mode"
+
+            assertThatThrownBy { command.execute() }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("--bcache.mode must be one of")
+                .hasMessageContaining("writethrough")
+                .hasMessageContaining("writeback")
+        }
+
+        @Test
+        fun `execute stores bcache config in cluster state`() {
+            val command = Init()
+            command.clean = true
+            command.bcache = true
+            command.bcacheMode = "writeback"
+            command.execute()
+
+            verify(mockClusterStateManager).save(
+                argThat {
+                    initConfig?.bcache == true && initConfig?.bcacheMode == "writeback"
+                },
+            )
+        }
+
+        @Test
+        fun `execute stores bcache disabled by default`() {
+            val command = Init()
+            command.clean = true
+            command.execute()
+
+            verify(mockClusterStateManager).save(
+                argThat {
+                    initConfig?.bcache == false && initConfig?.bcacheMode == "writethrough"
+                },
+            )
         }
     }
 }

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/commands/InitTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/commands/InitTest.kt
@@ -1,6 +1,7 @@
 package com.rustyrazorblade.easydblab.commands
 
 import com.rustyrazorblade.easydblab.BaseKoinTest
+import com.rustyrazorblade.easydblab.Constants
 import com.rustyrazorblade.easydblab.configuration.ClusterState
 import com.rustyrazorblade.easydblab.configuration.ClusterStateManager
 import com.rustyrazorblade.easydblab.output.BufferedOutputHandler
@@ -248,6 +249,46 @@ class InitTest : BaseKoinTest() {
                     initConfig?.bcache == false && initConfig?.bcacheMode == "writethrough"
                 },
             )
+        }
+
+        @Test
+        fun `setup script contains bcache enabled substitution`() {
+            val command = Init()
+            command.clean = true
+            command.bcache = true
+            command.bcacheMode = "writeback"
+            command.execute()
+
+            val scriptContent = File("setup_instance.sh").readText()
+            assertThat(scriptContent).contains("BCACHE_ENABLED=true")
+            assertThat(scriptContent).contains("BCACHE_MODE=writeback")
+            assertThat(scriptContent).contains("EBS_DEVICE=${Constants.EBS.DEFAULT_DEVICE_NAME}")
+        }
+
+        @Test
+        fun `setup script contains bcache disabled substitution by default`() {
+            val command = Init()
+            command.clean = true
+            command.execute()
+
+            val scriptContent = File("setup_instance.sh").readText()
+            assertThat(scriptContent).contains("BCACHE_ENABLED=false")
+            assertThat(scriptContent).contains("BCACHE_MODE=writethrough")
+            assertThat(scriptContent).contains("EBS_DEVICE=${Constants.EBS.DEFAULT_DEVICE_NAME}")
+        }
+
+        @Test
+        fun `setup script does not contain unsubstituted placeholders`() {
+            val command = Init()
+            command.clean = true
+            command.bcache = true
+            command.bcacheMode = "writethrough"
+            command.execute()
+
+            val scriptContent = File("setup_instance.sh").readText()
+            assertThat(scriptContent).doesNotContain("__BCACHE_ENABLED__")
+            assertThat(scriptContent).doesNotContain("__BCACHE_MODE__")
+            assertThat(scriptContent).doesNotContain("__EBS_DEVICE__")
         }
     }
 }

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/services/aws/InstanceSpecFactoryTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/services/aws/InstanceSpecFactoryTest.kt
@@ -202,6 +202,70 @@ class InstanceSpecFactoryTest {
     }
 
     @Nested
+    inner class BcacheValidation {
+        @Test
+        fun `should succeed when bcache enabled with EBS and instance store (writethrough default)`() {
+            val initConfig = createInitConfig(ebsType = "gp3", ebsSize = 200, bcache = true)
+
+            val specs = factory.createInstanceSpecs(initConfig, emptyMap(), dbHasInstanceStore = true)
+
+            assertThat(specs).hasSize(3)
+            assertThat(specs.find { it.serverType == ServerType.Cassandra }!!.ebsConfig).isNotNull
+        }
+
+        @Test
+        fun `should succeed when bcache enabled with EBS and instance store in writeback mode`() {
+            val initConfig = createInitConfig(ebsType = "gp3", ebsSize = 200, bcache = true, bcacheMode = "writeback")
+
+            val specs = factory.createInstanceSpecs(initConfig, emptyMap(), dbHasInstanceStore = true)
+
+            assertThat(specs).hasSize(3)
+            assertThat(specs.find { it.serverType == ServerType.Cassandra }!!.ebsConfig).isNotNull
+        }
+
+        @Test
+        fun `should succeed when bcache enabled with EBS and instance store in writethrough mode`() {
+            val initConfig =
+                createInitConfig(ebsType = "gp3", ebsSize = 200, bcache = true, bcacheMode = "writethrough")
+
+            val specs = factory.createInstanceSpecs(initConfig, emptyMap(), dbHasInstanceStore = true)
+
+            assertThat(specs).hasSize(3)
+        }
+
+        @Test
+        fun `should fail when bcache enabled without EBS`() {
+            val initConfig = createInitConfig(ebsType = "NONE", bcache = true)
+
+            assertThatThrownBy {
+                factory.createInstanceSpecs(initConfig, emptyMap(), dbHasInstanceStore = true)
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("--bcache requires an EBS volume")
+                .hasMessageContaining("--ebs.type")
+        }
+
+        @Test
+        fun `should fail when bcache enabled without instance store`() {
+            val initConfig = createInitConfig(instanceType = "c5.2xlarge", ebsType = "gp3", bcache = true)
+
+            assertThatThrownBy {
+                factory.createInstanceSpecs(initConfig, emptyMap(), dbHasInstanceStore = false)
+            }.isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessageContaining("--bcache requires an instance type with local NVMe instance store")
+                .hasMessageContaining("c5.2xlarge")
+        }
+
+        @Test
+        fun `should leave validation unchanged when bcache disabled`() {
+            val initConfig = createInitConfig(ebsType = "NONE", bcache = false)
+
+            // With instance store this should pass
+            val specs = factory.createInstanceSpecs(initConfig, emptyMap(), dbHasInstanceStore = true)
+            assertThat(specs).hasSize(3)
+        }
+    }
+
+    @Nested
     inner class CreateEbsConfig {
         @Test
         fun `should return null for NONE type`() {
@@ -281,6 +345,8 @@ class InstanceSpecFactoryTest {
         ebsSize: Int = 100,
         ebsIops: Int = 0,
         ebsThroughput: Int = 0,
+        bcache: Boolean = false,
+        bcacheMode: String = "writethrough",
     ): InitConfig =
         InitConfig(
             cassandraInstances = cassandraInstances,
@@ -295,6 +361,8 @@ class InstanceSpecFactoryTest {
             ebsThroughput = ebsThroughput,
             controlInstances = controlInstances,
             controlInstanceType = controlInstanceType,
+            bcache = bcache,
+            bcacheMode = bcacheMode,
         )
 
     /**


### PR DESCRIPTION
Add OpenSpec change for #562: -- bcache flag on init that configures local NVMe as write-back cache in front of EBS via Linux bcache.

Includes proposal, design, tasks, and specs for the bcache capability and updated instance-storage-validation spec.

Closes #562

Generated with [Claude Code](https://claude.ai/code)