### PR TITLE
feat(networking): skip SOCKS proxy when Tailscale is active

### DIFF
--- a/bin/end-to-end-test
+++ b/bin/end-to-end-test
@@ -475,6 +475,23 @@ step_setup_cassandra() {
     fi
 }
 
+step_test_cql_connection() {
+    if [ "$ENABLE_CASSANDRA" != true ]; then
+        echo "=== Skipping CQL connection test (use --cassandra to enable) ==="
+        return 0
+    fi
+    echo "=== Testing direct CQL connection via system.local ==="
+    local output
+    output=$(easy-db-lab cassandra cql "SELECT cluster_name, release_version FROM system.local")
+    echo "$output"
+    if echo "$output" | grep -q "cluster_name"; then
+        echo "=== CQL connection test passed ==="
+    else
+        echo "ERROR: CQL query did not return expected system.local data"
+        return 1
+    fi
+}
+
 step_verify_cassandra_backup() {
     if [ "$ENABLE_CASSANDRA" != true ]; then
         echo "=== Skipping Cassandra backup verification (use --cassandra to enable) ==="
@@ -1462,6 +1479,7 @@ STEPS_WORKDIR=(
     "step_test_mcp_server:Test server status endpoint"
     "step_verify_s3_backup:Verify S3 backup"
     "step_setup_cassandra:Setup Cassandra"
+    "step_test_cql_connection:Test CQL connection"
     "step_verify_cassandra_backup:Verify Cassandra backup"
     "step_verify_restore:Verify restore from VPC"
     "step_test_ssh_nodetool:Test SSH and nodetool"

--- a/openspec/changes/archive/2026-05-27-add-observability-urls-to-status/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-27-add-observability-urls-to-status/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-27

--- a/openspec/changes/archive/2026-05-27-add-observability-urls-to-status/design.md
+++ b/openspec/changes/archive/2026-05-27-add-observability-urls-to-status/design.md
@@ -1,0 +1,25 @@
+## Context
+
+The `/status` endpoint returns an `accessInfo.observability` object with URLs for services running on the control node. Currently it includes Grafana, VictoriaMetrics, and VictoriaLogs. Tempo (tracing) and Pyroscope (profiling) run on the same control node and have constants already defined (`TEMPO_PORT=3200`, `PYROSCOPE_PORT=4040` in `Constants.K8s`). The pattern for constructing URLs is uniform: `"http://$controlIp:$port"`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Expose `tempo` and `pyroscope` URLs in the `accessInfo.observability` response object, consistent with existing fields
+
+**Non-Goals:**
+- Changing how other fields are constructed
+- Adding conditional logic (these services always run on the control node)
+- Any changes to port assignments or service configuration
+
+## Decisions
+
+**Field naming: `tempo` and `pyroscope` (no `Url` suffix)**
+Consistent with existing fields (`grafana`, `victoriaMetrics`, `victoriaLogs`) which don't use a `Url` suffix. Diverging would be inconsistent.
+
+**No nullability**
+All other `ObservabilityAccess` fields are non-nullable `String`. Tempo and Pyroscope are always deployed on the control node alongside the rest of the observability stack, so no conditional logic is needed.
+
+## Risks / Trade-offs
+
+No meaningful risks. The ports are already defined constants, the construction pattern is identical to existing fields, and no consumers currently depend on the shape of `ObservabilityAccess` in tests.

--- a/openspec/changes/archive/2026-05-27-add-observability-urls-to-status/proposal.md
+++ b/openspec/changes/archive/2026-05-27-add-observability-urls-to-status/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+Pyroscope and Tempo are part of the observability stack on every cluster, but their URLs are absent from the `/status` endpoint's `accessInfo.observability` response. Consumers of the status API (MCP agents, scripts) have no way to discover these endpoints without hardcoding port numbers.
+
+## What Changes
+
+- Add `tempo` field to `ObservabilityAccess` in the `/status` response (port 3200)
+- Add `pyroscope` field to `ObservabilityAccess` in the `/status` response (port 4040)
+
+## Capabilities
+
+### New Capabilities
+
+None — this extends an existing capability.
+
+### Modified Capabilities
+
+- `server`: The `/status` endpoint's `accessInfo.observability` object now includes `tempo` and `pyroscope` URL fields alongside the existing `grafana`, `victoriaMetrics`, and `victoriaLogs` fields.
+
+## Impact
+
+- `src/main/kotlin/com/rustyrazorblade/easydblab/mcp/StatusResponse.kt` — `ObservabilityAccess` data class
+- `src/main/kotlin/com/rustyrazorblade/easydblab/mcp/StatusCache.kt` — `buildAccessInfo()` construction
+- No existing tests assert on `ObservabilityAccess` shape; no test changes required

--- a/openspec/changes/archive/2026-05-27-add-observability-urls-to-status/specs/server/spec.md
+++ b/openspec/changes/archive/2026-05-27-add-observability-urls-to-status/specs/server/spec.md
@@ -1,0 +1,16 @@
+## MODIFIED Requirements
+
+### Requirement: REQ-SERVER-003: REST Status Endpoints
+
+The server MUST expose REST HTTP endpoints for programmatic access to cluster status, independent of the MCP protocol.
+
+**Scenarios:**
+
+- **GIVEN** a running server, **WHEN** a client sends GET /status, **THEN** the server returns JSON with cluster info, EC2 instances, K8s pods, networking, security groups, EMR, OpenSearch, S3, Cassandra version, and access URLs.
+- **GIVEN** a running server, **WHEN** a client sends GET /status?section=nodes, **THEN** the server returns only the nodes section of the status response.
+- **GIVEN** a running server, **WHEN** a client sends GET /status?live=true, **THEN** the server bypasses the cache and fetches fresh data before responding.
+- **GIVEN** a running cluster with a reachable control node, **WHEN** a client sends GET /status, **THEN** the `accessInfo.observability` object SHALL include `tempo` and `pyroscope` URL fields alongside `grafana`, `victoriaMetrics`, and `victoriaLogs`.
+
+#### Scenario: Observability URLs include Tempo and Pyroscope
+- **WHEN** a client requests GET /status on a cluster with a reachable control node
+- **THEN** the response `accessInfo.observability` object contains `tempo` at `http://<controlPrivateIp>:3200` and `pyroscope` at `http://<controlPrivateIp>:4040`

--- a/openspec/changes/archive/2026-05-27-add-observability-urls-to-status/tasks.md
+++ b/openspec/changes/archive/2026-05-27-add-observability-urls-to-status/tasks.md
@@ -1,0 +1,7 @@
+## 1. Data Model
+
+- [x] 1.1 Add `tempo: String` and `pyroscope: String` fields to `ObservabilityAccess` in `StatusResponse.kt`
+
+## 2. URL Construction
+
+- [x] 2.1 Add `tempo` and `pyroscope` URL entries to `buildAccessInfo()` in `StatusCache.kt` using `Constants.K8s.TEMPO_PORT` and `Constants.K8s.PYROSCOPE_PORT`

--- a/openspec/changes/tailscale-direct-connect/.openspec.yaml
+++ b/openspec/changes/tailscale-direct-connect/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-27

--- a/openspec/changes/tailscale-direct-connect/design.md
+++ b/openspec/changes/tailscale-direct-connect/design.md
@@ -1,0 +1,55 @@
+## Context
+
+All cluster traffic (CQL, HTTP to Victoria metrics/logs, and K8s API calls via Fabric8) currently routes through a SOCKS5 proxy established via SSH dynamic port forwarding (`MinaSocksProxyService`). This was the only viable path when the developer's machine has no direct route to cluster private IPs.
+
+Tailscale changes this: when Tailscale is running locally and the cluster control node has Tailscale started (via `tailscale start`), the local machine is on the VPN mesh and private IPs are directly reachable. The SSH SOCKS tunnel is then redundant.
+
+The `tailscaleActive` flag is detected once at `init` time and persisted in `state.json`. All subsequent commands read this flag and skip the proxy.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Never start the SOCKS proxy when `tailscaleActive = true` in cluster state
+- Apply to all three proxy consumers: CQL driver, OkHttp (Victoria metrics/logs), Fabric8 K8s client
+- Zero behavior change when `tailscaleActive = false` (the default)
+
+**Non-Goals:**
+- Detecting Tailscale at runtime or per-connection (snapshot at init is sufficient)
+- Handling Tailscale disconnecting mid-session
+- Starting or managing Tailscale — that's already handled by `TailscaleService`
+
+## Decisions
+
+### Detection: `tailscale status --json` via ProcessBuilder
+
+Run `tailscale status --json` locally (no SSH) and check `BackendState == "Running"`. Falls back to `false` if tailscale isn't installed or the process fails.
+
+**Why not check a network interface (e.g., `utun`, `tailscale0`)?** Interface names vary by OS and Tailscale version; the CLI is more stable and gives authoritative state.
+
+**Why not check Tailscale on the remote host?** We need to know if *the local machine* can reach cluster private IPs. The cluster node's Tailscale state is a separate concern.
+
+### Storage: `tailscaleActive` field on `ClusterState`
+
+The field goes directly on `ClusterState` (not inside `InitConfig`) because it affects connection routing at command execution time, not cluster provisioning parameters.
+
+Default value `false` ensures backwards compatibility with existing `state.json` files.
+
+### Factory pattern: conditional inside existing classes, not new implementations
+
+Rather than introducing `DirectCqlSessionFactory`, `DirectHttpClientFactory`, etc., the existing factory classes each get `ClusterStateManager` injected and check `tailscaleActive` at creation time. This keeps the number of classes stable and avoids a parallel class hierarchy.
+
+**`CqlSessionFactory`**: Add `createDirectSession(contactPoints, datacenter)` alongside existing `createSession(..., proxyPort)`. `CqlSessionService` selects which to call.
+
+**`ProxiedHttpClientFactory`**: Returns a plain `OkHttpClient` (no proxy) when `tailscaleActive`. The "Proxied" prefix in the class name becomes misleading — acceptable given this is an internal implementation class.
+
+**`ProxiedKubernetesClientFactory`**: Skips `config.httpsProxy` assignment when `tailscaleActive`.
+
+### `CqlSessionService.close()`: skip `socksProxyService.stop()` when Tailscale active
+
+If the proxy was never started, calling `stop()` is a no-op on the current implementation — but it's semantically wrong. The service should track whether it started the proxy and only stop it if it did.
+
+## Risks / Trade-offs
+
+- **Stale flag**: If Tailscale is started after `init`, the flag won't reflect it. User must re-init. → Acceptable; the pattern matches how other init-time decisions (instance type, region) work.
+- **Misleading class name**: `ProxiedHttpClientFactory` sometimes returns an unproxied client. → Low impact; the interface `HttpClientFactory` is what consumers depend on. Can rename in a follow-up if it becomes confusing.
+- **K8s module wiring**: `ProxiedKubernetesClientFactory` is currently created via a Koin factory lambda with `proxyPort` from `SocksProxyService`. It will need `ClusterStateManager` added to the lambda. → Straightforward Koin change.

--- a/openspec/changes/tailscale-direct-connect/proposal.md
+++ b/openspec/changes/tailscale-direct-connect/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+The SOCKS proxy (SSH dynamic port forwarding) is used for all cluster traffic — CQL, HTTP (Victoria metrics/logs), and K8s API calls — even when Tailscale is active. When Tailscale is running locally, the cluster's private IPs are directly reachable, making the SSH tunnel unnecessary overhead.
+
+## What Changes
+
+- Tailscale presence is detected locally (via `tailscale status --json`) during `init` and stored in `state.json` as `tailscaleActive`
+- When `tailscaleActive` is `true`, all three proxy consumers (CQL driver, OkHttp, Fabric8 K8s client) connect directly to private IPs with no SOCKS proxy
+- The SOCKS proxy is never started when Tailscale is active
+
+## Capabilities
+
+### New Capabilities
+
+- `tailscale-direct-connect`: Detect local Tailscale at init time and bypass the SOCKS proxy for all cluster connections when active
+
+### Modified Capabilities
+
+- `networking`: Connection routing behavior changes — direct path added alongside existing SOCKS proxy path
+
+## Impact
+
+- `ClusterState` / `state.json`: new `tailscaleActive` boolean field
+- `Init` command: runs local Tailscale detection during state setup
+- `CqlSessionService` + `CqlSessionFactory`: conditional proxy bypass for CQL
+- `ProxiedHttpClientFactory`: conditional proxy bypass for Victoria metrics/logs HTTP
+- `ProxiedKubernetesClientFactory` + its Koin module: conditional proxy bypass for K8s API

--- a/openspec/changes/tailscale-direct-connect/specs/networking/spec.md
+++ b/openspec/changes/tailscale-direct-connect/specs/networking/spec.md
@@ -1,0 +1,17 @@
+## MODIFIED Requirements
+
+### Requirement: SOCKS Proxy
+The system MUST support a SOCKS5 proxy via SSH dynamic port forwarding for routing traffic to internal cluster services when Tailscale is not active. When `tailscaleActive` is `true` in cluster state, the SOCKS proxy SHALL NOT be started or used; all traffic routes directly to cluster private IPs instead.
+
+#### Scenario: SOCKS proxy used without Tailscale
+- **WHEN** a component needs to reach internal cluster services and `tailscaleActive` is `false`
+- **THEN** a SOCKS proxy is established through an SSH tunnel to a cluster node
+
+#### Scenario: SOCKS proxy skipped with Tailscale active
+- **WHEN** a component needs to reach internal cluster services and `tailscaleActive` is `true`
+- **THEN** no SOCKS proxy is started and connections are made directly to private IPs
+
+#### Scenario: SOCKS proxy persists in long-running mode without Tailscale
+- **GIVEN** the REPL or server is running and `tailscaleActive` is `false`
+- **WHEN** the proxy is needed
+- **THEN** it persists for the lifetime of the session rather than per-command

--- a/openspec/changes/tailscale-direct-connect/specs/tailscale-direct-connect/spec.md
+++ b/openspec/changes/tailscale-direct-connect/specs/tailscale-direct-connect/spec.md
@@ -1,0 +1,38 @@
+## ADDED Requirements
+
+### Requirement: Local Tailscale detection at init
+The system SHALL detect whether Tailscale is running on the local machine during `init` by running `tailscale status --json` via a subprocess and checking that `BackendState` equals `"Running"`. The result SHALL be stored as `tailscaleActive` in `state.json`. If the `tailscale` binary is not installed or the subprocess fails, the system SHALL treat Tailscale as inactive (`false`).
+
+#### Scenario: Tailscale is running at init time
+- **WHEN** the user runs `init` and `tailscale status --json` returns `BackendState: "Running"`
+- **THEN** `state.json` is written with `tailscaleActive: true`
+
+#### Scenario: Tailscale is not installed at init time
+- **WHEN** the user runs `init` and the `tailscale` binary is not found
+- **THEN** `state.json` is written with `tailscaleActive: false` and no error is shown
+
+#### Scenario: Tailscale is installed but not connected at init time
+- **WHEN** the user runs `init` and `tailscale status --json` returns a non-Running `BackendState`
+- **THEN** `state.json` is written with `tailscaleActive: false`
+
+### Requirement: SOCKS proxy bypassed when Tailscale active
+When `tailscaleActive` is `true` in cluster state, the system SHALL NOT start or use the SOCKS proxy for any cluster connection. This applies to CQL (Cassandra Java driver), HTTP (Victoria metrics and logs via OkHttp), and Kubernetes API (Fabric8 client). All connections SHALL use the cluster node's private IP directly.
+
+#### Scenario: CQL connection with Tailscale active
+- **WHEN** `tailscaleActive` is `true` and a CQL command is executed
+- **THEN** no SOCKS proxy is started and the Cassandra driver connects directly to private IPs on port 9042
+
+#### Scenario: HTTP connection with Tailscale active
+- **WHEN** `tailscaleActive` is `true` and Victoria metrics or logs are queried
+- **THEN** the OkHttp client has no proxy configured and connects directly to the private IP
+
+#### Scenario: Kubernetes API connection with Tailscale active
+- **WHEN** `tailscaleActive` is `true` and any K8s operation is performed
+- **THEN** the Fabric8 client has no `httpsProxy` set and connects directly to the K3s API on the private IP
+
+### Requirement: SOCKS proxy used unchanged when Tailscale inactive
+When `tailscaleActive` is `false` (the default for all existing clusters), the system SHALL behave identically to pre-change behavior: SOCKS proxy is started on demand and used for all cluster connections.
+
+#### Scenario: Existing cluster state without tailscaleActive field
+- **WHEN** an existing `state.json` is loaded that has no `tailscaleActive` field
+- **THEN** the system treats it as `false` and uses the SOCKS proxy as before

--- a/openspec/changes/tailscale-direct-connect/tasks.md
+++ b/openspec/changes/tailscale-direct-connect/tasks.md
@@ -1,0 +1,33 @@
+## 1. Cluster State
+
+- [x] 1.1 Add `tailscaleActive: Boolean = false` field to `ClusterState` data class
+
+## 2. Local Tailscale Detection
+
+- [x] 2.1 Add a `detectLocalTailscale(): Boolean` function (private, in `Init.kt` or a companion) that runs `tailscale status --json` via `ProcessBuilder`, parses `BackendState`, and returns `false` on any failure
+- [x] 2.2 Call `detectLocalTailscale()` in `Init.prepareEnvironment()` and set `tailscaleActive` on the `ClusterState` before saving
+
+## 3. CQL Session — Direct Path
+
+- [x] 3.1 Add `createDirectSession(contactPoints: List<String>, datacenter: String): CqlSession` to `CqlSessionFactory` interface and `DefaultCqlSessionFactory` (uses plain `CqlSession.builder()`, same driver config, no proxy)
+- [x] 3.2 Update `CqlSessionService.getOrCreateSession()` to check `clusterState.tailscaleActive`: if `true`, skip `socksProxyService.ensureRunning()` and call `sessionFactory.createDirectSession()`
+- [x] 3.3 Update `CqlSessionService.close()` to only call `socksProxyService.stop()` when the proxy was actually used
+
+## 4. HTTP Client — Direct Path
+
+- [x] 4.1 Inject `ClusterStateManager` into `ProxiedHttpClientFactory`
+- [x] 4.2 In `ProxiedHttpClientFactory.createClient()`, check `clusterStateManager.load().tailscaleActive`: if `true`, return a plain `OkHttpClient` with no proxy
+
+## 5. Kubernetes Client — Direct Path
+
+- [x] 5.1 Inject `ClusterStateManager` into `ProxiedKubernetesClientFactory`
+- [x] 5.2 In `ProxiedKubernetesClientFactory.createClient()`, check `tailscaleActive`: if `true`, skip `config.httpsProxy` assignment
+- [x] 5.3 Update `KubernetesModule.kt` Koin factory lambda to inject and pass `ClusterStateManager`
+
+## 6. Tests
+
+- [x] 6.1 Unit test `detectLocalTailscale()` for: tailscale running, tailscale not connected, tailscale not installed (verify returns `false` without throwing)
+- [x] 6.2 Unit test `DefaultCqlSessionFactory.createDirectSession()` produces a session config without SOCKS proxy options
+- [x] 6.3 Unit test `CqlSessionService` with `tailscaleActive=true`: verify `socksProxyService.ensureRunning()` is never called
+- [x] 6.4 Unit test `ProxiedHttpClientFactory` with `tailscaleActive=true`: verify returned `OkHttpClient` has no proxy set
+- [x] 6.5 Unit test `ProxiedKubernetesClientFactory` with `tailscaleActive=true`: verify `config.httpsProxy` is `null`

--- a/openspec/specs/server/spec.md
+++ b/openspec/specs/server/spec.md
@@ -30,6 +30,11 @@ The server MUST expose REST HTTP endpoints for programmatic access to cluster st
 - **GIVEN** a running server, **WHEN** a client sends GET /status, **THEN** the server returns JSON with cluster info, EC2 instances, K8s pods, networking, security groups, EMR, OpenSearch, S3, Cassandra version, and access URLs.
 - **GIVEN** a running server, **WHEN** a client sends GET /status?section=nodes, **THEN** the server returns only the nodes section of the status response.
 - **GIVEN** a running server, **WHEN** a client sends GET /status?live=true, **THEN** the server bypasses the cache and fetches fresh data before responding.
+- **GIVEN** a running cluster with a reachable control node, **WHEN** a client sends GET /status, **THEN** the `accessInfo.observability` object SHALL include `tempo` and `pyroscope` URL fields alongside `grafana`, `victoriaMetrics`, and `victoriaLogs`.
+
+#### Scenario: Observability URLs include Tempo and Pyroscope
+- **WHEN** a client requests GET /status on a cluster with a reachable control node
+- **THEN** the response `accessInfo.observability` object contains `tempo` at `http://<controlPrivateIp>:3200` and `pyroscope` at `http://<controlPrivateIp>:4040`
 
 ### REQ-SERVER-004: Background Status Cache
 

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/Constants.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/Constants.kt
@@ -316,6 +316,7 @@ object Constants {
         const val AUTH_KEY_EXPIRY_SECONDS = 604800
         const val DAEMON_STARTUP_DELAY_MS = 2000L
         const val DEFAULT_DEVICE_TAG = "tag:easy-db-lab"
+        const val STATUS_TIMEOUT_SECONDS = 5L
     }
 
     // Container Registry configuration

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Init.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Init.kt
@@ -23,6 +23,8 @@ import picocli.CommandLine.Option
 import picocli.CommandLine.Parameters
 import java.io.File
 import java.time.LocalDate
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.TimeUnit
 import kotlin.system.exitProcess
 
 /**
@@ -272,6 +274,7 @@ class Init : PicoBaseCommand() {
                 name = name,
                 versions = mutableMapOf(),
                 initConfig = InitConfig.fromInit(this, userConfig.region),
+                tailscaleActive = detectLocalTailscale(),
             )
         clusterStateManager.save(state)
         return state
@@ -304,3 +307,28 @@ class Init : PicoBaseCommand() {
         )
     }
 }
+
+/**
+ * Parses the JSON output of `tailscale status --json` and returns true if BackendState is "Running".
+ * Exposed as an internal function so it can be tested independently of the process invocation.
+ */
+internal fun parseTailscaleOutput(json: String): Boolean = json.contains("\"BackendState\":\"Running\"")
+
+/**
+ * Detects whether Tailscale is running on the local machine by invoking `tailscale status --json`.
+ * Returns false if the binary is not installed, the process fails, or Tailscale is not connected.
+ */
+internal fun detectLocalTailscale(): Boolean =
+    runCatching {
+        val process =
+            ProcessBuilder("tailscale", "status", "--json")
+                .redirectErrorStream(true)
+                .start()
+        val outputFuture = CompletableFuture.supplyAsync { process.inputStream.bufferedReader().readText() }
+        if (!process.waitFor(Constants.Tailscale.STATUS_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+            process.destroyForcibly()
+            outputFuture.cancel(true)
+            return@runCatching false
+        }
+        parseTailscaleOutput(outputFuture.get())
+    }.getOrDefault(false)

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Status.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Status.kt
@@ -394,10 +394,12 @@ class Status :
 
         eventBus.emit(
             Event.Provision.ObservabilityAccessInfo(
-                controlHost.privateIp,
-                Constants.K8s.GRAFANA_PORT,
-                Constants.K8s.VICTORIAMETRICS_PORT,
-                Constants.K8s.VICTORIALOGS_PORT,
+                controlNodeIp = controlHost.privateIp,
+                grafanaPort = Constants.K8s.GRAFANA_PORT,
+                victoriaMetricsPort = Constants.K8s.VICTORIAMETRICS_PORT,
+                victoriaLogsPort = Constants.K8s.VICTORIALOGS_PORT,
+                tempoPort = Constants.K8s.TEMPO_PORT,
+                pyroscopePort = Constants.K8s.PYROSCOPE_PORT,
             ),
         )
     }

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/ClusterState.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/ClusterState.kt
@@ -202,6 +202,9 @@ data class ClusterState(
     var tailscaleAuthKeyId: String? = null,
     // Counter for stress job naming and port assignment
     var stressJobCounter: Int = 0,
+    // Whether Tailscale was active on the local machine at init time.
+    // When true, all cluster connections bypass the SOCKS proxy and use private IPs directly.
+    var tailscaleActive: Boolean = false,
 ) {
     /**
      * Returns true when the db nodes are running Cassandra (not ClickHouse or another database).

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/driver/CqlSessionFactory.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/driver/CqlSessionFactory.kt
@@ -1,6 +1,7 @@
 package com.rustyrazorblade.easydblab.driver
 
 import com.datastax.oss.driver.api.core.CqlSession
+import com.datastax.oss.driver.api.core.CqlSessionBuilder
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption
 import com.datastax.oss.driver.api.core.config.DriverConfigLoader
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -8,10 +9,10 @@ import java.net.InetSocketAddress
 import java.time.Duration
 
 /**
- * Factory for creating CqlSession instances configured for SOCKS proxy access.
+ * Factory for creating CqlSession instances.
  *
- * Uses the Java Driver's custom context mechanism to set up connections
- * through a SOCKS5 proxy for accessing Cassandra clusters on private networks.
+ * [createSession] routes through a SOCKS5 proxy; [createDirectSession] connects
+ * directly (used when Tailscale is active and private IPs are reachable).
  */
 interface CqlSessionFactory {
     /**
@@ -27,6 +28,19 @@ interface CqlSessionFactory {
         datacenter: String,
         proxyPort: Int,
     ): CqlSession
+
+    /**
+     * Create a CqlSession connected directly to the specified hosts (no proxy).
+     * Used when Tailscale is active and private IPs are reachable from the local machine.
+     *
+     * @param contactPoints List of Cassandra host private IPs
+     * @param datacenter The local datacenter name
+     * @return A connected CqlSession
+     */
+    fun createDirectSession(
+        contactPoints: List<String>,
+        datacenter: String,
+    ): CqlSession
 }
 
 /**
@@ -36,7 +50,7 @@ interface CqlSessionFactory {
  * [SocksProxyDriverContext] that provides [SocksProxyNettyOptions] for routing
  * all connections through a SOCKS5 proxy.
  */
-class DefaultCqlSessionFactory : CqlSessionFactory {
+open class DefaultCqlSessionFactory : CqlSessionFactory {
     companion object {
         private val log = KotlinLogging.logger {}
         private const val DEFAULT_PORT = 9042
@@ -44,6 +58,13 @@ class DefaultCqlSessionFactory : CqlSessionFactory {
         private const val CONNECTION_TIMEOUT_SECONDS = 30L
         private const val REQUEST_TIMEOUT_SECONDS = 60L
     }
+
+    internal open fun newDirectBuilder(): CqlSessionBuilder = CqlSession.builder()
+
+    internal open fun newProxiedBuilder(
+        proxyHost: String,
+        proxyPort: Int,
+    ): SocksProxySessionBuilder = SocksProxySessionBuilder(proxyHost, proxyPort)
 
     override fun createSession(
         contactPoints: List<String>,
@@ -53,29 +74,10 @@ class DefaultCqlSessionFactory : CqlSessionFactory {
         log.info { "Creating CqlSession with SOCKS proxy on port $proxyPort" }
         log.debug { "Contact points: $contactPoints, datacenter: $datacenter" }
 
-        val configLoader =
-            DriverConfigLoader
-                .programmaticBuilder()
-                .withDuration(
-                    DefaultDriverOption.CONNECTION_CONNECT_TIMEOUT,
-                    Duration.ofSeconds(CONNECTION_TIMEOUT_SECONDS),
-                ).withDuration(
-                    DefaultDriverOption.REQUEST_TIMEOUT,
-                    Duration.ofSeconds(REQUEST_TIMEOUT_SECONDS),
-                ).withString(DefaultDriverOption.LOAD_BALANCING_LOCAL_DATACENTER, datacenter)
-                // Disable metadata to avoid additional connections during initial setup
-                .withBoolean(DefaultDriverOption.METADATA_SCHEMA_ENABLED, false)
-                // Reduce connection pool size for initial connection
-                .withInt(DefaultDriverOption.CONNECTION_POOL_LOCAL_SIZE, 1)
-                .withInt(DefaultDriverOption.CONNECTION_POOL_REMOTE_SIZE, 1)
-                .build()
-
-        // Use our custom session builder that injects SOCKS proxy support
         val builder =
-            SocksProxySessionBuilder(DEFAULT_PROXY_HOST, proxyPort)
-                .withConfigLoader(configLoader)
+            newProxiedBuilder(DEFAULT_PROXY_HOST, proxyPort)
+                .withConfigLoader(buildConfigLoader(datacenter))
 
-        // Add contact points
         contactPoints.forEach { host ->
             builder.addContactPoint(InetSocketAddress(host, DEFAULT_PORT))
         }
@@ -84,4 +86,39 @@ class DefaultCqlSessionFactory : CqlSessionFactory {
         log.info { "CqlSession created successfully" }
         return session
     }
+
+    override fun createDirectSession(
+        contactPoints: List<String>,
+        datacenter: String,
+    ): CqlSession {
+        log.info { "Creating CqlSession with direct connection (Tailscale active)" }
+        log.debug { "Contact points: $contactPoints, datacenter: $datacenter" }
+
+        val builder = newDirectBuilder().withConfigLoader(buildConfigLoader(datacenter))
+
+        contactPoints.forEach { host ->
+            builder.addContactPoint(InetSocketAddress(host, DEFAULT_PORT))
+        }
+
+        val session = builder.build()
+        log.info { "CqlSession created successfully (direct)" }
+        return session
+    }
+
+    private fun buildConfigLoader(datacenter: String) =
+        DriverConfigLoader
+            .programmaticBuilder()
+            .withDuration(
+                DefaultDriverOption.CONNECTION_CONNECT_TIMEOUT,
+                Duration.ofSeconds(CONNECTION_TIMEOUT_SECONDS),
+            ).withDuration(
+                DefaultDriverOption.REQUEST_TIMEOUT,
+                Duration.ofSeconds(REQUEST_TIMEOUT_SECONDS),
+            ).withString(DefaultDriverOption.LOAD_BALANCING_LOCAL_DATACENTER, datacenter)
+            // Disable metadata to avoid additional connections during initial setup
+            .withBoolean(DefaultDriverOption.METADATA_SCHEMA_ENABLED, false)
+            // Reduce connection pool size for initial connection
+            .withInt(DefaultDriverOption.CONNECTION_POOL_LOCAL_SIZE, 1)
+            .withInt(DefaultDriverOption.CONNECTION_POOL_REMOTE_SIZE, 1)
+            .build()
 }

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/events/Event.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/events/Event.kt
@@ -3197,6 +3197,8 @@ sealed interface Event {
             val grafanaPort: Int,
             val victoriaMetricsPort: Int,
             val victoriaLogsPort: Int,
+            val tempoPort: Int,
+            val pyroscopePort: Int,
         ) : Provision {
             override fun toDisplayString(): String =
                 """
@@ -3205,6 +3207,8 @@ sealed interface Event {
                 |  Grafana:         http://$controlNodeIp:$grafanaPort
                 |  VictoriaMetrics: http://$controlNodeIp:$victoriaMetricsPort
                 |  VictoriaLogs:    http://$controlNodeIp:$victoriaLogsPort
+                |  Tempo:           http://$controlNodeIp:$tempoPort
+                |  Pyroscope:       http://$controlNodeIp:$pyroscopePort
                 |
                 """.trimMargin()
         }

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/kubernetes/KubernetesClientFactory.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/kubernetes/KubernetesClientFactory.kt
@@ -22,16 +22,17 @@ interface KubernetesClientFactory {
 }
 
 /**
- * Kubernetes client factory that configures SOCKS5 proxy for access to private clusters.
+ * Kubernetes client factory that routes K8s API traffic through a SOCKS5 proxy or directly,
+ * depending on whether Tailscale was active at init time.
  *
- * This is used when accessing K3s clusters running on private IPs through an SSH tunnel.
- *
- * @property proxyHost The SOCKS5 proxy host (typically "localhost")
+ * @property proxyHost The SOCKS5 proxy host (typically "127.0.0.1")
  * @property proxyPort The SOCKS5 proxy port
+ * @property tailscaleActive Whether Tailscale was active at init time; skips proxy when true
  */
 class ProxiedKubernetesClientFactory(
-    private val proxyHost: String = "localhost",
+    private val proxyHost: String = "127.0.0.1",
     private val proxyPort: Int,
+    private val tailscaleActive: Boolean,
 ) : KubernetesClientFactory {
     companion object {
         private const val CONNECTION_TIMEOUT_MS = 30000
@@ -39,15 +40,13 @@ class ProxiedKubernetesClientFactory(
     }
 
     override fun createClient(kubeconfigPath: Path): KubernetesClient {
-        // Load kubeconfig from file
         val kubeconfigContent = kubeconfigPath.toFile().readText()
         val config = Config.fromKubeconfig(kubeconfigContent)
 
-        // Configure SOCKS5 proxy for HTTPS (K8s API uses HTTPS on port 6443)
-        val proxyUrl = "socks5://$proxyHost:$proxyPort"
-        config.httpsProxy = proxyUrl
+        if (!tailscaleActive) {
+            config.httpsProxy = "socks5://$proxyHost:$proxyPort"
+        }
 
-        // Increase timeouts for SOCKS proxy connections (default 10s is too short)
         config.connectionTimeout = CONNECTION_TIMEOUT_MS
         config.requestTimeout = REQUEST_TIMEOUT_MS
 

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/kubernetes/KubernetesModule.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/kubernetes/KubernetesModule.kt
@@ -1,6 +1,7 @@
 package com.rustyrazorblade.easydblab.kubernetes
 
 import com.rustyrazorblade.easydblab.Constants
+import com.rustyrazorblade.easydblab.configuration.ClusterStateManager
 import com.rustyrazorblade.easydblab.proxy.SocksProxyService
 import org.koin.dsl.module
 import java.nio.file.Paths
@@ -9,7 +10,7 @@ import java.nio.file.Paths
  * Koin module for Kubernetes-related dependency injection.
  *
  * Provides:
- * - KubernetesClientFactory: Creates K8s API clients with SOCKS proxy support
+ * - KubernetesClientFactory: Creates K8s API clients, direct or SOCKS-proxied based on tailscaleActive
  * - KubernetesService: High-level service for K8s operations
  *
  * Note: Requires SocksProxyService from proxyModule and expects kubeconfig
@@ -17,13 +18,12 @@ import java.nio.file.Paths
  */
 val kubernetesModule =
     module {
-        // Kubernetes client factory - uses SOCKS proxy for private cluster access
         factory<KubernetesClientFactory> {
-            val proxyService = get<SocksProxyService>()
+            val tailscaleActive = get<ClusterStateManager>().load().tailscaleActive
             ProxiedKubernetesClientFactory(
-                // Use 127.0.0.1 for consistency with SOCKS proxy binding
                 proxyHost = "127.0.0.1",
-                proxyPort = proxyService.getLocalPort(),
+                proxyPort = get<SocksProxyService>().getLocalPort(),
+                tailscaleActive = tailscaleActive,
             )
         }
 

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/mcp/StatusCache.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/mcp/StatusCache.kt
@@ -482,6 +482,8 @@ class StatusCache(
                 grafana = "http://$controlIp:${Constants.K8s.GRAFANA_PORT}",
                 victoriaMetrics = "http://$controlIp:${Constants.K8s.VICTORIAMETRICS_PORT}",
                 victoriaLogs = "http://$controlIp:${Constants.K8s.VICTORIALOGS_PORT}",
+                tempo = "http://$controlIp:${Constants.K8s.TEMPO_PORT}",
+                pyroscope = "http://$controlIp:${Constants.K8s.PYROSCOPE_PORT}",
             )
 
         val clickhouse = buildClickHouseAccess(state, controlHost, instanceStates)

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/mcp/StatusResponse.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/mcp/StatusResponse.kt
@@ -153,6 +153,8 @@ data class ObservabilityAccess(
     val grafana: String,
     val victoriaMetrics: String,
     val victoriaLogs: String,
+    val tempo: String,
+    val pyroscope: String,
 )
 
 @Serializable

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/output/OutputHandler.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/output/OutputHandler.kt
@@ -476,10 +476,12 @@ class FilteringChannelOutputHandler(
 fun EventBus.displayObservabilityAccess(controlNodeIp: String) {
     emit(
         Event.Provision.ObservabilityAccessInfo(
-            controlNodeIp,
-            Constants.K8s.GRAFANA_PORT,
-            Constants.K8s.VICTORIAMETRICS_PORT,
-            Constants.K8s.VICTORIALOGS_PORT,
+            controlNodeIp = controlNodeIp,
+            grafanaPort = Constants.K8s.GRAFANA_PORT,
+            victoriaMetricsPort = Constants.K8s.VICTORIAMETRICS_PORT,
+            victoriaLogsPort = Constants.K8s.VICTORIALOGS_PORT,
+            tempoPort = Constants.K8s.TEMPO_PORT,
+            pyroscopePort = Constants.K8s.PYROSCOPE_PORT,
         ),
     )
 }

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/proxy/ProxiedHttpClientFactory.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/proxy/ProxiedHttpClientFactory.kt
@@ -1,5 +1,6 @@
 package com.rustyrazorblade.easydblab.proxy
 
+import com.rustyrazorblade.easydblab.configuration.ClusterStateManager
 import io.github.oshai.kotlinlogging.KotlinLogging
 import okhttp3.OkHttpClient
 import java.net.InetSocketAddress
@@ -19,7 +20,8 @@ private val log = KotlinLogging.logger {}
  */
 interface HttpClientFactory : AutoCloseable {
     /**
-     * Get an OkHttp client configured for proxy access.
+     * Get an OkHttp client configured for cluster access.
+     * Returns a direct client when Tailscale is active, or a SOCKS-proxied client otherwise.
      * Implementations should return a cached singleton client.
      *
      * @return Configured OkHttpClient ready for HTTP requests
@@ -28,15 +30,15 @@ interface HttpClientFactory : AutoCloseable {
 }
 
 /**
- * HTTP client factory that configures SOCKS5 proxy for access to private endpoints.
+ * HTTP client factory that routes cluster traffic through a SOCKS5 proxy or directly,
+ * depending on whether Tailscale was active at init time.
  *
- * This is used when accessing services running on private IPs through an SSH tunnel.
- * Uses OkHttp which has native SOCKS5 proxy support.
- *
- * @property socksProxyService The SOCKS proxy service for establishing connections
+ * @property socksProxyService The SOCKS proxy service for non-Tailscale connections
+ * @property clusterStateManager Used to check [tailscaleActive] at client creation time
  */
 class ProxiedHttpClientFactory(
     private val socksProxyService: SocksProxyService,
+    private val clusterStateManager: ClusterStateManager,
 ) : HttpClientFactory {
     companion object {
         private const val CONNECTION_TIMEOUT_SECONDS = 30L
@@ -52,18 +54,25 @@ class ProxiedHttpClientFactory(
         synchronized(this) {
             cachedClient?.let { return it }
 
-            val proxyPort = socksProxyService.getLocalPort()
-            log.info { "Creating OkHttp client with SOCKS5 proxy on 127.0.0.1:$proxyPort" }
-
-            val proxy = Proxy(Proxy.Type.SOCKS, InetSocketAddress("127.0.0.1", proxyPort))
-
             val client =
-                OkHttpClient
-                    .Builder()
-                    .proxy(proxy)
-                    .connectTimeout(CONNECTION_TIMEOUT_SECONDS, TimeUnit.SECONDS)
-                    .readTimeout(READ_TIMEOUT_SECONDS, TimeUnit.SECONDS)
-                    .build()
+                if (clusterStateManager.load().tailscaleActive) {
+                    log.info { "Creating direct OkHttp client (Tailscale active)" }
+                    OkHttpClient
+                        .Builder()
+                        .connectTimeout(CONNECTION_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                        .readTimeout(READ_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                        .build()
+                } else {
+                    val proxyPort = socksProxyService.getLocalPort()
+                    log.info { "Creating OkHttp client with SOCKS5 proxy on 127.0.0.1:$proxyPort" }
+                    val proxy = Proxy(Proxy.Type.SOCKS, InetSocketAddress("127.0.0.1", proxyPort))
+                    OkHttpClient
+                        .Builder()
+                        .proxy(proxy)
+                        .connectTimeout(CONNECTION_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                        .readTimeout(READ_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                        .build()
+                }
 
             cachedClient = client
             return client

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/proxy/ProxyModule.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/proxy/ProxyModule.kt
@@ -1,5 +1,6 @@
 package com.rustyrazorblade.easydblab.proxy
 
+import com.rustyrazorblade.easydblab.configuration.ClusterStateManager
 import com.rustyrazorblade.easydblab.services.ResourceManager
 import org.koin.dsl.module
 
@@ -8,7 +9,7 @@ import org.koin.dsl.module
  *
  * Provides:
  * - SocksProxyService as a singleton (manages proxy lifecycle across requests in server mode)
- * - HttpClientFactory for creating HTTP clients that use the SOCKS proxy
+ * - HttpClientFactory for creating HTTP clients (direct or SOCKS-proxied based on tailscaleActive)
  *
  * Note: SSHConnectionProvider must be provided by sshModule
  */
@@ -19,10 +20,13 @@ val proxyModule =
         // Port is dynamically selected at startup to avoid conflicts.
         single<SocksProxyService> { MinaSocksProxyService(get()) }
 
-        // HTTP client factory - uses SOCKS proxy for accessing private endpoints
-        // Registered with ResourceManager so the cached OkHttpClient is cleaned up on exit
+        // HTTP client factory - routes via SOCKS proxy or directly depending on tailscaleActive.
+        // Registered with ResourceManager so the cached OkHttpClient is cleaned up on exit.
         single<HttpClientFactory> {
-            ProxiedHttpClientFactory(get()).also { factory ->
+            ProxiedHttpClientFactory(
+                socksProxyService = get(),
+                clusterStateManager = get<ClusterStateManager>(),
+            ).also { factory ->
                 get<ResourceManager>().register(factory)
             }
         }

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/CqlSessionService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/CqlSessionService.kt
@@ -30,7 +30,7 @@ interface CqlSessionService : AutoCloseable {
 /**
  * Default implementation using Java Driver v4.
  *
- * Always uses SOCKS proxy for reliable connections to Cassandra.
+ * Uses direct connection when Tailscale is active, SOCKS proxy otherwise.
  *
  * The session is cached for reuse in REPL/Server mode.
  * Registers with [ResourceManager] when session is created for centralized cleanup.
@@ -52,6 +52,7 @@ class DefaultCqlSessionService(
     private var cachedSession: CqlSession? = null
     private var cachedDatacenter: String? = null
     private var registeredWithResourceManager = false
+    private var proxyStarted = false
 
     override fun execute(cql: String): Result<String> =
         runCatching {
@@ -67,13 +68,15 @@ class DefaultCqlSessionService(
         }
 
     override fun close() {
-        log.debug { "Closing CqlSession and SOCKS proxy" }
+        log.debug { "Closing CqlSession" }
         cachedSession?.close()
         cachedSession = null
         cachedDatacenter = null
         registeredWithResourceManager = false
-        // Also stop the SOCKS proxy to allow the JVM to exit
-        socksProxyService.stop()
+        if (proxyStarted) {
+            socksProxyService.stop()
+            proxyStarted = false
+        }
     }
 
     private fun getOrCreateSession(): CqlSession {
@@ -82,14 +85,9 @@ class DefaultCqlSessionService(
 
         require(cassandraHosts.isNotEmpty()) { "No Cassandra hosts found in cluster state" }
 
-        // Use the datacenter from the first host or default to region
         val datacenter =
             clusterState.initConfig?.region
                 ?: error("No region/datacenter found in cluster state")
-
-        // Ensure SOCKS proxy is running
-        val gatewayHost = cassandraHosts.first()
-        socksProxyService.ensureRunning(gatewayHost)
 
         // Return cached session if valid
         cachedSession?.let { session ->
@@ -99,18 +97,24 @@ class DefaultCqlSessionService(
             session.close()
         }
 
-        // Get all private IPs
         val contactPoints = cassandraHosts.map { it.privateIp }
 
-        // Create session through SOCKS proxy
-        val proxyPort = socksProxyService.getLocalPort()
-        log.info { "Creating new CqlSession through SOCKS proxy on port $proxyPort" }
-        val session = sessionFactory.createSession(contactPoints, datacenter, proxyPort)
+        val session =
+            if (clusterState.tailscaleActive) {
+                log.info { "Creating new CqlSession via direct connection (Tailscale active)" }
+                sessionFactory.createDirectSession(contactPoints, datacenter)
+            } else {
+                val gatewayHost = cassandraHosts.first()
+                socksProxyService.ensureRunning(gatewayHost)
+                proxyStarted = true
+                val proxyPort = socksProxyService.getLocalPort()
+                log.info { "Creating new CqlSession through SOCKS proxy on port $proxyPort" }
+                sessionFactory.createSession(contactPoints, datacenter, proxyPort)
+            }
 
         cachedSession = session
         cachedDatacenter = datacenter
 
-        // Register with ResourceManager for centralized cleanup (only once)
         if (!registeredWithResourceManager) {
             resourceManager.register(this)
             registeredWithResourceManager = true

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/K3sService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/K3sService.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import com.rustyrazorblade.easydblab.Constants
 import com.rustyrazorblade.easydblab.configuration.ClusterHost
+import com.rustyrazorblade.easydblab.configuration.ClusterStateManager
 import com.rustyrazorblade.easydblab.configuration.Host
 import com.rustyrazorblade.easydblab.events.EventBus
 import com.rustyrazorblade.easydblab.kubernetes.DefaultKubernetesService
@@ -116,6 +117,7 @@ interface K3sService : SystemDServiceManager {
 class DefaultK3sService(
     remoteOps: RemoteOperationsService,
     private val socksProxyService: SocksProxyService,
+    private val clusterStateManager: ClusterStateManager,
     eventBus: EventBus,
 ) : AbstractSystemDServiceManager("k3s", remoteOps, eventBus),
     K3sService {
@@ -220,17 +222,7 @@ class DefaultK3sService(
         kubeconfigPath: Path,
     ): Result<List<KubernetesJob>> =
         runCatching {
-            socksProxyService.ensureRunning(controlHost)
-
-            val clientFactory =
-                ProxiedKubernetesClientFactory(
-                    proxyHost = "localhost",
-                    proxyPort = socksProxyService.getLocalPort(),
-                )
-            val kubeService = DefaultKubernetesService(clientFactory, kubeconfigPath)
-
-            // List all jobs
-            kubeService.listJobs().getOrThrow()
+            kubernetesService(controlHost, kubeconfigPath).listJobs().getOrThrow()
         }
 
     override fun listPods(
@@ -238,18 +230,25 @@ class DefaultK3sService(
         kubeconfigPath: Path,
     ): Result<List<KubernetesPod>> =
         runCatching {
-            socksProxyService.ensureRunning(controlHost)
-
-            val clientFactory =
-                ProxiedKubernetesClientFactory(
-                    proxyHost = "localhost",
-                    proxyPort = socksProxyService.getLocalPort(),
-                )
-            val kubeService = DefaultKubernetesService(clientFactory, kubeconfigPath)
-
-            // List all pods
-            kubeService.listPods().getOrThrow()
+            kubernetesService(controlHost, kubeconfigPath).listPods().getOrThrow()
         }
+
+    private fun kubernetesService(
+        controlHost: ClusterHost,
+        kubeconfigPath: Path,
+    ): DefaultKubernetesService {
+        val tailscaleActive = clusterStateManager.load().tailscaleActive
+        if (!tailscaleActive) {
+            socksProxyService.ensureRunning(controlHost)
+        }
+        val clientFactory =
+            ProxiedKubernetesClientFactory(
+                proxyHost = "127.0.0.1",
+                proxyPort = if (!tailscaleActive) socksProxyService.getLocalPort() else 0,
+                tailscaleActive = tailscaleActive,
+            )
+        return DefaultKubernetesService(clientFactory, kubeconfigPath)
+    }
 
     /**
      * Uploads a script from classpath resources to a remote host.

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/K8sClientProvider.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/K8sClientProvider.kt
@@ -2,6 +2,7 @@ package com.rustyrazorblade.easydblab.services
 
 import com.rustyrazorblade.easydblab.Constants
 import com.rustyrazorblade.easydblab.configuration.ClusterHost
+import com.rustyrazorblade.easydblab.configuration.ClusterStateManager
 import com.rustyrazorblade.easydblab.kubernetes.ProxiedKubernetesClientFactory
 import com.rustyrazorblade.easydblab.proxy.SocksProxyService
 import io.fabric8.kubernetes.client.KubernetesClient
@@ -11,25 +12,31 @@ import java.nio.file.Path
 private val log = KotlinLogging.logger {}
 
 /**
- * Creates Kubernetes clients using a SOCKS5 proxy for reliable internal network access.
+ * Creates Kubernetes clients, routing through a SOCKS5 proxy or directly
+ * depending on whether Tailscale was active at init time.
  * Shared by all K8s operation implementations.
  */
 class K8sClientProvider(
     private val socksProxyService: SocksProxyService,
+    private val clusterStateManager: ClusterStateManager,
 ) {
     fun createClient(controlHost: ClusterHost): KubernetesClient {
         log.debug { "Creating K8s client for ${controlHost.alias} (${controlHost.privateIp})" }
 
-        socksProxyService.ensureRunning(controlHost)
-        val proxyPort = socksProxyService.getLocalPort()
+        val tailscaleActive = clusterStateManager.load().tailscaleActive
+        if (!tailscaleActive) {
+            socksProxyService.ensureRunning(controlHost)
+        }
+        val proxyPort = if (!tailscaleActive) socksProxyService.getLocalPort() else 0
 
         val kubeconfigPath = Path.of(Constants.K3s.LOCAL_KUBECONFIG)
-        log.debug { "Using kubeconfig=$kubeconfigPath proxy=localhost:$proxyPort" }
+        log.debug { "Using kubeconfig=$kubeconfigPath tailscale=$tailscaleActive" }
 
         val clientFactory =
             ProxiedKubernetesClientFactory(
-                proxyHost = "localhost",
+                proxyHost = "127.0.0.1",
                 proxyPort = proxyPort,
+                tailscaleActive = tailscaleActive,
             )
 
         val client = clientFactory.createClient(kubeconfigPath)

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/commands/TailscaleDetectionTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/commands/TailscaleDetectionTest.kt
@@ -1,0 +1,45 @@
+package com.rustyrazorblade.easydblab.commands
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatCode
+import org.junit.jupiter.api.Test
+
+class TailscaleDetectionTest {
+    @Test
+    fun `parseTailscaleOutput returns true when BackendState is Running`() {
+        val json = """{"BackendState":"Running","Version":"1.60.0","TailscaleIPs":["100.x.x.x"]}"""
+        assertThat(parseTailscaleOutput(json)).isTrue()
+    }
+
+    @Test
+    fun `parseTailscaleOutput returns false when BackendState is Stopped`() {
+        val json = """{"BackendState":"Stopped"}"""
+        assertThat(parseTailscaleOutput(json)).isFalse()
+    }
+
+    @Test
+    fun `parseTailscaleOutput returns false when BackendState is NeedsLogin`() {
+        val json = """{"BackendState":"NeedsLogin"}"""
+        assertThat(parseTailscaleOutput(json)).isFalse()
+    }
+
+    @Test
+    fun `parseTailscaleOutput returns false for empty string`() {
+        assertThat(parseTailscaleOutput("")).isFalse()
+    }
+
+    @Test
+    fun `parseTailscaleOutput returns false for JSON with spaces around colon`() {
+        // The implementation uses exact string matching — Tailscale CLI always emits
+        // compact JSON, so "BackendState" : "Running" (with spaces) is not matched.
+        val json = """{"BackendState" : "Running"}"""
+        assertThat(parseTailscaleOutput(json)).isFalse()
+    }
+
+    @Test
+    fun `detectLocalTailscale does not throw when tailscale binary is absent`() {
+        // On CI where tailscale is not installed this exercises the IOException path.
+        // On dev machines with active Tailscale it simply returns true — both are valid.
+        assertThatCode { detectLocalTailscale() }.doesNotThrowAnyException()
+    }
+}

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/driver/CqlSessionFactoryTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/driver/CqlSessionFactoryTest.kt
@@ -1,10 +1,20 @@
 package com.rustyrazorblade.easydblab.driver
 
+import com.datastax.oss.driver.api.core.CqlSession
+import com.datastax.oss.driver.api.core.CqlSessionBuilder
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption
 import com.datastax.oss.driver.api.core.config.DriverConfigLoader
 import com.datastax.oss.driver.api.core.config.DriverExecutionProfile
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.spy
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import java.time.Duration
 
 /**
@@ -141,5 +151,44 @@ class CqlSessionFactoryConfigTest {
                 DefaultDriverOption.CONNECTION_POOL_REMOTE_SIZE,
             ),
         ).isEqualTo(1)
+    }
+}
+
+class DefaultCqlSessionFactoryTest {
+    private val mockSession = mock<CqlSession>()
+    private val mockDirectBuilder = mock<CqlSessionBuilder>()
+    private val mockSocksBuilder = mock<SocksProxySessionBuilder>()
+
+    @BeforeEach
+    fun setup() {
+        whenever(mockDirectBuilder.withConfigLoader(any())).thenReturn(mockDirectBuilder)
+        whenever(mockDirectBuilder.addContactPoint(any())).thenReturn(mockDirectBuilder)
+        whenever(mockDirectBuilder.build()).thenReturn(mockSession)
+
+        whenever(mockSocksBuilder.withConfigLoader(any())).thenReturn(mockSocksBuilder)
+        whenever(mockSocksBuilder.addContactPoint(any())).thenReturn(mockSocksBuilder)
+        whenever(mockSocksBuilder.build()).thenReturn(mockSession)
+    }
+
+    @Test
+    fun `createDirectSession uses plain builder not SocksProxySessionBuilder`() {
+        val factory = spy(DefaultCqlSessionFactory())
+        doReturn(mockDirectBuilder).whenever(factory).newDirectBuilder()
+
+        factory.createDirectSession(listOf("10.0.0.1"), "dc1")
+
+        verify(factory).newDirectBuilder()
+        verify(factory, never()).newProxiedBuilder(any(), any())
+    }
+
+    @Test
+    fun `createSession uses SocksProxySessionBuilder not plain builder`() {
+        val factory = spy(DefaultCqlSessionFactory())
+        doReturn(mockSocksBuilder).whenever(factory).newProxiedBuilder(any(), any())
+
+        factory.createSession(listOf("10.0.0.1"), "dc1", 1080)
+
+        verify(factory).newProxiedBuilder("127.0.0.1", 1080)
+        verify(factory, never()).newDirectBuilder()
     }
 }

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/kubernetes/ProxiedKubernetesClientFactoryTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/kubernetes/ProxiedKubernetesClientFactoryTest.kt
@@ -1,0 +1,67 @@
+package com.rustyrazorblade.easydblab.kubernetes
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+class ProxiedKubernetesClientFactoryTest {
+    @TempDir
+    lateinit var tempDir: File
+
+    private val minimalKubeconfig =
+        """
+        apiVersion: v1
+        clusters:
+        - cluster:
+            server: https://10.0.1.5:6443
+            insecure-skip-tls-verify: true
+          name: test-cluster
+        contexts:
+        - context:
+            cluster: test-cluster
+            user: admin
+          name: test-context
+        current-context: test-context
+        kind: Config
+        preferences: {}
+        users:
+        - name: admin
+          user:
+            token: fake-token-for-testing
+        """.trimIndent()
+
+    private fun writeKubeconfig(): java.nio.file.Path {
+        val file = File(tempDir, "kubeconfig")
+        file.writeText(minimalKubeconfig)
+        return file.toPath()
+    }
+
+    @Test
+    fun `httpsProxy is null on client config when tailscaleActive is true`() {
+        val factory =
+            ProxiedKubernetesClientFactory(
+                proxyHost = "127.0.0.1",
+                proxyPort = 1080,
+                tailscaleActive = true,
+            )
+
+        factory.createClient(writeKubeconfig()).use { client ->
+            assertThat(client.configuration.httpsProxy).isNull()
+        }
+    }
+
+    @Test
+    fun `httpsProxy is set on client config when tailscaleActive is false`() {
+        val factory =
+            ProxiedKubernetesClientFactory(
+                proxyHost = "127.0.0.1",
+                proxyPort = 1080,
+                tailscaleActive = false,
+            )
+
+        factory.createClient(writeKubeconfig()).use { client ->
+            assertThat(client.configuration.httpsProxy).isEqualTo("socks5://127.0.0.1:1080")
+        }
+    }
+}

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/proxy/ProxiedHttpClientFactoryTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/proxy/ProxiedHttpClientFactoryTest.kt
@@ -1,0 +1,47 @@
+package com.rustyrazorblade.easydblab.proxy
+
+import com.rustyrazorblade.easydblab.configuration.ClusterState
+import com.rustyrazorblade.easydblab.configuration.ClusterStateManager
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class ProxiedHttpClientFactoryTest {
+    private val mockSocksProxy: SocksProxyService = mock()
+    private val mockClusterStateManager: ClusterStateManager = mock()
+
+    private fun stateWith(tailscaleActive: Boolean) =
+        ClusterState(name = "test", versions = mutableMapOf(), tailscaleActive = tailscaleActive)
+
+    @Test
+    fun `createClient returns client with no proxy when tailscaleActive is true`() {
+        whenever(mockClusterStateManager.load()).thenReturn(stateWith(tailscaleActive = true))
+
+        val factory =
+            ProxiedHttpClientFactory(
+                socksProxyService = mockSocksProxy,
+                clusterStateManager = mockClusterStateManager,
+            )
+        val client = factory.createClient()
+
+        assertThat(client.proxy).isNull()
+        factory.close()
+    }
+
+    @Test
+    fun `createClient returns SOCKS-proxied client when tailscaleActive is false`() {
+        whenever(mockClusterStateManager.load()).thenReturn(stateWith(tailscaleActive = false))
+        whenever(mockSocksProxy.getLocalPort()).thenReturn(1080)
+
+        val factory =
+            ProxiedHttpClientFactory(
+                socksProxyService = mockSocksProxy,
+                clusterStateManager = mockClusterStateManager,
+            )
+        val client = factory.createClient()
+
+        assertThat(client.proxy).isNotNull()
+        factory.close()
+    }
+}

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/services/CqlSessionServiceTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/services/CqlSessionServiceTest.kt
@@ -1,0 +1,141 @@
+package com.rustyrazorblade.easydblab.services
+
+import com.rustyrazorblade.easydblab.BaseKoinTest
+import com.rustyrazorblade.easydblab.configuration.ClusterHost
+import com.rustyrazorblade.easydblab.configuration.ClusterState
+import com.rustyrazorblade.easydblab.configuration.ClusterStateManager
+import com.rustyrazorblade.easydblab.configuration.InitConfig
+import com.rustyrazorblade.easydblab.configuration.ServerType
+import com.rustyrazorblade.easydblab.driver.CqlSessionFactory
+import com.rustyrazorblade.easydblab.proxy.SocksProxyService
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.koin.core.module.Module
+import org.koin.dsl.module
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class CqlSessionServiceTest : BaseKoinTest() {
+    private lateinit var mockSocksProxy: SocksProxyService
+    private lateinit var mockClusterStateManager: ClusterStateManager
+    private lateinit var mockSessionFactory: CqlSessionFactory
+    private lateinit var mockResourceManager: ResourceManager
+
+    private val testHost =
+        ClusterHost(
+            publicIp = "54.1.2.3",
+            privateIp = "10.0.1.5",
+            alias = "db0",
+            availabilityZone = "us-west-2a",
+        )
+
+    private fun stateWith(tailscaleActive: Boolean) =
+        ClusterState(
+            name = "test",
+            versions = mutableMapOf(),
+            tailscaleActive = tailscaleActive,
+            initConfig = InitConfig(region = "us-west-2"),
+            hosts = mapOf(ServerType.Cassandra to listOf(testHost)),
+        )
+
+    override fun additionalTestModules(): List<Module> =
+        listOf(
+            module {
+                single<ClusterStateManager> { mockClusterStateManager }
+                single<SocksProxyService> { mockSocksProxy }
+                single<CqlSessionFactory> { mockSessionFactory }
+                single<ResourceManager> { mockResourceManager }
+            },
+        )
+
+    @BeforeEach
+    fun setupMocks() {
+        mockSocksProxy = mock()
+        mockClusterStateManager = mock()
+        mockSessionFactory = mock()
+        mockResourceManager = mock()
+
+        whenever(mockSocksProxy.getLocalPort()).thenReturn(1080)
+        val mockSession = mock<com.datastax.oss.driver.api.core.CqlSession>()
+        whenever(mockSession.isClosed).thenReturn(false)
+        whenever(mockSessionFactory.createDirectSession(any(), any())).thenReturn(mockSession)
+        whenever(mockSessionFactory.createSession(any(), any(), any())).thenReturn(mockSession)
+    }
+
+    @Test
+    fun `does not start SOCKS proxy when tailscaleActive is true`() {
+        whenever(mockClusterStateManager.load()).thenReturn(stateWith(tailscaleActive = true))
+
+        val service =
+            DefaultCqlSessionService(
+                socksProxyService = mockSocksProxy,
+                clusterStateManager = mockClusterStateManager,
+                sessionFactory = mockSessionFactory,
+                resourceManager = mockResourceManager,
+            )
+
+        service.execute("SELECT now() FROM system.local")
+
+        verify(mockSocksProxy, never()).ensureRunning(any())
+        verify(mockSessionFactory).createDirectSession(any(), any())
+        verify(mockSessionFactory, never()).createSession(any(), any(), any())
+    }
+
+    @Test
+    fun `starts SOCKS proxy and uses proxied session when tailscaleActive is false`() {
+        whenever(mockClusterStateManager.load()).thenReturn(stateWith(tailscaleActive = false))
+
+        val service =
+            DefaultCqlSessionService(
+                socksProxyService = mockSocksProxy,
+                clusterStateManager = mockClusterStateManager,
+                sessionFactory = mockSessionFactory,
+                resourceManager = mockResourceManager,
+            )
+
+        service.execute("SELECT now() FROM system.local")
+
+        verify(mockSocksProxy).ensureRunning(testHost)
+        verify(mockSessionFactory).createSession(any(), any(), any())
+        verify(mockSessionFactory, never()).createDirectSession(any(), any())
+    }
+
+    @Test
+    fun `does not stop SOCKS proxy on close when tailscaleActive is true`() {
+        whenever(mockClusterStateManager.load()).thenReturn(stateWith(tailscaleActive = true))
+
+        val service =
+            DefaultCqlSessionService(
+                socksProxyService = mockSocksProxy,
+                clusterStateManager = mockClusterStateManager,
+                sessionFactory = mockSessionFactory,
+                resourceManager = mockResourceManager,
+            )
+
+        service.execute("SELECT now() FROM system.local")
+        service.close()
+
+        verify(mockSocksProxy, never()).stop()
+    }
+
+    @Test
+    fun `stops SOCKS proxy on close when tailscaleActive is false`() {
+        whenever(mockClusterStateManager.load()).thenReturn(stateWith(tailscaleActive = false))
+
+        val service =
+            DefaultCqlSessionService(
+                socksProxyService = mockSocksProxy,
+                clusterStateManager = mockClusterStateManager,
+                sessionFactory = mockSessionFactory,
+                resourceManager = mockResourceManager,
+            )
+
+        service.execute("SELECT now() FROM system.local")
+        service.close()
+
+        verify(mockSocksProxy).stop()
+    }
+}

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/services/K3sServiceTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/services/K3sServiceTest.kt
@@ -1,6 +1,7 @@
 package com.rustyrazorblade.easydblab.services
 
 import com.rustyrazorblade.easydblab.BaseKoinTest
+import com.rustyrazorblade.easydblab.configuration.ClusterStateManager
 import com.rustyrazorblade.easydblab.configuration.Host
 import com.rustyrazorblade.easydblab.providers.ssh.RemoteOperationsService
 import com.rustyrazorblade.easydblab.proxy.SocksProxyService
@@ -41,7 +42,8 @@ class K3sServiceTest : BaseKoinTest() {
             module {
                 single<RemoteOperationsService> { mockRemoteOps }
                 single<SocksProxyService> { mockSocksProxyService }
-                factory<K3sService> { DefaultK3sService(get(), get(), get()) }
+                single<ClusterStateManager> { mock() }
+                factory<K3sService> { DefaultK3sService(get(), get(), get(), get()) }
             },
         )
 

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/services/K8sServiceTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/services/K8sServiceTest.kt
@@ -2,6 +2,8 @@ package com.rustyrazorblade.easydblab.services
 
 import com.rustyrazorblade.easydblab.BaseKoinTest
 import com.rustyrazorblade.easydblab.configuration.ClusterHost
+import com.rustyrazorblade.easydblab.configuration.ClusterState
+import com.rustyrazorblade.easydblab.configuration.ClusterStateManager
 import com.rustyrazorblade.easydblab.proxy.SocksProxyService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -10,6 +12,7 @@ import org.koin.core.module.Module
 import org.koin.dsl.module
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
@@ -22,6 +25,7 @@ import org.mockito.kotlin.whenever
  */
 class K8sServiceTest : BaseKoinTest() {
     private lateinit var mockSocksProxyService: SocksProxyService
+    private lateinit var mockClusterStateManager: ClusterStateManager
     private lateinit var k8sService: K8sService
 
     private val testClusterHost =
@@ -37,7 +41,8 @@ class K8sServiceTest : BaseKoinTest() {
         listOf(
             module {
                 single<SocksProxyService> { mockSocksProxyService }
-                single { K8sClientProvider(get()) }
+                single<ClusterStateManager> { mockClusterStateManager }
+                single { K8sClientProvider(get(), get()) }
                 factory<K8sService> { DefaultK8sService(get(), get()) }
             },
         )
@@ -45,6 +50,8 @@ class K8sServiceTest : BaseKoinTest() {
     @BeforeEach
     fun setupMocks() {
         mockSocksProxyService = mock()
+        mockClusterStateManager = mock()
+        whenever(mockClusterStateManager.load()).thenReturn(ClusterState(name = "test", versions = mutableMapOf()))
 
         k8sService = getKoin().get()
     }
@@ -52,7 +59,19 @@ class K8sServiceTest : BaseKoinTest() {
     // ========== SOCKS PROXY TESTS ==========
 
     @Test
-    fun `applyManifests should always use SOCKS proxy`() {
+    fun `applyManifests skips SOCKS proxy when tailscaleActive is true`() {
+        whenever(mockClusterStateManager.load()).thenReturn(
+            ClusterState(name = "test", versions = mutableMapOf(), tailscaleActive = true),
+        )
+        val manifestDir = createTestManifestDir()
+
+        k8sService.applyManifests(testClusterHost, manifestDir)
+
+        verify(mockSocksProxyService, never()).ensureRunning(any())
+    }
+
+    @Test
+    fun `applyManifests uses SOCKS proxy when tailscaleActive is false`() {
         // Given
         val manifestDir = createTestManifestDir()
         whenever(mockSocksProxyService.getLocalPort()).thenReturn(1080)
@@ -81,7 +100,7 @@ class K8sServiceTest : BaseKoinTest() {
     }
 
     @Test
-    fun `getObservabilityStatus should always use SOCKS proxy`() {
+    fun `getObservabilityStatus uses SOCKS proxy when tailscaleActive is false`() {
         // Given
         whenever(mockSocksProxyService.getLocalPort()).thenReturn(1080)
 
@@ -108,7 +127,7 @@ class K8sServiceTest : BaseKoinTest() {
     }
 
     @Test
-    fun `deleteObservability should always use SOCKS proxy`() {
+    fun `deleteObservability uses SOCKS proxy when tailscaleActive is false`() {
         // Given
         whenever(mockSocksProxyService.getLocalPort()).thenReturn(1080)
 
@@ -135,7 +154,7 @@ class K8sServiceTest : BaseKoinTest() {
     }
 
     @Test
-    fun `waitForPodsReady should always use SOCKS proxy`() {
+    fun `waitForPodsReady uses SOCKS proxy when tailscaleActive is false`() {
         // Given
         whenever(mockSocksProxyService.getLocalPort()).thenReturn(1080)
 


### PR DESCRIPTION
Detect local Tailscale at init time via `tailscale status --json` and store the result as `tailscaleActive` in ClusterState/state.json. When active, CQL sessions, HTTP clients (VictoriaMetrics/logs), and the Kubernetes API client connect directly over private IPs instead of routing through the SSH SOCKS5 tunnel.