### PR TITLE
Fix cassandra dashboards to filter hosts on db* pattern

### DIFF
--- a/src/main/resources/com/rustyrazorblade/easydblab/configuration/grafana/dashboards/cassandra-condensed.json
+++ b/src/main/resources/com/rustyrazorblade/easydblab/configuration/grafana/dashboards/cassandra-condensed.json
@@ -875,7 +875,7 @@
         "options": [],
         "query": "label_values(up{job=\"cassandra-maac\", cluster=~\"$cluster\", datacenter=~\"$datacenter\", rack=~\"$rack\"}, host_name)",
         "refresh": 2,
-        "regex": "",
+        "regex": "db.*",
         "sort": 0,
         "type": "query"
       },

--- a/src/main/resources/com/rustyrazorblade/easydblab/configuration/grafana/dashboards/cassandra-overview.json
+++ b/src/main/resources/com/rustyrazorblade/easydblab/configuration/grafana/dashboards/cassandra-overview.json
@@ -1539,7 +1539,7 @@
         "options": [],
         "query": "label_values(up{job=\"cassandra-maac\", cluster=~\"$cluster\", datacenter=~\"$datacenter\", rack=~\"$rack\"}, host_name)",
         "refresh": 2,
-        "regex": "",
+        "regex": "db.*",
         "sort": 0,
         "type": "query"
       }


### PR DESCRIPTION
Updates the host/node variable regex in both Cassandra Grafana dashboards to filter on `db*` hosts only, preventing non-db hosts from appearing in the dropdown.

Closes #561

Generated with [Claude Code](https://claude.ai/code)