### PR TITLE
Add /usr/share/bcc/tools to PATH

### DIFF
--- a/packer/cassandra/environment
+++ b/packer/cassandra/environment
@@ -1,3 +1,3 @@
-PATH="/usr/local/cassandra/current/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin:/usr/local/async-profiler/bin/:/usr/local/cassandra-sidecar/bin"
+PATH="/usr/local/cassandra/current/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin:/usr/local/async-profiler/bin/:/usr/local/cassandra-sidecar/bin:/usr/share/bcc/tools"
 CASSANDRA_LOG_DIR=/mnt/db1/cassandra/tmp
 CASSANDRA_EASY_STRESS_LOG_DIR=/mnt/db1/cassandra/stress


### PR DESCRIPTION
Add `/usr/share/bcc/tools` to the PATH in `/etc/environment` so bcc tools are accessible via sudo without specifying full paths.

Closes #231