### PR TITLE
Add OpenSpec proposal for JDK 21 support

### DIFF
--- a/openspec/changes/2026-03-15-add-jdk-21/.openspec.yaml
+++ b/openspec/changes/2026-03-15-add-jdk-21/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-15

--- a/openspec/changes/2026-03-15-add-jdk-21/design.md
+++ b/openspec/changes/2026-03-15-add-jdk-21/design.md
@@ -1,0 +1,52 @@
+## Context
+
+EC2 database nodes are built with a two-stage packer pipeline:
+
+1. **Base image** (`packer/base/base.pkr.hcl`) — installs OS-level packages including all JDK versions. The current inline provisioner installs `openjdk-8-jdk openjdk-8-dbg openjdk-11-jdk openjdk-11-dbg openjdk-17-jdk openjdk-17-dbg` and sets JDK 11 as the default via `update-java-alternatives`.
+
+2. **Cassandra image** (`packer/cassandra/cassandra.pkr.hcl`) — installs Cassandra versions defined in `cassandra_versions.yaml`. The `install_cassandra.sh` script hardcodes `update-java-alternatives -s java-1.11.0-openjdk-amd64` for the build phase. At runtime, the `use-cassandra` bin script reads the `java` field from `/etc/cassandra_versions.yaml` and switches the active JDK via `update-java-alternatives`.
+
+The `use-cassandra` script currently handles `java` values `"8"`, `"11"`, and `"17"`. Any other value falls through to an error exit. The `cassandra_versions.yaml` `trunk` entry specifies `java: "17"` but trunk is built and CI-tested against JDK 21.
+
+## Goals / Non-Goals
+
+**Goals:**
+- JDK 21 installed on all EC2 database nodes (base image)
+- `use-cassandra` correctly switches to JDK 21 when `java: "21"` is specified
+- `trunk` version runs on JDK 21 at runtime
+
+**Non-Goals:**
+- Changing the Cassandra build phase to use JDK 21 (the `install_cassandra.sh` build phase hardcodes JDK 11 for source builds; this is a separate concern)
+- Adding JDK 21 support to ARM64 `update-java-alternatives` alternative names (the same `java-1.21.0-openjdk-$ARCH` pattern should work for both `amd64` and `arm64` on Ubuntu 24.04)
+- Upgrading `5.0` or `4.x` versions to JDK 21 (they continue on their existing versions)
+
+## Decisions
+
+### 1. JDK 21 package names on Ubuntu 24.04
+
+Ubuntu 24.04 (Noble) ships `openjdk-21-jdk` and `openjdk-21-dbg` in the default package repositories — no PPA required. The `update-java-alternatives` alternative name follows the same pattern as the others: `java-1.21.0-openjdk-amd64` / `java-1.21.0-openjdk-arm64`.
+
+**Alternatives considered:**
+- *Eclipse Temurin via Adoptium PPA* — adds an external dependency for something already available in Ubuntu's repos. Not worth the complexity.
+- *SDKMAN on nodes* — overkill for server images; `update-java-alternatives` is already in use and works well.
+
+### 2. `use-cassandra` branch for java 21
+
+The existing code follows a simple if/elif chain. Adding `elif [ "$JAVA_VERSION" = "21" ]` with `sudo update-java-alternatives -s java-1.21.0-openjdk-$ARCH` is consistent with the pattern for 8, 11, and 17. No structural changes needed.
+
+### 3. `cassandra_versions.yaml` — trunk only
+
+Only `trunk` is changed to `java: "21"`. The `5.0` and `5.0-HEAD` entries stay on `java: "11"`:
+- Cassandra 5.0's release documentation lists JDK 11 and 17 as supported (21 is compatible but not the default recommendation for 5.0 GA)
+- Changing 5.0 to JDK 21 would be a user-visible behaviour change beyond the scope of this fix
+- Users can override via `set-java-version 21` if they want to test 5.0 on JDK 21
+
+## Risks / Trade-offs
+
+- **[Image size]** Adding JDK 21 `jdk + dbg` packages adds ~300–400 MB to the base image. This is consistent with the existing multi-JDK strategy (8, 11, 17 already present) and acceptable for a lab tool.
+- **[`update-java-alternatives` name]** If the alternative name for JDK 21 on Ubuntu 24.04 differs from the expected `java-1.21.0-openjdk-amd64` pattern, `use-cassandra` will fail. This can be validated with `testPackerBase` in CI before merging.
+- **[ARM64 parity]** The base packer build runs for both `amd64` and `arm64`. Ubuntu 24.04 provides `openjdk-21-jdk` for both architectures, so no arch-specific handling is needed in the apt install step.
+
+## Open Questions
+
+None. This is a narrow, well-scoped change with no architectural decisions outstanding.

