### PR TITLE
feat(spark): allow cassandra-analytics to be built from a configurable repo and branch

### DIFF
--- a/bin/build-cassandra-analytics
+++ b/bin/build-cassandra-analytics
@@ -16,9 +16,24 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 ANALYTICS_DIR="$PROJECT_ROOT/.cassandra-analytics"
 
-# Parse arguments
-FORCE_REBUILD=false
+# Read defaults from spark/cassandra-analytics-source.properties (committed config)
+CONFIG_FILE="$PROJECT_ROOT/spark/cassandra-analytics-source.properties"
+ANALYTICS_REPO="https://github.com/apache/cassandra-analytics.git"
 ANALYTICS_BRANCH="trunk"
+if [ -f "$CONFIG_FILE" ]; then
+    while IFS='=' read -r key value; do
+        key="${key// /}"
+        [[ "$key" == \#* || -z "$key" ]] && continue
+        value="${value# }"
+        case "$key" in
+            repo)   ANALYTICS_REPO="$value" ;;
+            branch) ANALYTICS_BRANCH="$value" ;;
+        esac
+    done < "$CONFIG_FILE"
+fi
+
+# Parse arguments (CLI flags override the config file)
+FORCE_REBUILD=false
 
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -30,13 +45,21 @@ while [[ $# -gt 0 ]]; do
             ANALYTICS_BRANCH="$2"
             shift 2
             ;;
+        --repo)
+            ANALYTICS_REPO="$2"
+            shift 2
+            ;;
         *)
             echo "Unknown option: $1"
-            echo "Usage: $0 [--force] [--branch <branch>]"
+            echo "Usage: $0 [--force] [--repo <url>] [--branch <branch>]"
             exit 1
             ;;
     esac
 done
+
+echo "=== cassandra-analytics source ==="
+echo "  repo:   $ANALYTICS_REPO"
+echo "  branch: $ANALYTICS_BRANCH"
 
 # Check if already built by looking for Maven artifacts (any version)
 MAVEN_ARTIFACT_BASE="$HOME/.m2/repository/org/apache/cassandra/cassandra-analytics-core_spark3_2.12"
@@ -50,11 +73,26 @@ echo "=== Building Apache Cassandra Analytics (requires JDK 11) ==="
 
 # Clone or update the repository
 if [ -d "$ANALYTICS_DIR" ]; then
-    echo "=== Updating existing clone ==="
-    (cd "$ANALYTICS_DIR" && git fetch origin && git checkout "$ANALYTICS_BRANCH" && git pull origin "$ANALYTICS_BRANCH" 2>/dev/null || true)
+    CURRENT_REMOTE="$(git -C "$ANALYTICS_DIR" remote get-url origin 2>/dev/null || true)"
+    if [ "$CURRENT_REMOTE" != "$ANALYTICS_REPO" ]; then
+        if [ "$FORCE_REBUILD" = true ]; then
+            echo "=== Remote changed ($CURRENT_REMOTE -> $ANALYTICS_REPO), re-cloning ==="
+            rm -rf "$ANALYTICS_DIR"
+            git clone --depth 1 --branch "$ANALYTICS_BRANCH" "$ANALYTICS_REPO" "$ANALYTICS_DIR"
+        else
+            echo "Error: existing clone uses a different remote."
+            echo "  current: $CURRENT_REMOTE"
+            echo "  wanted:  $ANALYTICS_REPO"
+            echo "Re-run with --force to re-clone from the new repo."
+            exit 1
+        fi
+    else
+        echo "=== Updating existing clone ==="
+        (cd "$ANALYTICS_DIR" && git fetch origin && git checkout "$ANALYTICS_BRANCH" && git pull origin "$ANALYTICS_BRANCH")
+    fi
 else
     echo "=== Cloning cassandra-analytics ==="
