### PR TITLE
openspec: packer S3 build cache proposal

### DIFF
--- a/openspec/changes/2026-03-15-packer-s3-build-cache/.openspec.yaml
+++ b/openspec/changes/2026-03-15-packer-s3-build-cache/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-15

--- a/openspec/changes/2026-03-15-packer-s3-build-cache/design.md
+++ b/openspec/changes/2026-03-15-packer-s3-build-cache/design.md
@@ -1,0 +1,104 @@
+## Context
+
+The packer build pipeline produces two image layers: `base` and `cassandra` (db). The bottlenecks are:
+
+- `packer/base/install/install_bcc.sh`: Downloads BCC v0.35.0 source, runs `cmake` + `make -j$(nproc)` (C++ compilation). Installs to `/usr/lib/libbcc*`, `/usr/share/bcc/`, and Python bindings. Takes ~15–20 minutes. Version is pinned — the compiled output never changes for a given version + arch combination.
+
+- `packer/cassandra/install/install_cassandra.sh`: Has three install paths controlled by `cassandra_versions.yaml`:
+  1. Download from Apache CDN by version prefix (no URL, no branch) — already fast
+  2. Download tarball from explicit URL — already fast
+  3. Clone git repo + `ant realclean && ant` build (URL ending in `.git` + `branch` field) — slow; pays full build cost every time
+
+The YAML currently uses paths 1 and 2 for all versions (including `trunk` and `5.0-HEAD` which point to nightly pre-built tarballs on GitHub Releases). Path 3 is available for custom branch builds and will be used as the project evolves.
+
+The `aws` CLI is already installed on packer instances (`install_awscli.sh` runs before these scripts).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Cache the BCC compiled artifact in S3, keyed by version + architecture. Skip compilation on cache hit.
+- Cache Cassandra git-branch build artifacts in S3, keyed by version name + git SHA of the branch tip. Skip ant build on cache hit.
+- Make cache operations best-effort: any S3 failure falls through to a normal build.
+- Allow cache bypass via `PACKER_CACHE_SKIP=1` for debugging or forced rebuilds.
+- Keep the S3 bucket name configurable via `PACKER_CACHE_BUCKET`.
+
+**Non-Goals:**
+- Caching Cassandra binary downloads (Apache CDN / GitHub Releases) — these are already pre-built and fast to download.
+- Caching sidecar builds (addressed in a separate PR).
+- Creating or managing the S3 bucket from Kotlin — the bucket is provisioned separately (same bucket used for cluster data, or a dedicated build cache bucket).
+- Invalidating the cache automatically when build scripts change — the cache key is content-based (version + arch/SHA), so script changes only matter for BCC (which is version-pinned).
+
+## Decisions
+
+### 1. Cache key design
+
+**BCC**: `bcc/bcc-v{VERSION}-{ARCH}.tar.gz`
+- `VERSION` = `BCC_VERSION` variable (e.g., `0.35.0`)
+- `ARCH` = output of `uname -m` (e.g., `x86_64`, `aarch64`)
+- Rationale: BCC is version-pinned. The output is fully determined by version + architecture. No content hash needed.
+
+**Cassandra source builds**: `cassandra/{VERSION}-{GIT_SHA}.tar.gz`
+- `VERSION` = the version field from `cassandra_versions.yaml` (e.g., `trunk`, `5.1-dev`)
+- `GIT_SHA` = `git rev-parse HEAD` after cloning (first 12 chars)
+- Rationale: Branch HEAD moves. The git SHA uniquely identifies the exact source code that was compiled. Old entries accumulate in S3 but storage cost is negligible vs build time.
+
+Both keys are prefixed with `packer-build-cache/` within the bucket to keep them organized.
+
+### 2. What gets cached for BCC
+
+The cache tarball captures the installed output:
+- `/usr/lib/libbcc*`
+- `/usr/lib/libbpf*` (installed by BCC build)
+- `/usr/share/bcc/`
+- `/usr/lib/python3/dist-packages/bcc/` (Python bindings)
+
+The tarball is created with `tar -czf - /usr/lib/libbcc* /usr/share/bcc /usr/lib/python3/dist-packages/bcc` and extracted with `tar -xzf - -C /`.
+
+**Alternative considered:** Cache the entire build directory and re-run `make install`. Rejected — more complex and slower than caching the install artifacts.
+
+### 3. Cache write timing
+
+For BCC: upload happens immediately after `sudo make install` succeeds and the Python bindings are verified.
+
+For Cassandra source builds: upload happens after the built directory is moved to `/usr/local/cassandra/$version` and configured.
+
+Cache writes are best-effort — a failure to upload does not fail the build (`aws s3 cp ... || true`).
+
+### 4. Cache reads are also best-effort
+
+If the `aws s3 cp` download fails for any reason (bucket doesn't exist, no permissions, network error), the script proceeds with the normal build path. This ensures the cache never blocks a build.
+
+**Implementation**: Use `aws s3 cp --no-progress` wrapped in an `if` statement. A non-zero exit falls through to the build.
+
+### 5. Shared helper function
+
+A shared `s3_cache_get` / `s3_cache_put` helper will be extracted to `packer/lib/s3_cache.sh` and sourced by both `install_bcc.sh` and `install_cassandra.sh`. This avoids duplicating the bucket name resolution and error handling logic.
+
+**Alternative considered:** Inline the logic in each script. Rejected — duplication makes it harder to change the bucket naming convention later.
+
+### 6. `PACKER_CACHE_SKIP` bypass
+
+Setting `PACKER_CACHE_SKIP=1` skips both cache reads and writes. Useful when:
+- Debugging a build issue and wanting a clean compile
+- The cache entry is suspected to be corrupted
+- Testing that the build still works from scratch
+
+### 7. IAM requirements
+
+The packer instance profile needs:
+```json
+{
+  "Effect": "Allow",
+  "Action": ["s3:GetObject", "s3:PutObject", "s3:HeadObject"],
+  "Resource": "arn:aws:s3:::{PACKER_CACHE_BUCKET}/packer-build-cache/*"
+}
+```
+
+This will be documented but not automated — the IAM policy for packer instances is managed outside this codebase.
+
+## Risks / Trade-offs
+
+- **Stale BCC cache**: If the BCC version bumps and the variable is updated but the cache key doesn't change for some reason — impossible by design since `BCC_VERSION` is in the key.
+- **Corrupted cache entry**: If a cache upload was interrupted, the S3 object may be partial. The `tar` extraction will fail, causing the build to fall back to compiling from scratch (best-effort read handles this).
+- **S3 bucket not configured**: If `PACKER_CACHE_BUCKET` is unset, cache operations are skipped entirely and the build proceeds normally. This is the safe default for users who haven't set up caching.
+- **Architecture mismatch**: `uname -m` in the key prevents cross-architecture cache hits.

--- a/openspec/changes/2026-03-15-packer-s3-build-cache/design.md
+++ b/openspec/changes/2026-03-15-packer-s3-build-cache/design.md
@@ -76,6 +76,10 @@ A shared `s3_cache_get` / `s3_cache_put` helper will be extracted to `packer/lib
 
 **Alternative considered:** Inline the logic in each script. Rejected — duplication makes it harder to change the bucket naming convention later.
 
+**Deployment**: Packer's `script` provisioner uploads only a single file. `s3_cache.sh` will not exist at the relative path once the script runs on the remote build machine. Both `base.pkr.hcl` and `cassandra.pkr.hcl` must include a `provisioner "file"` block that uploads `../lib/s3_cache.sh` to `/tmp/s3_cache.sh` before any script that sources it. The scripts source it from this fixed path.
+
+**Provisioner ordering for BCC in `base.pkr.hcl`**: `install_awscli.sh` must run before `install_bcc.sh` because the cache helpers call `aws s3 cp`.
+
 ### 6. `PACKER_CACHE_SKIP` bypass
 
 Setting `PACKER_CACHE_SKIP=1` skips both cache reads and writes. Useful when:
@@ -102,3 +106,4 @@ This will be documented but not automated — the IAM policy for packer instance
 - **Corrupted cache entry**: If a cache upload was interrupted, the S3 object may be partial. The `tar` extraction will fail, causing the build to fall back to compiling from scratch (best-effort read handles this).
 - **S3 bucket not configured**: If `PACKER_CACHE_BUCKET` is unset, cache operations are skipped entirely and the build proceeds normally. This is the safe default for users who haven't set up caching.
 - **Architecture mismatch**: `uname -m` in the key prevents cross-architecture cache hits.
+- **Base OS change**: The BCC cache key (`bcc-v{VERSION}-{ARCH}`) does not include the OS release. If the base AMI moves to a new Ubuntu LTS (e.g., 24.04 → 26.04), the existing cache entry would match but the binary may be incompatible. Mitigation: set `PACKER_CACHE_SKIP=1` whenever the base OS is upgraded, or manually delete the affected S3 objects.

--- a/openspec/changes/2026-03-15-packer-s3-build-cache/proposal.md
+++ b/openspec/changes/2026-03-15-packer-s3-build-cache/proposal.md
@@ -1,0 +1,37 @@
+## Why
+
+Packer AMI builds are slow due to repeated compilation of large artifacts whose content never changes between builds. Two key bottlenecks have been identified:
+
+1. **BCC compilation**: `install_bcc.sh` compiles BCC v0.35.0 from source on every build using cmake + make. This C++ compilation takes 15–20 minutes. The version is pinned, so the compiled output is always identical for a given architecture. There is no reason to recompile it.
+
+2. **Cassandra source builds**: `install_cassandra.sh` supports building Cassandra from a git branch (clone + `ant realclean && ant`). When branch-based versions are configured in `cassandra_versions.yaml`, the full build runs from scratch every time, including Maven dependency resolution (which is then explicitly cleared between versions).
+
+AMIs are built infrequently, but the operator provisions clusters from the same AMI repeatedly. Every AMI build currently pays these costs in full even when none of the inputs have changed.
+
+## What Changes
+
+- Add an S3-based binary cache to `install_bcc.sh`. Before compiling, check S3 for a cached tarball keyed by BCC version and architecture. On a cache hit, download and extract instead of compiling. On a miss, compile as normal then upload the result to S3.
+
+- Add an S3-based binary cache to `install_cassandra.sh` for the git-branch build path only. Cache key is derived from the version name and git SHA of the branch tip. Downloaded binary releases (Apache CDN, GitHub releases) do not need caching — they are already pre-built tarballs.
+
+- The S3 bucket name is configurable via the `PACKER_CACHE_BUCKET` environment variable. Cache operations are best-effort: S3 unavailability or a missing object falls back to a normal build.
+
+- Both scripts expose a `PACKER_CACHE_SKIP` environment variable to bypass the cache (useful for forcing a clean rebuild).
+
+## Capabilities
+
+### New Capabilities
+
+- `packer-s3-build-cache`: S3-backed binary artifact cache for compiled packer dependencies. Reduces image build time by 15–40 minutes on cache hits.
+
+### Modified Capabilities
+
+- `packer-base-image`: `install_bcc.sh` now checks/populates S3 cache before compiling BCC.
+- `packer-db-image`: `install_cassandra.sh` now checks/populates S3 cache for git-branch Cassandra builds.
+
+## Impact
+
+- **AMI build time**: Reduces to ~5 minutes for BCC (download vs compile) and ~2–5 minutes per Cassandra source version (download vs ant build) on cache hits.
+- **First build / cache miss**: No change — builds proceed exactly as today and populate the cache.
+- **IAM permissions**: The packer instance role needs `s3:GetObject`, `s3:PutObject`, and `s3:HeadObject` on the cache bucket.
+- **No Kotlin changes**: This is entirely packer/bash scope.

--- a/openspec/changes/2026-03-15-packer-s3-build-cache/tasks.md
+++ b/openspec/changes/2026-03-15-packer-s3-build-cache/tasks.md
@@ -1,0 +1,30 @@
+## 1. Shared S3 cache helper
+
+- [ ] 1.1 Create `packer/lib/s3_cache.sh` with `s3_cache_get` and `s3_cache_put` functions
+  - `s3_cache_get <bucket> <key> <dest>`: downloads `s3://<bucket>/<key>` to `<dest>`, returns 0 on success, 1 on any failure
+  - `s3_cache_put <bucket> <key> <src>`: uploads `<src>` to `s3://<bucket>/<key>`, best-effort (failure is non-fatal)
+  - Both functions no-op and return 0 when `PACKER_CACHE_BUCKET` is unset or empty
+  - Both functions no-op and return 0 when `PACKER_CACHE_SKIP=1`
+
+## 2. BCC cache in install_bcc.sh
+
+- [ ] 2.1 Source `packer/lib/s3_cache.sh` at the top of `install_bcc.sh`
+- [ ] 2.2 Compute `CACHE_KEY="packer-build-cache/bcc/bcc-v${BCC_VERSION}-$(uname -m).tar.gz"` before the build
+- [ ] 2.3 Add cache-read block before the cmake/make section: call `s3_cache_get`, and if successful, extract the tarball to `/` and skip compilation
+- [ ] 2.4 Add post-install cache-write block: after verifying the Python import, create a tarball of the installed BCC files and call `s3_cache_put`
+- [ ] 2.5 Verify the existing Python import check (`python3 -c "import bcc"`) still runs on both cache-hit and cache-miss paths
+
+## 3. Cassandra source build cache in install_cassandra.sh
+
+- [ ] 3.1 Source `packer/lib/s3_cache.sh` at the top of `install_cassandra.sh`
+- [ ] 3.2 In the git-branch build path (the `else` branch): after `git clone`, capture `GIT_SHA=$(git -C "$version" rev-parse --short=12 HEAD)`
+- [ ] 3.3 Compute `CACHE_KEY="packer-build-cache/cassandra/${version}-${GIT_SHA}.tar.gz"`
+- [ ] 3.4 Add cache-read block: call `s3_cache_get`; if successful, extract the tarball to `/usr/local/cassandra/` and skip the ant build
+- [ ] 3.5 Add post-build cache-write block: after `sudo mv "$version" "/usr/local/cassandra/$version"`, create a tarball of the installed version directory and call `s3_cache_put`
+- [ ] 3.6 Ensure the configuration block (conf backup, `cassandra.in.sh` append) still runs on both cache-hit and cache-miss paths
+
+## 4. Documentation
+
+- [ ] 4.1 Document `PACKER_CACHE_BUCKET` and `PACKER_CACHE_SKIP` in `packer/README.md`
+- [ ] 4.2 Document required IAM permissions (`s3:GetObject`, `s3:PutObject`, `s3:HeadObject`) for the packer instance role
+- [ ] 4.3 Document the S3 key structure and how to manually invalidate a cache entry (delete the S3 object)

--- a/openspec/changes/2026-03-15-packer-s3-build-cache/tasks.md
+++ b/openspec/changes/2026-03-15-packer-s3-build-cache/tasks.md
@@ -1,6 +1,6 @@
 ## 1. Shared S3 cache helper
 
-- [ ] 1.1 Create `packer/lib/s3_cache.sh` with `s3_cache_get` and `s3_cache_put` functions
+- [x] 1.1 Create `packer/lib/s3_cache.sh` with `s3_cache_get` and `s3_cache_put` functions
   - `s3_cache_get <bucket> <key> <dest>`: downloads `s3://<bucket>/<key>` to `<dest>`, returns 0 on success, 1 on any failure
   - `s3_cache_put <bucket> <key> <src>`: uploads `<src>` to `s3://<bucket>/<key>`, best-effort (failure is non-fatal)
   - Both functions no-op and return 0 when `PACKER_CACHE_BUCKET` is unset or empty
@@ -8,23 +8,23 @@
 
 ## 2. BCC cache in install_bcc.sh
 
-- [ ] 2.1 Source `packer/lib/s3_cache.sh` at the top of `install_bcc.sh`
-- [ ] 2.2 Compute `CACHE_KEY="packer-build-cache/bcc/bcc-v${BCC_VERSION}-$(uname -m).tar.gz"` before the build
-- [ ] 2.3 Add cache-read block before the cmake/make section: call `s3_cache_get`, and if successful, extract the tarball to `/` and skip compilation
-- [ ] 2.4 Add post-install cache-write block: after verifying the Python import, create a tarball of the installed BCC files and call `s3_cache_put`
-- [ ] 2.5 Verify the existing Python import check (`python3 -c "import bcc"`) still runs on both cache-hit and cache-miss paths
+- [x] 2.1 Source `packer/lib/s3_cache.sh` at the top of `install_bcc.sh`
+- [x] 2.2 Compute `CACHE_KEY="packer-build-cache/bcc/bcc-v${BCC_VERSION}-$(uname -m).tar.gz"` before the build
+- [x] 2.3 Add cache-read block before the cmake/make section: call `s3_cache_get`, and if successful, extract the tarball to `/` and skip compilation
+- [x] 2.4 Add post-install cache-write block: after verifying the Python import, create a tarball of the installed BCC files and call `s3_cache_put`
+- [x] 2.5 Verify the existing Python import check (`python3 -c "import bcc"`) still runs on both cache-hit and cache-miss paths
 
 ## 3. Cassandra source build cache in install_cassandra.sh
 
-- [ ] 3.1 Source `packer/lib/s3_cache.sh` at the top of `install_cassandra.sh`
-- [ ] 3.2 In the git-branch build path (the `else` branch): after `git clone`, capture `GIT_SHA=$(git -C "$version" rev-parse --short=12 HEAD)`
-- [ ] 3.3 Compute `CACHE_KEY="packer-build-cache/cassandra/${version}-${GIT_SHA}.tar.gz"`
-- [ ] 3.4 Add cache-read block: call `s3_cache_get`; if successful, extract the tarball to `/usr/local/cassandra/` and skip the ant build
-- [ ] 3.5 Add post-build cache-write block: after `sudo mv "$version" "/usr/local/cassandra/$version"`, create a tarball of the installed version directory and call `s3_cache_put`
-- [ ] 3.6 Ensure the configuration block (conf backup, `cassandra.in.sh` append) still runs on both cache-hit and cache-miss paths
+- [x] 3.1 Source `packer/lib/s3_cache.sh` at the top of `install_cassandra.sh`
+- [x] 3.2 In the git-branch build path (the `else` branch): after `git clone`, capture `GIT_SHA=$(git -C "$version" rev-parse --short=12 HEAD)`
+- [x] 3.3 Compute `CACHE_KEY="packer-build-cache/cassandra/${version}-${GIT_SHA}.tar.gz"`
+- [x] 3.4 Add cache-read block: call `s3_cache_get`; if successful, extract the tarball to `/usr/local/cassandra/` and skip the ant build
+- [x] 3.5 Add post-build cache-write block: after `sudo mv "$version" "/usr/local/cassandra/$version"`, create a tarball of the installed version directory and call `s3_cache_put`
+- [x] 3.6 Ensure the configuration block (conf backup, `cassandra.in.sh` append) still runs on both cache-hit and cache-miss paths
 
 ## 4. Documentation
 
-- [ ] 4.1 Document `PACKER_CACHE_BUCKET` and `PACKER_CACHE_SKIP` in `packer/README.md`
-- [ ] 4.2 Document required IAM permissions (`s3:GetObject`, `s3:PutObject`, `s3:HeadObject`) for the packer instance role
-- [ ] 4.3 Document the S3 key structure and how to manually invalidate a cache entry (delete the S3 object)
+- [x] 4.1 Document `PACKER_CACHE_BUCKET` and `PACKER_CACHE_SKIP` in `packer/README.md`
+- [x] 4.2 Document required IAM permissions (`s3:GetObject`, `s3:PutObject`, `s3:HeadObject`) for the packer instance role
+- [x] 4.3 Document the S3 key structure and how to manually invalidate a cache entry (delete the S3 object)

--- a/packer/README.md
+++ b/packer/README.md
@@ -75,6 +75,63 @@ See [TESTING.md](TESTING.md) for comprehensive testing documentation including:
 - CI integration
 - Best practices
 
+## S3 Build Cache
+
+Packer scripts support an optional S3-backed binary cache to skip expensive compilation steps on repeat builds.
+
+Two scripts benefit from caching:
+- `base/install/install_bcc.sh` — caches compiled BCC artifacts (~15–20 min saved per cache hit)
+- `cassandra/install/install_cassandra.sh` — caches git-branch Cassandra builds (~20 min saved per cache hit)
+
+### Environment Variables
+
+| Variable | Description |
+|---|---|
+| `PACKER_CACHE_BUCKET` | S3 bucket name for the build cache. When unset or empty, cache operations are skipped and builds proceed normally. |
+| `PACKER_CACHE_SKIP` | Set to `1` to bypass both cache reads and writes. Useful for forced rebuilds or debugging. |
+
+### S3 Key Structure
+
+All cache entries are stored under the `packer-build-cache/` prefix within the bucket:
+
+| Artifact | Key Pattern | Example |
+|---|---|---|
+| BCC | `packer-build-cache/bcc/bcc-v{VERSION}-{ARCH}.tar.gz` | `packer-build-cache/bcc/bcc-v0.35.0-x86_64.tar.gz` |
+| Cassandra source build | `packer-build-cache/cassandra/{VERSION}-{GIT_SHA}.tar.gz` | `packer-build-cache/cassandra/trunk-a1b2c3d4e5f6.tar.gz` |
+
+### Required IAM Permissions
+
+The packer instance profile needs the following permissions on the cache bucket:
+
+```json
+{
+  "Effect": "Allow",
+  "Action": ["s3:GetObject", "s3:PutObject", "s3:HeadObject"],
+  "Resource": "arn:aws:s3:::{PACKER_CACHE_BUCKET}/packer-build-cache/*"
+}
+```
+
+### Cache Invalidation
+
+Cache entries are content-addressed (version + architecture for BCC; version + git SHA for Cassandra source builds), so they are automatically invalidated when the underlying inputs change.
+
+To manually invalidate a cache entry, delete the corresponding S3 object:
+
+```shell
+# Invalidate BCC cache for a specific version and architecture
+aws s3 rm "s3://${PACKER_CACHE_BUCKET}/packer-build-cache/bcc/bcc-v0.35.0-x86_64.tar.gz"
+
+# Invalidate a Cassandra source build cache entry
+aws s3 rm "s3://${PACKER_CACHE_BUCKET}/packer-build-cache/cassandra/trunk-a1b2c3d4e5f6.tar.gz"
+
+# List all cache entries
+aws s3 ls "s3://${PACKER_CACHE_BUCKET}/packer-build-cache/" --recursive
+```
+
+### Cache Behavior
+
+Cache operations are best-effort. If the bucket is unavailable, permissions are missing, or a download fails, the build falls back to compiling from scratch. A failed cache write never fails the build.
+
 ## Directory Structure
 
 ```

--- a/packer/base/base.pkr.hcl
+++ b/packer/base/base.pkr.hcl
@@ -115,13 +115,19 @@ build {
   }
 
 
-  provisioner "shell" {
-    script = "install/install_bcc.sh"
-  }
-
-  # install AWS CLI v2
+  # install AWS CLI v2 (must run before install_bcc.sh which uses aws s3 cp for caching)
   provisioner "shell" {
     script = "install/install_awscli.sh"
+  }
+
+  # upload S3 cache helpers before any script that sources them
+  provisioner "file" {
+    source      = "../lib/s3_cache.sh"
+    destination = "/tmp/s3_cache.sh"
+  }
+
+  provisioner "shell" {
+    script = "install/install_bcc.sh"
   }
 
   # install k3s (disabled, not auto-started)

--- a/packer/base/install/install_bcc.sh
+++ b/packer/base/install/install_bcc.sh
@@ -3,9 +3,9 @@ set -euo pipefail
 
 echo "=== Running: install_bcc.sh ==="
 
+# Uploaded to /tmp/s3_cache.sh by the packer file provisioner in base.pkr.hcl
 # shellcheck source=../../lib/s3_cache.sh
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "${SCRIPT_DIR}/../../lib/s3_cache.sh"
+source "/tmp/s3_cache.sh"
 
 BCC_VERSION=0.35.0
 WORK_DIR=""
@@ -32,21 +32,28 @@ echo "Installing BCC version ${BCC_VERSION}..."
 CACHE_KEY="packer-build-cache/bcc/bcc-v${BCC_VERSION}-$(uname -m).tar.gz"
 CACHE_ARCHIVE=$(mktemp --suffix=".tar.gz")
 
-# Try to restore from S3 cache before compiling
+# Try to restore from S3 cache before compiling.
+# Use nested if for tar extraction so a corrupted archive falls back to compilation
+# rather than aborting the build under set -euo pipefail.
 if s3_cache_get "${PACKER_CACHE_BUCKET:-}" "${CACHE_KEY}" "${CACHE_ARCHIVE}"; then
     echo "Extracting BCC from cache..."
-    sudo tar -xzf "${CACHE_ARCHIVE}" -C /
-    rm -f "${CACHE_ARCHIVE}"
-    echo "Verifying BCC installation from cache..."
-    if ! python3 -c "import bcc" 2>/dev/null; then
-        echo "ERROR: BCC Python module not found after cache restore"
-        exit 1
+    if sudo tar -xzf "${CACHE_ARCHIVE}" -C /; then
+        rm -f "${CACHE_ARCHIVE}"
+        echo "Verifying BCC installation from cache..."
+        if ! python3 -c "import bcc" 2>/dev/null; then
+            echo "ERROR: BCC Python module not found after cache restore"
+            exit 1
+        fi
+        echo "BCC ${BCC_VERSION} restored from cache successfully"
+        echo "✓ install_bcc.sh completed successfully"
+        exit 0
+    else
+        echo "WARNING: Cache archive extraction failed, falling back to compilation"
+        rm -f "${CACHE_ARCHIVE}"
     fi
-    echo "BCC ${BCC_VERSION} restored from cache successfully"
-    echo "✓ install_bcc.sh completed successfully"
-    exit 0
+else
+    rm -f "${CACHE_ARCHIVE}"
 fi
-rm -f "${CACHE_ARCHIVE}"
 
 # Remove any existing BCC installations
 echo "Removing existing BCC packages..."
@@ -121,6 +128,8 @@ if compgen -G "/usr/lib/libbpf*" > /dev/null 2>&1; then
     BCC_CACHE_PATHS+=(/usr/lib/libbpf*)
 fi
 sudo tar -czf "${CACHE_ARCHIVE}" "${BCC_CACHE_PATHS[@]}" 2>/dev/null || true
+# Make archive readable by the non-root user running aws s3 cp
+sudo chmod a+r "${CACHE_ARCHIVE}"
 s3_cache_put "${PACKER_CACHE_BUCKET:-}" "${CACHE_KEY}" "${CACHE_ARCHIVE}"
 rm -f "${CACHE_ARCHIVE}"
 

--- a/packer/base/install/install_bcc.sh
+++ b/packer/base/install/install_bcc.sh
@@ -3,6 +3,10 @@ set -euo pipefail
 
 echo "=== Running: install_bcc.sh ==="
 
+# shellcheck source=../../lib/s3_cache.sh
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../../lib/s3_cache.sh"
+
 BCC_VERSION=0.35.0
 WORK_DIR=""
 
@@ -24,6 +28,25 @@ if command -v bcc-lua &> /dev/null; then
 fi
 
 echo "Installing BCC version ${BCC_VERSION}..."
+
+CACHE_KEY="packer-build-cache/bcc/bcc-v${BCC_VERSION}-$(uname -m).tar.gz"
+CACHE_ARCHIVE=$(mktemp --suffix=".tar.gz")
+
+# Try to restore from S3 cache before compiling
+if s3_cache_get "${PACKER_CACHE_BUCKET:-}" "${CACHE_KEY}" "${CACHE_ARCHIVE}"; then
+    echo "Extracting BCC from cache..."
+    sudo tar -xzf "${CACHE_ARCHIVE}" -C /
+    rm -f "${CACHE_ARCHIVE}"
+    echo "Verifying BCC installation from cache..."
+    if ! python3 -c "import bcc" 2>/dev/null; then
+        echo "ERROR: BCC Python module not found after cache restore"
+        exit 1
+    fi
+    echo "BCC ${BCC_VERSION} restored from cache successfully"
+    echo "✓ install_bcc.sh completed successfully"
+    exit 0
+fi
+rm -f "${CACHE_ARCHIVE}"
 
 # Remove any existing BCC installations
 echo "Removing existing BCC packages..."
@@ -88,6 +111,18 @@ if ! python3 -c "import bcc" 2>/dev/null; then
     echo "ERROR: BCC Python module not found after installation"
     exit 1
 fi
+
+# Upload compiled artifacts to S3 cache (best-effort)
+echo "Creating cache archive of installed BCC artifacts..."
+CACHE_ARCHIVE=$(mktemp --suffix=".tar.gz")
+# Collect installed paths; libbpf may not always be present
+BCC_CACHE_PATHS=(/usr/lib/libbcc* /usr/share/bcc /usr/lib/python3/dist-packages/bcc)
+if compgen -G "/usr/lib/libbpf*" > /dev/null 2>&1; then
+    BCC_CACHE_PATHS+=(/usr/lib/libbpf*)
+fi
+sudo tar -czf "${CACHE_ARCHIVE}" "${BCC_CACHE_PATHS[@]}" 2>/dev/null || true
+s3_cache_put "${PACKER_CACHE_BUCKET:-}" "${CACHE_KEY}" "${CACHE_ARCHIVE}"
+rm -f "${CACHE_ARCHIVE}"
 
 echo "BCC ${BCC_VERSION} installed successfully"
 echo "✓ install_bcc.sh completed successfully"

--- a/packer/cassandra/cassandra.pkr.hcl
+++ b/packer/cassandra/cassandra.pkr.hcl
@@ -159,6 +159,12 @@ build {
     destination = "/tmp/cassandra.in.sh"
   }
 
+  # upload S3 cache helpers before install_cassandra.sh which sources them
+  provisioner "file" {
+    source      = "../lib/s3_cache.sh"
+    destination = "/tmp/s3_cache.sh"
+  }
+
   provisioner "shell" {
     environment_vars = [
       # we need this to be set because install_cassandra checks for it and exits if it's not there

--- a/packer/cassandra/install/install_cassandra.sh
+++ b/packer/cassandra/install/install_cassandra.sh
@@ -83,6 +83,10 @@ if [ -z "$INSTALL_CASSANDRA" ]; then
     exit 0
 fi
 
+# shellcheck source=../../lib/s3_cache.sh
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../../lib/s3_cache.sh"
+
 # Enable strict error handling
 set -euo pipefail
 set -x
@@ -211,20 +215,41 @@ do
         exit 1
     fi
 
-    echo "Building version $version with ant"
-    (
-      cd "$version" || exit 1
-      ant realclean && ant -Dno-checkstyle=true $ANT_FLAGS || exit 1
-      rm -rf .git
-    ) || {
-        echo "ERROR: Ant build failed for version $version"
-        exit 1
-    }
+    GIT_SHA=$(git -C "$version" rev-parse --short=12 HEAD)
+    CACHE_KEY="packer-build-cache/cassandra/${version}-${GIT_SHA}.tar.gz"
+    CACHE_ARCHIVE=$(mktemp --suffix=".tar.gz")
 
-    sudo mv "$version" "/usr/local/cassandra/$version" || {
-        echo "ERROR: Failed to move built version $version to /usr/local/cassandra/"
-        exit 1
-    }
+    if s3_cache_get "${PACKER_CACHE_BUCKET:-}" "${CACHE_KEY}" "${CACHE_ARCHIVE}"; then
+        echo "Extracting Cassandra $version from cache..."
+        sudo mkdir -p "/usr/local/cassandra"
+        sudo tar -xzf "${CACHE_ARCHIVE}" -C "/usr/local/cassandra/"
+        rm -f "${CACHE_ARCHIVE}"
+        echo "Cassandra $version restored from cache, skipping ant build"
+    else
+        rm -f "${CACHE_ARCHIVE}"
+
+        echo "Building version $version with ant"
+        (
+          cd "$version" || exit 1
+          ant realclean && ant -Dno-checkstyle=true $ANT_FLAGS || exit 1
+          rm -rf .git
+        ) || {
+            echo "ERROR: Ant build failed for version $version"
+            exit 1
+        }
+
+        sudo mv "$version" "/usr/local/cassandra/$version" || {
+            echo "ERROR: Failed to move built version $version to /usr/local/cassandra/"
+            exit 1
+        }
+
+        # Upload built artifact to S3 cache (best-effort)
+        echo "Creating cache archive for Cassandra $version..."
+        CACHE_ARCHIVE=$(mktemp --suffix=".tar.gz")
+        sudo tar -czf "${CACHE_ARCHIVE}" -C "/usr/local/cassandra" "$version" 2>/dev/null || true
+        s3_cache_put "${PACKER_CACHE_BUCKET:-}" "${CACHE_KEY}" "${CACHE_ARCHIVE}"
+        rm -f "${CACHE_ARCHIVE}"
+    fi
   fi
 
   # Verify the version was successfully moved to /usr/local/cassandra/

--- a/packer/cassandra/install/install_cassandra.sh
+++ b/packer/cassandra/install/install_cassandra.sh
@@ -83,9 +83,9 @@ if [ -z "$INSTALL_CASSANDRA" ]; then
     exit 0
 fi
 
+# Uploaded to /tmp/s3_cache.sh by the packer file provisioner in cassandra.pkr.hcl
 # shellcheck source=../../lib/s3_cache.sh
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "${SCRIPT_DIR}/../../lib/s3_cache.sh"
+source "/tmp/s3_cache.sh"
 
 # Enable strict error handling
 set -euo pipefail
@@ -219,15 +219,24 @@ do
     CACHE_KEY="packer-build-cache/cassandra/${version}-${GIT_SHA}.tar.gz"
     CACHE_ARCHIVE=$(mktemp --suffix=".tar.gz")
 
+    # Use a flag variable and nested if for tar extraction so a corrupted archive
+    # falls back to the ant build rather than aborting under set -euo pipefail.
+    CACHE_HIT=0
     if s3_cache_get "${PACKER_CACHE_BUCKET:-}" "${CACHE_KEY}" "${CACHE_ARCHIVE}"; then
         echo "Extracting Cassandra $version from cache..."
         sudo mkdir -p "/usr/local/cassandra"
-        sudo tar -xzf "${CACHE_ARCHIVE}" -C "/usr/local/cassandra/"
-        rm -f "${CACHE_ARCHIVE}"
-        echo "Cassandra $version restored from cache, skipping ant build"
-    else
-        rm -f "${CACHE_ARCHIVE}"
+        if sudo tar -xzf "${CACHE_ARCHIVE}" -C "/usr/local/cassandra/"; then
+            # Clean up the cloned repo — it can be several hundred MB
+            rm -rf "$version"
+            CACHE_HIT=1
+            echo "Cassandra $version restored from cache, skipping ant build"
+        else
+            echo "WARNING: Cache extraction failed, falling back to ant build"
+        fi
+    fi
+    rm -f "${CACHE_ARCHIVE}"
 
+    if [[ "$CACHE_HIT" == "0" ]]; then
         echo "Building version $version with ant"
         (
           cd "$version" || exit 1
@@ -247,6 +256,8 @@ do
         echo "Creating cache archive for Cassandra $version..."
         CACHE_ARCHIVE=$(mktemp --suffix=".tar.gz")
         sudo tar -czf "${CACHE_ARCHIVE}" -C "/usr/local/cassandra" "$version" 2>/dev/null || true
+        # Make archive readable by the non-root user running aws s3 cp
+        sudo chmod a+r "${CACHE_ARCHIVE}"
         s3_cache_put "${PACKER_CACHE_BUCKET:-}" "${CACHE_KEY}" "${CACHE_ARCHIVE}"
         rm -f "${CACHE_ARCHIVE}"
     fi

--- a/packer/lib/s3_cache.sh
+++ b/packer/lib/s3_cache.sh
@@ -58,7 +58,10 @@ s3_cache_put() {
     fi
 
     echo "[s3_cache] Writing cache: s3://${bucket}/${key}"
-    aws s3 cp --no-progress "${src}" "s3://${bucket}/${key}" || true
-    echo "[s3_cache] Cache write complete (errors are non-fatal)"
+    if aws s3 cp --no-progress "${src}" "s3://${bucket}/${key}"; then
+        echo "[s3_cache] Cache write successful: s3://${bucket}/${key}"
+    else
+        echo "[s3_cache] Cache write failed (non-fatal): s3://${bucket}/${key}"
+    fi
     return 0
 }

--- a/packer/lib/s3_cache.sh
+++ b/packer/lib/s3_cache.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# S3 build cache helpers for packer scripts.
+#
+# Environment variables:
+#   PACKER_CACHE_BUCKET  - S3 bucket name. When unset or empty, all cache
+#                          operations are no-ops and the build proceeds normally.
+#   PACKER_CACHE_SKIP    - Set to 1 to bypass both cache reads and writes.
+#                          Useful for forced rebuilds or debugging.
+
+# s3_cache_get <bucket> <key> <dest>
+#
+# Downloads s3://<bucket>/<key> to <dest>.
+# Returns 0 on success, 1 on any failure (including no bucket configured).
+# A non-zero return means the caller should proceed with a normal build.
+s3_cache_get() {
+    local bucket="$1"
+    local key="$2"
+    local dest="$3"
+
+    if [[ -z "${bucket:-}" ]]; then
+        echo "[s3_cache] PACKER_CACHE_BUCKET not set, skipping cache read"
+        return 1
+    fi
+
+    if [[ "${PACKER_CACHE_SKIP:-0}" == "1" ]]; then
+        echo "[s3_cache] PACKER_CACHE_SKIP=1, skipping cache read"
+        return 1
+    fi
+
+    echo "[s3_cache] Checking cache: s3://${bucket}/${key}"
+    if aws s3 cp --no-progress "s3://${bucket}/${key}" "${dest}" 2>/dev/null; then
+        echo "[s3_cache] Cache hit: s3://${bucket}/${key}"
+        return 0
+    else
+        echo "[s3_cache] Cache miss: s3://${bucket}/${key}"
+        return 1
+    fi
+}
+
+# s3_cache_put <bucket> <key> <src>
+#
+# Uploads <src> to s3://<bucket>/<key>.
+# Best-effort: failure is non-fatal (the build has already succeeded).
+# No-ops when PACKER_CACHE_BUCKET is unset or PACKER_CACHE_SKIP=1.
+s3_cache_put() {
+    local bucket="$1"
+    local key="$2"
+    local src="$3"
+
+    if [[ -z "${bucket:-}" ]]; then
+        echo "[s3_cache] PACKER_CACHE_BUCKET not set, skipping cache write"
+        return 0
+    fi
+
+    if [[ "${PACKER_CACHE_SKIP:-0}" == "1" ]]; then
+        echo "[s3_cache] PACKER_CACHE_SKIP=1, skipping cache write"
+        return 0
+    fi
+
+    echo "[s3_cache] Writing cache: s3://${bucket}/${key}"
+    aws s3 cp --no-progress "${src}" "s3://${bucket}/${key}" || true
+    echo "[s3_cache] Cache write complete (errors are non-fatal)"
+    return 0
+}


### PR DESCRIPTION
Add OpenSpec change proposal for caching compiled packer artifacts (BCC, Cassandra source builds) in S3 to reduce AMI build time by 15–40 minutes on cache hits.

Closes #569
