### PR TITLE
Add JDK 21 support for Cassandra trunk

### DIFF
--- a/openspec/changes/archive/2026-03-15-add-jdk-21/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-15-add-jdk-21/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-15

--- a/openspec/changes/archive/2026-03-15-add-jdk-21/design.md
+++ b/openspec/changes/archive/2026-03-15-add-jdk-21/design.md
@@ -1,0 +1,21 @@
+## Decisions
+
+### JDK 21 package source
+
+Use Ubuntu 24.04's built-in `openjdk-21-jdk` package. No PPA or custom repository is required — `openjdk-21-jdk` is available in the default Ubuntu Noble repositories. This is consistent with how JDK 8, 11, and 17 are installed in the base image.
+
+### Alternative name pattern
+
+The `update-java-alternatives` name for JDK 21 follows the same pattern as the existing versions:
+- JDK 8 → `java-1.8.0-openjdk-$ARCH`
+- JDK 11 → `java-1.11.0-openjdk-$ARCH`
+- JDK 17 → `java-1.17.0-openjdk-$ARCH`
+- JDK 21 → `java-1.21.0-openjdk-$ARCH`
+
+### Scope of cassandra_versions.yaml change
+
+Only `trunk` is updated to JDK 21. `5.0` and `5.0-HEAD` remain on JDK 11 to avoid unintended behaviour changes for stable releases.
+
+### No changes to ant build defaults
+
+The `install_cassandra.sh` script sets JDK 11 as the default before running ant builds. Since `trunk` uses a pre-built tarball (downloaded via URL), it never goes through the ant build path. The ant default is not changed.

--- a/openspec/changes/archive/2026-03-15-add-jdk-21/proposal.md
+++ b/openspec/changes/archive/2026-03-15-add-jdk-21/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+Cassandra `trunk` is built and tested against JDK 21. The `use-cassandra` script exits with "Unknown java version 21" when switching to trunk, making the trunk version unusable on existing AMIs. JDK 21 is available in Ubuntu 24.04's standard package repositories with no additional PPAs required.
+
+## What Changes
+
+- Install `openjdk-21-jdk` and `openjdk-21-dbg` in the base packer image alongside the existing JDK 8, 11, and 17 packages.
+- Add a `java: "21"` branch to the `use-cassandra` script that calls `update-java-alternatives -s java-1.21.0-openjdk-$ARCH`.
+- Update `trunk` in `cassandra_versions.yaml` from `java: "17"` to `java: "21"`.
+
+## Capabilities
+
+### Modified Capabilities
+
+- **packer-base-image**: Now includes JDK 21 alongside JDK 8, 11, and 17.
+- **use-cassandra**: Supports switching to JDK 21 when a Cassandra version requires it.
+- **cassandra-versions**: `trunk` now targets JDK 21.
+
+## Impact
+
+- **Base AMI rebuild required**: The base image must be rebuilt to include `openjdk-21-jdk`.
+- **Cassandra AMI rebuild required**: The cassandra image must be rebuilt after the base image to pick up the new JDK and updated `cassandra_versions.yaml`.
+- **No behaviour change for existing versions**: `5.0`, `5.0-HEAD`, and older versions continue using JDK 11.

--- a/openspec/changes/archive/2026-03-15-add-jdk-21/tasks.md
+++ b/openspec/changes/archive/2026-03-15-add-jdk-21/tasks.md
@@ -1,0 +1,15 @@
+## 1. Base Packer Image
+
+- [x] 1.1 Add `openjdk-21-jdk openjdk-21-dbg` to the apt install line in `packer/base/base.pkr.hcl`
+
+## 2. use-cassandra Script
+
+- [x] 2.1 Add `elif [ "$JAVA_VERSION" = "21" ]` branch to `packer/cassandra/bin/use-cassandra` that calls `sudo update-java-alternatives -s java-1.21.0-openjdk-$ARCH`
+
+## 3. cassandra_versions.yaml
+
+- [x] 3.1 Update `trunk` entry in `packer/cassandra/cassandra_versions.yaml` from `java: "17"` to `java: "21"`
+
+## 4. Documentation
+
+- [x] 4.1 No user-facing docs require update — JDK version management is an internal packer detail not documented separately

--- a/packer/base/base.pkr.hcl
+++ b/packer/base/base.pkr.hcl
@@ -141,7 +141,7 @@ build {
 
   provisioner "shell" {
     inline = [
-      "sudo apt install openjdk-8-jdk openjdk-8-dbg openjdk-11-jdk openjdk-11-dbg openjdk-17-jdk openjdk-17-dbg -y",
+      "sudo apt install openjdk-8-jdk openjdk-8-dbg openjdk-11-jdk openjdk-11-dbg openjdk-17-jdk openjdk-17-dbg openjdk-21-jdk openjdk-21-dbg -y",
       "sudo update-java-alternatives -s /usr/lib/jvm/java-1.11.0-openjdk-${var.arch}",
       "sudo sed -i '/hl jexec.*/d' /usr/lib/jvm/.java-1.8.0-openjdk-${var.arch}.jinfo"
     ]

--- a/packer/cassandra/bin/use-cassandra
+++ b/packer/cassandra/bin/use-cassandra
@@ -48,6 +48,8 @@ elif [ "$JAVA_VERSION" = "11" ]; then
   sudo update-java-alternatives -s java-1.11.0-openjdk-$ARCH
 elif [ "$JAVA_VERSION" = "17" ]; then
   sudo update-java-alternatives -s java-1.17.0-openjdk-$ARCH
+elif [ "$JAVA_VERSION" = "21" ]; then
+  sudo update-java-alternatives -s java-1.21.0-openjdk-$ARCH
 else
   echo "Unknown java version $JAVA_VERSION"
   exit 1

--- a/packer/cassandra/cassandra_versions.yaml
+++ b/packer/cassandra/cassandra_versions.yaml
@@ -31,5 +31,5 @@
 
 - version: "trunk"
   url: https://github.com/rustyrazorblade/easy-db-lab/releases/download/nightly/apache-cassandra-trunk-bin.tar.gz
-  java: "17"
+  java: "21"
   python: "3.10.6"


### PR DESCRIPTION
Installs JDK 21 in the base packer image, adds JDK 21 support to the use-cassandra script, and updates trunk in cassandra_versions.yaml to target JDK 21.

Closes #51