-    git clone --depth 1 --branch "$ANALYTICS_BRANCH" https://github.com/apache/cassandra-analytics.git "$ANALYTICS_DIR"
+    git clone --depth 1 --branch "$ANALYTICS_BRANCH" "$ANALYTICS_REPO" "$ANALYTICS_DIR"
 fi
 
 # Initialize SDKMAN

--- a/docs/development/spark.md
+++ b/docs/development/spark.md
@@ -31,6 +31,8 @@ Options:
 
 The default repo and branch are read from `spark/cassandra-analytics-source.properties`. CLI flags override the file. To switch to a different repo, update that file and re-run with `--force` to re-clone.
 
+**Getting the latest code from the remote**: The script skips all git operations if Maven artifacts already exist (the common case). It does not check whether the clone is up to date. To pull the latest from the configured repo/branch, either run with `--force` or manually `cd .cassandra-analytics && git pull` and then rebuild the spark modules.
+
 ## Building
 
 ```bash

--- a/docs/development/spark.md
+++ b/docs/development/spark.md
@@ -26,7 +26,10 @@ bin/build-cassandra-analytics
 
 Options:
 - `--force` - Rebuild even if already built
+- `--repo <url>` - Clone from a different repo (e.g., a fork)
 - `--branch <branch>` - Use a specific branch (default: trunk)
+
+The default repo and branch are read from `spark/cassandra-analytics-source.properties`. CLI flags override the file. To switch to a different repo, update that file and re-run with `--force` to re-clone.
 
 ## Building
 

--- a/openspec/changes/custom-spark-repo-and-branch/.openspec.yaml
+++ b/openspec/changes/custom-spark-repo-and-branch/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-05

--- a/openspec/changes/custom-spark-repo-and-branch/design.md
+++ b/openspec/changes/custom-spark-repo-and-branch/design.md
@@ -1,0 +1,48 @@
+## Context
+
+`bin/build-cassandra-analytics` clones cassandra-analytics and builds it locally, publishing artifacts to `~/.m2`. The clone destination is always `.cassandra-analytics/` in the project root (gitignored). The repo URL is currently hardcoded in the script as `https://github.com/apache/cassandra-analytics.git` with a default branch of `trunk`.
+
+`spark/build.gradle.kts` reads the built version from `.cassandra-analytics/gradle.properties` and references both Maven-published artifacts and local build output JARs — all under `.cassandra-analytics/`. The Gradle build doesn't care which repo was cloned; it only cares that the build artifacts are present.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make the cassandra-analytics source repo and branch configurable via a committed properties file
+- Allow CLI flag overrides (`--repo`, `--branch`) for one-off builds without touching the committed config
+- Print the resolved repo/branch at build time for visibility
+- Work correctly from both the devcontainer (`bin/dev build-analytics`) and directly (`bin/build-cassandra-analytics`)
+
+**Non-Goals:**
+- Supporting multiple simultaneous clone directories for different forks
+- Adding repo/branch config to Gradle (the Gradle build doesn't need to know the source)
+- Changing how `spark/build.gradle.kts` resolves artifacts
+
+## Decisions
+
+### Decision: Properties file over Gradle properties or env vars
+
+A committed `spark/cassandra-analytics-source.properties` file is the single source of truth for which repo and branch to use. This makes the intent explicit and visible in git history (e.g., "switch to fork", "switch back to upstream"). Env vars were rejected because they're invisible and easy to forget; Gradle properties were rejected because the build itself doesn't need this information — only the shell script does.
+
+Format:
+```properties
+repo=https://github.com/apache/cassandra-analytics.git
+branch=trunk
+```
+
+### Decision: CLI flags override the file, not vice versa
+
+`--repo` and `--branch` flags take precedence over the properties file. This allows one-off builds against a different source without editing the committed config. The existing `--force` flag behavior is unchanged.
+
+### Decision: No change to `spark/build.gradle.kts`
+
+The Gradle build resolves artifacts from `.cassandra-analytics/` regardless of which repo was cloned there. Since the clone destination is fixed, Gradle doesn't need to know the source. This keeps the change entirely within the shell script and the new properties file.
+
+### Decision: Print resolved repo/branch early
+
+The script prints the resolved repo and branch before any git operations, so it's obvious which fork/branch is in use if a build fails or produces unexpected results.
+
+## Risks / Trade-offs
+
+- **External fork dependency in CI**: When the properties file points to a personal fork, CI is dependent on that fork being accessible. If the fork goes private or is deleted, CI breaks. → Mitigation: Switch the config back to upstream once the upstream PR merges. The two-commit round-trip is acceptable for a personal tool.
+
+- **Stale `.cassandra-analytics/` clone**: If the properties file is updated to point to a different repo, but `.cassandra-analytics/` already exists from a prior clone, the script's update path (`git fetch && git checkout`) will silently continue using the old remote. → Mitigation: Document that switching to a different repo requires `--force` to re-clone. The script should also detect a remote mismatch and warn.

--- a/openspec/changes/custom-spark-repo-and-branch/proposal.md
+++ b/openspec/changes/custom-spark-repo-and-branch/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+The `bulk-writer-*` Spark modules depend on `cassandra-analytics`, which is cloned from the Apache upstream and built locally. The source repo URL is hardcoded, making it impossible to build against a fork without manually editing the script. This blocks development on changes that require cassandra-analytics modifications (e.g., CASSANALYTICS-155: IAM role support for S3) until those changes land upstream.
+
+## What Changes
+
+- Add `spark/cassandra-analytics-source.properties` — a committed config file specifying the default repo URL and branch for cassandra-analytics builds.
+- Update `bin/build-cassandra-analytics` to read defaults from this config file, with `--repo` and `--branch` CLI flags available as overrides.
+- Print the resolved repo and branch at build time so it's clear which source is being used.
+
+## Capabilities
+
+### New Capabilities
+
+- `cassandra-analytics-source`: Configuration of which cassandra-analytics Git repository and branch is cloned and built for the `bulk-writer-*` Spark modules.
+
+### Modified Capabilities
+
+- `spark-modules`: The build prerequisite for bulk-writer modules now supports a configurable upstream source rather than a hardcoded Apache repo URL.
+
+## Impact
+
+- `bin/build-cassandra-analytics` — add `--repo` flag, read from config file
+- `spark/cassandra-analytics-source.properties` — new committed file (defaults to upstream Apache repo/trunk)
+- No Gradle build file changes required
+- No changes to Kotlin application code

--- a/openspec/changes/custom-spark-repo-and-branch/specs/cassandra-analytics-source/spec.md
+++ b/openspec/changes/custom-spark-repo-and-branch/specs/cassandra-analytics-source/spec.md
@@ -1,0 +1,30 @@
+## ADDED Requirements
+
+### Requirement: Configurable cassandra-analytics source repo and branch
+
+The build script SHALL read the cassandra-analytics Git repository URL and branch from `spark/cassandra-analytics-source.properties` when that file exists, and fall back to the Apache upstream defaults when it does not.
+
+#### Scenario: Default config file points to Apache upstream
+
+- **WHEN** `spark/cassandra-analytics-source.properties` contains `repo=https://github.com/apache/cassandra-analytics.git` and `branch=trunk`
+- **THEN** `bin/build-cassandra-analytics` MUST clone from that URL and check out that branch
+
+#### Scenario: Config file points to a fork
+
+- **WHEN** `spark/cassandra-analytics-source.properties` contains a custom `repo` URL and `branch` value
+- **THEN** `bin/build-cassandra-analytics` MUST clone from the custom repo URL and check out the specified branch
+
+#### Scenario: CLI flags override the config file
+
+- **WHEN** `bin/build-cassandra-analytics --repo <url> --branch <branch>` is invoked with explicit flags
+- **THEN** the script MUST use the CLI-provided values, ignoring whatever is in the config file
+
+#### Scenario: Resolved source is printed at build time
+
+- **WHEN** `bin/build-cassandra-analytics` starts
+- **THEN** it MUST print the resolved repo URL and branch before performing any git operations
+
+#### Scenario: Remote mismatch triggers error
+
+- **WHEN** `.cassandra-analytics/` already exists and its configured remote URL differs from the resolved repo URL
+- **THEN** the script MUST exit with a non-zero code and print an error message directing the user to re-run with `--force` to re-clone from the new repo

--- a/openspec/changes/custom-spark-repo-and-branch/specs/spark-modules/spec.md
+++ b/openspec/changes/custom-spark-repo-and-branch/specs/spark-modules/spec.md
@@ -1,0 +1,20 @@
+## MODIFIED Requirements
+
+### Requirement: Spark modules organized under spark parent
+
+All Spark job modules SHALL be Gradle subprojects under the `spark/` directory, using nested module paths. The cassandra-analytics source used to build bulk-writer modules SHALL be configurable via `spark/cassandra-analytics-source.properties`.
+
+#### Scenario: Gradle module resolution
+
+- **WHEN** the project is built with `./gradlew :spark:common:build` or `./gradlew :spark:bulk-writer-sidecar:shadowJar`
+- **THEN** Gradle MUST resolve the modules from `spark/common/` and `spark/bulk-writer-sidecar/` respectively
+
+#### Scenario: Common module provides shared config and data generation
+
+- **WHEN** a Spark job module depends on `:spark:common`
+- **THEN** it MUST have access to `SparkJobConfig`, `DataGenerator`, `BulkTestDataGenerator`, and `CqlSetup`
+
+#### Scenario: Build prerequisite uses configured source
+
+- **WHEN** `bin/build-cassandra-analytics` is run before building bulk-writer modules
+- **THEN** it MUST clone and build from the repo and branch specified in `spark/cassandra-analytics-source.properties`

--- a/openspec/changes/custom-spark-repo-and-branch/tasks.md
+++ b/openspec/changes/custom-spark-repo-and-branch/tasks.md
@@ -1,0 +1,16 @@
+## 1. Config File
+
+- [x] 1.1 Create `spark/cassandra-analytics-source.properties` with `repo=https://github.com/apache/cassandra-analytics.git` and `branch=trunk`
+
+## 2. Update `bin/build-cassandra-analytics`
+
+- [x] 2.1 Add logic to read `repo` and `branch` defaults from `spark/cassandra-analytics-source.properties` (relative to project root)
+- [x] 2.2 Add `--repo` CLI flag (overrides config file value)
+- [x] 2.3 Print the resolved repo and branch before any git operations
+- [x] 2.4 After resolving the repo URL, check if `.cassandra-analytics/` already exists with a different remote — if so, print a warning and exit with instructions to re-run with `--force`
+
+## 3. Verification
+
+- [x] 3.1 Run `bin/build-cassandra-analytics --help` and confirm `--repo` appears in usage
+- [x] 3.2 Confirm build output shows the resolved repo and branch
+- [x] 3.3 Update `docs/development/` or `CLAUDE.md` if the build prerequisite section needs updating

--- a/spark/cassandra-analytics-source.properties
+++ b/spark/cassandra-analytics-source.properties
@@ -1,0 +1,4 @@
+# TEMPORARY: points to a personal fork for CASSANALYTICS-155 (IAM S3 credential support)
+# Switch back to apache/cassandra-analytics@trunk once the upstream PR merges.
+repo=https://github.com/rustyrazorblade/cassandra-analytics.git
+branch=iam_credentials


### PR DESCRIPTION
## Summary

- Adds `spark/cassandra-analytics-source.properties` as a committed config file specifying which cassandra-analytics repo and branch to clone and build
- Updates `bin/build-cassandra-analytics` to read defaults from this file, adds a `--repo` flag, prints the resolved source at build time, and detects remote mismatches when an existing clone is present
- Currently points to `rustyrazorblade/cassandra-analytics@iam_credentials` for CASSANALYTICS-155 (IAM role support for S3); will be switched back to `apache/cassandra-analytics@trunk` once that PR merges

Closes #636