--- a/openspec/changes/2026-03-15-add-jdk-21/proposal.md
+++ b/openspec/changes/2026-03-15-add-jdk-21/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+EC2 database nodes currently ship with OpenJDK 8, 11, and 17. Cassandra trunk (the development branch of Cassandra 5.x+) is built and tested against JDK 21. Running trunk on JDK 17 misses JDK 21 runtime characteristics — GC tuning, virtual threads, and JVM flag behavior can differ enough to invalidate test results.
+
+Beyond trunk, Cassandra 5.0 is officially compatible with JDK 17 and 21. Users who want to test JDK 21 performance or behavior on Cassandra 5.0 have no way to do so today: the `use-cassandra` script does not recognise `java: "21"` and will exit with "Unknown java version 21".
+
+The fix is straightforward: install JDK 21 in the base packer image, teach `use-cassandra` to switch to it, and update `cassandra_versions.yaml` to declare the correct JDK for trunk.
+
+## What Changes
+
+- **Install JDK 21** in the base packer image (`packer/base/base.pkr.hcl`). Add `openjdk-21-jdk` and `openjdk-21-dbg` to the apt install step alongside the existing 8/11/17 packages.
+- **Support `java: "21"` in `use-cassandra`** (`packer/cassandra/bin/use-cassandra`). Add an `elif` branch for `JAVA_VERSION = "21"` that calls `update-java-alternatives -s java-1.21.0-openjdk-$ARCH`, matching the existing pattern for other versions.
+- **Update `cassandra_versions.yaml`** to set `trunk` to `java: "21"`. The trunk build already runs on JDK 21; this aligns the runtime to match. Cassandra `5.0` remains on JDK 11 (its minimum supported version) unless explicitly requested.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `db-node-provisioning` (implicitly): EC2 database nodes now ship with JDK 8, 11, 17, and 21. The version-switching mechanism covers all four.
+
+## Impact
+
+- **`packer/base/base.pkr.hcl`**: Add `openjdk-21-jdk openjdk-21-dbg` to the apt install inline provisioner.
+- **`packer/cassandra/bin/use-cassandra`**: Add `elif [ "$JAVA_VERSION" = "21" ]` branch.
+- **`packer/cassandra/cassandra_versions.yaml`**: Change trunk entry from `java: "17"` to `java: "21"`.
+- **Docs**: Update any documentation that lists supported JDK versions on cluster nodes.
+- **Tests**: Packer script tests can verify the JDK 21 install step (Docker-based `testPackerBase`).
+- **No Kotlin changes required**: This is a packer / provisioning-only change.

--- a/openspec/changes/2026-03-15-add-jdk-21/tasks.md
+++ b/openspec/changes/2026-03-15-add-jdk-21/tasks.md
@@ -1,0 +1,21 @@
+## 1. Install JDK 21 in Base Packer Image
+
+- [ ] 1.1 In `packer/base/base.pkr.hcl`, add `openjdk-21-jdk openjdk-21-dbg` to the inline apt install provisioner alongside the existing 8/11/17 packages. Keep JDK 11 as the post-install default (the `update-java-alternatives` call on the next line stays unchanged).
+
+## 2. Add JDK 21 Support to `use-cassandra`
+
+- [ ] 2.1 In `packer/cassandra/bin/use-cassandra`, add an `elif [ "$JAVA_VERSION" = "21" ]` branch that runs `sudo update-java-alternatives -s java-1.21.0-openjdk-$ARCH`, following the existing pattern for 8, 11, and 17.
+
+## 3. Update `cassandra_versions.yaml`
+
+- [ ] 3.1 In `packer/cassandra/cassandra_versions.yaml`, change the `trunk` entry's `java` field from `"17"` to `"21"`.
+
+## 4. Documentation
+
+- [ ] 4.1 Check `docs/` for any page that lists supported JDK versions on cluster nodes (e.g., packer or AMI reference docs) and update to include JDK 21.
+- [ ] 4.2 Update `CLAUDE.md` Development Setup section if it references the JDK versions available on nodes (currently it only describes the dev toolchain JDKs; add a note that nodes also ship JDK 21).
+
+## 5. Verify
+
+- [ ] 5.1 Run `./gradlew testPackerBase` to verify the base image provisioning scripts pass with JDK 21 added (Docker-based test, no AWS required).
+- [ ] 5.2 Confirm `use-cassandra trunk` can be invoked in the packer test environment without hitting "Unknown java version".


### PR DESCRIPTION
Adds OpenSpec proposal for adding JDK 21 to EC2 database nodes (packer base image, use-cassandra script, cassandra_versions.yaml).

Closes #51
