### PR TITLE
feat(kit): add postgres kit with Presto integration and SQL capability

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,5 @@
 - **Clusters are ephemeral by design.** easy-db-lab spins up temporary test clusters that are destroyed after use. There is no production data, no long-lived deployments, and no users who need to migrate. **Do NOT warn about backwards compatibility** when reviewing PRs or planning changes — it is never a concern here.
+- **Large `storageSize` defaults in kit.yaml (e.g. `10Ti`) are intentional and correct.** Clusters use Local Persistent Volumes via the `local-storage` provisioner, which does not enforce PVC capacity — the declared size is metadata only and does not affect real disk usage. **Never flag large storage defaults as excessive, wasteful, or a bug** during code review or planning.
 - This is a **general purpose database test tool**, not a Cassandra-specific tool. It supports Cassandra, ClickHouse, OpenSearch, TiDB, and more. In user-facing text (docs, error messages, comments), use "database" or "db" instead of "Cassandra" unless referring to Cassandra-specific functionality. The `ServerType.Cassandra` / "db" node type is the generic database node — don't assume it's always Cassandra.
 - This is a command line tool.  The user interacts by reading the output.  Do not suggest replacing print statements with logging, because it breaks the UX.
 - **Structured user-facing output** uses `eventBus.emit(Event.Domain.Type(...))` with domain-specific typed events. Events are defined as sealed data classes in `events/Event.kt` across 28 domain interfaces. See [`events/CLAUDE.md`](src/main/kotlin/com/rustyrazorblade/easydblab/events/CLAUDE.md). **Events are for things an external system would need to be aware of** — lifecycle transitions, state changes, failures. If an MCP client or Redis subscriber would have no reason to care, it is not an event.
@@ -129,6 +130,7 @@ See [`src/test/.../CLAUDE.md`](src/test/kotlin/com/rustyrazorblade/easydblab/CLA
 - **Never add memory limiters to OTel collectors or other observability components.** The `memory_limiter` processor causes data to be refused and dropped under load. The nodes have enough memory — let them use it.
 - **Configuration problems require configuration fixes.** If a service can't connect to a dependency, the fix is to provide the correct endpoint/credentials, not to make the dependency optional.
 - **`RemoteOperationsService` is for commands that run on the remote control node** — filesystem operations, service management (systemd), node-level configuration, and all cluster API tooling (helm, kubectl, cilium). These tools are baked into the AMI and run on the control node via SSH. Use `RemoteOperationsService.executeRemotely()` with `KUBECONFIG=${Constants.K3s.REMOTE_KUBECONFIG}` prefixed on each command. Do NOT use `ProcessBuilder` or local CLI invocations for cluster operations — the tools are not installed on the developer's machine.
+- **Kit shell scripts that create K8s pods must use unique timestamp-based names** — use `pod-name-$(date +%s)` and label every pod with `easydblab/kit=${KIT_NAME}` and `easydblab/role=<role>`. Fixed pod names cause stale-pod conflicts after natural completion (the completed pod persists in K8s indefinitely). Cleanup in `stop.sh` must delete by label selector (`-l "easydblab/kit=...,easydblab/role=..."`) not by name. See `kits/sysbench/bin/` for the reference implementation.
 
 ### Testing
 
@@ -340,7 +342,11 @@ All observability K8s resources are built programmatically using Fabric8 manifes
 
 **Storage backends** (control node): VictoriaMetrics (metrics, port 8428), VictoriaLogs (logs, port 9428), Tempo (traces, port 3200), Pyroscope (profiles, port 4040)
 
-**Grafana** (port 3000): Dashboards built via `GrafanaManifestBuilder`. Dashboard JSON files live in the top-level `dashboards/` directory — Gradle copies them into the JAR at build time. `GrafanaDashboard` enum is the single source of truth for dashboard metadata. See [`dashboards/CLAUDE.md`](dashboards/CLAUDE.md) for datasource UIDs, label conventions, spanmetrics metric names, and the correct pattern for cross-dashboard dataLinks (panes= URL format, TraceQL query strings).
+**Grafana** (port 3000): Two dashboard sources:
+- **Kit dashboards (new, correct)**: JSON files in `src/main/resources/.../kits/<name>/dashboards/`. `KitRunnerCommand` auto-installs them from that directory after a successful `start`. No `GrafanaDashboard` enum entry needed — adding a JSON file is all that's required.
+- **Core/system dashboards (legacy)**: JSON files in the top-level `dashboards/` directory, registered in the `GrafanaDashboard` enum, loaded by `GrafanaManifestBuilder`. Use this only for non-kit dashboards (system-overview, profiling, etc.). **Do NOT add new kit dashboards here.**
+
+See [`dashboards/CLAUDE.md`](dashboards/CLAUDE.md) for datasource UIDs, label conventions, spanmetrics metric names, and the correct pattern for cross-dashboard dataLinks (panes= URL format, TraceQL query strings).
 
 **CLI Tool Instrumentation**: The CLI tool uses the OpenTelemetry Java Agent for automatic instrumentation of AWS SDK calls, HTTP clients, JDBC operations, and JVM metrics. No manual instrumentation exists in the Kotlin code. See `docs/reference/opentelemetry.md`.
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,6 +42,7 @@ group = "com.rustyrazorblade"
 
 tasks.withType<ShadowJar> {
     isZip64 = true
+    mergeServiceFiles()
 }
 
 java {
@@ -150,6 +151,7 @@ dependencies {
     implementation(libs.trino.jdbc)
     implementation(libs.clickhouse.jdbc)
     implementation(libs.mysql.connector.j)
+    implementation(libs.postgresql.jdbc)
 
     // Testing
     testImplementation(libs.archunit.junit5)

--- a/dashboards/CLAUDE.md
+++ b/dashboards/CLAUDE.md
@@ -219,6 +219,19 @@ GrafanaTracesToLogsConfig(
 
 **tracesToMetrics**: Use `traces_spanmetrics_duration_milliseconds_bucket` (not `latency_bucket`). Use `histogram_quantile(0.99, ...)` (p99, not p90). The `$$__tags` variable injects the span's service label as a Prometheus filter.
 
+## Kit Dashboard Metric Queries
+
+### NodePort Triple-Scraping
+
+When a kit exposes Prometheus metrics via a K8s NodePort, the OTel collector scrapes from every cluster node (each node's NodePort redirects to the same pod). This produces one series per node in VictoriaMetrics — typically 3× the actual value.
+
+- **Ratio queries** (e.g. cache hit ratio, error rate): triple-counting cancels out in numerator and denominator — no filter needed.
+- **Absolute queries** (rates, byte counts, gauge totals): must filter by `host_name="<db-node>"` to get the correct value. Use the node where the pod actually runs (check with `kubectl get pod <pod> -o wide`; for postgres kits this is typically `db0`).
+
+### VictoriaMetrics Counter Naming
+
+The local Prometheus exporter may expose counters without a `_total` suffix, but VictoriaMetrics stores them **with** `_total` following the OpenMetrics convention. Dashboard queries must always use the `_total` form (e.g. `cnpg_pg_stat_database_blks_hit_total`, not `cnpg_pg_stat_database_blks_hit`). Use the `/api/v1/label/__name__/values` endpoint on VictoriaMetrics to confirm the exact stored name before writing a query.
+
 ## Modifying Dashboards
 
 When adding new dashboards or modifying existing ones:

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -21,6 +21,7 @@
   - [Trino](user-guide/install-trino.md)
   - [TiDB](user-guide/tidb.md)
   - [Sysbench](user-guide/sysbench.md)
+  - [PostgreSQL](user-guide/install-postgres.md)
 - [Monitoring](user-guide/monitoring.md)
   - [Profiling](user-guide/profiling.md)
   - [Metrics](user-guide/victoria-metrics.md)

--- a/docs/user-guide/install-postgres.md
+++ b/docs/user-guide/install-postgres.md
@@ -1,0 +1,125 @@
+# Install PostgreSQL
+
+The `postgres` kit deploys PostgreSQL on K8s db nodes via the [CloudNativePG](https://cloudnative-pg.io/) (CNPG) operator. Data is persisted on PersistentVolumes — stopping and restarting preserves your dataset.
+
+## Prerequisites
+
+- Cluster is up (`easy-db-lab up`) with at least one db node
+
+## Quick Start
+
+```bash
+easy-db-lab kit install postgres
+easy-db-lab postgres start
+```
+
+## Flags
+
+| Flag | Default | Description |
+|---|---|---|
+| `--version` | `17` | PostgreSQL major version (e.g. `17`, `16`) |
+| `--instances` | `1` | Number of PostgreSQL instances; values > 1 deploy a primary and read replicas |
+| `--size` | `10Ti` | Storage size per db node (e.g. `100Gi`) |
+
+## Managing PostgreSQL
+
+```bash
+# Start PostgreSQL
+easy-db-lab postgres start
+
+# Stop PostgreSQL (data is preserved)
+easy-db-lab postgres stop
+
+# Remove operator and delete all PersistentVolumes
+easy-db-lab postgres uninstall
+```
+
+### start
+
+1. Creates PersistentVolumes on db nodes via `platform-pvs`
+2. Applies the CNPG `Cluster` custom resource
+3. Waits for all pods to reach `Ready`
+4. Applies the NodePort service for external access
+
+### stop
+
+Deletes the CNPG `Cluster` CR and the NodePort service. PersistentVolumes are retained — running `postgres start` again resumes from the existing dataset.
+
+### uninstall
+
+Deletes PersistentVolumes and uninstalls the CNPG operator Helm release.
+
+## Connecting
+
+The PostgreSQL primary is exposed as a NodePort on port `30432` of each db node.
+
+```bash
+# JDBC URL
+jdbc:postgresql://<db-node-ip>:30432/postgres
+
+# psql via SOCKS5 proxy or port-forward
+kubectl port-forward svc/postgres-nodeport 5432:5432
+psql -h localhost -U postgres postgres
+```
+
+The default user is `postgres` with password `postgres` (stored in the `postgres-credentials` K8s Secret).
+
+## Running SQL
+
+Use the built-in `sql` capability to execute queries directly:
+
+```bash
+easy-db-lab postgres sql "SELECT version()"
+easy-db-lab postgres sql --file query.sql
+```
+
+## Extensions
+
+PostgreSQL extensions that require custom container images are activated at **install time** via `--extension` on `kit install postgres`. Each extension installs as a separate named instance (e.g. `postgres-duckdb`) that starts and stops independently.
+
+### Listing available extensions
+
+```bash
+easy-db-lab postgres extensions
+```
+
+Outputs a table of alias names, image templates, shared_preload_libraries, and CREATE EXTENSION statements.
+
+### Built-in aliases
+
+| Alias | Description |
+|---|---|
+| `duckdb` | DuckDB analytical query engine via pg_duckdb |
+| `postgis` | Geospatial types and functions |
+| `timescaledb` | Time-series storage and query optimization |
+
+### Example
+
+```bash
+# Install with an extension
+easy-db-lab kit install postgres --extension duckdb
+
+# Start, stop, and use the named instance
+easy-db-lab postgres-duckdb start
+easy-db-lab postgres-duckdb sql "SELECT duckdb_version()"
+easy-db-lab postgres-duckdb stop
+```
+
+### Versioning
+
+Built-in alias images use `__PG_MAJOR__` as a placeholder for the PostgreSQL major version (e.g. `17`). This is substituted automatically from the `--version` flag set at install time.
+
+## Presto Integration
+
+When both `postgres` and `presto` are running, Presto automatically exposes a `postgres` catalog using the PostgreSQL JDBC connector pointed at the CNPG primary service. No manual configuration is needed.
+
+```bash
+easy-db-lab kit install postgres
+easy-db-lab postgres start
+
+easy-db-lab kit install presto
+easy-db-lab presto start
+
+# postgres catalog is available automatically
+easy-db-lab presto sql "SHOW CATALOGS"
+```

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -68,6 +68,7 @@ presto-jdbc = "0.289"
 trino-jdbc = "474"
 clickhouse-jdbc = "0.7.2"
 mysql-connector-j = "9.3.0"
+postgresql-jdbc = "42.7.4"
 resilience4j = "2.4.0"
 fabric8-kubernetes = "7.5.0"
 
@@ -188,6 +189,7 @@ presto-jdbc = { module = "com.facebook.presto:presto-jdbc", version.ref = "prest
 trino-jdbc = { module = "io.trino:trino-jdbc", version.ref = "trino-jdbc" }
 clickhouse-jdbc = { module = "com.clickhouse:clickhouse-jdbc", version.ref = "clickhouse-jdbc" }
 mysql-connector-j = { module = "com.mysql:mysql-connector-j", version.ref = "mysql-connector-j" }
+postgresql-jdbc = { module = "org.postgresql:postgresql", version.ref = "postgresql-jdbc" }
 
 
 [bundles]

--- a/openspec/changes/archive/2026-06-03-add-postgres/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-03-add-postgres/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-03

--- a/openspec/changes/archive/2026-06-03-add-postgres/design.md
+++ b/openspec/changes/archive/2026-06-03-add-postgres/design.md
@@ -1,0 +1,78 @@
+## Context
+
+easy-db-lab has two database kits (Cassandra, ClickHouse) and one app kit (Presto). Both database kits use a K8s operator pattern: install an operator via Helm, then manage a custom resource (CR) for the actual cluster. PostgreSQL follows this same pattern using CloudNativePG (CNPG).
+
+The SQL capability (introduced in the `kit-capabilities` change) lets users run `<kit> sql "<query>"` against any kit that declares a `jdbc` endpoint and `sql` capability. ClickHouse already uses this. PostgreSQL adds a second implementation with zero changes to the capability framework.
+
+Presto catalog injection works via a hook: when any workload starts or stops, Presto's `update-catalogs.sh` scans `RUNNING_KITS` and injects a `.properties` file per running kit. Adding postgres requires only a new `presto/catalogs/postgres.properties.template` file.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Deploy PostgreSQL via CNPG on K8s db nodes
+- Support configurable instance count (default 1, enables primary + read replicas)
+- Stop preserves data (PVs survive); uninstall cleans up
+- `postgres sql` command via JDBC
+- Presto sees `postgres` catalog when both kits are running
+- Consistent flag naming: `--version`, `--instances`, `--size`
+
+**Non-Goals:**
+- Backup/restore (deferred)
+- Custom database/user creation beyond defaults
+- TLS/SSL configuration
+- Connection pooling (PgBouncer)
+
+## Decisions
+
+### D1: CloudNativePG over alternatives
+
+**Decision**: Use CloudNativePG (CNPG) operator.
+
+**Alternatives considered**:
+- *Bitnami Helm chart*: Simple but opinionated; no operator pattern, harder to manage lifecycle.
+- *Zalando Postgres Operator*: Battle-tested but heavier; CRD surface is larger than needed.
+- *Bare StatefulSet*: Maximum control but requires hand-rolling all operator logic (failover, replication setup).
+
+**Rationale**: CNPG is the closest analogue to Altinity for ClickHouse — an operator that manages a `Cluster` CRD. It exports Prometheus metrics natively on port 9187, supports configurable instances, and has a clean Helm install path. Active CNCF project with frequent releases.
+
+### D2: NodePort assignment
+
+**Decision**: `30432` for PostgreSQL (mirrors 5432 with 3-prefix), `30987` for metrics (mirrors 9187 with 3-prefix).
+
+**Rationale**: In-use NodePorts are 30123, 30900, 30936. The 3-prefix pattern mirrors service ports and is easy to remember.
+
+### D3: Credentials
+
+**Decision**: user=`postgres`, password=`postgres`, db=`postgres`.
+
+**Rationale**: Test clusters only. Simple, memorable. CNPG creates a `postgres` superuser by default; we inject the password via a K8s Secret referenced by the Cluster CR.
+
+### D4: CNPG service naming
+
+**Decision**: Presto catalog uses `postgres-rw.default.svc.cluster.local:5432`.
+
+**Rationale**: CNPG creates `<cluster>-rw` (primary read-write) and `<cluster>-ro` (replicas) services automatically. The Cluster CR name will be `postgres`, so the primary service is `postgres-rw`. Presto should always write to the primary.
+
+### D5: PostgreSQL JDBC driver
+
+**Decision**: Add `org.postgresql:postgresql` to `gradle/libs.versions.toml` and `build.gradle.kts`.
+
+**Rationale**: Same pattern as ClickHouse (`com.clickhouse:clickhouse-jdbc`) and Presto (`com.facebook.presto:presto-jdbc`). The PostgreSQL driver auto-registers via `ServiceLoader`, so `driver-class` in kit.yaml can be left empty.
+
+### D6: ClickHouse flag rename
+
+**Decision**: Rename `--clickhouse-version` to `--version` in `clickhouse/kit.yaml`.
+
+**Rationale**: Consistency — all kits should use `--version` for their version arg. This is a cosmetic change with no behavior impact. Already applied to kit.yaml and KitInfoTest.kt.
+
+## Risks / Trade-offs
+
+- **CNPG Helm chart availability**: The CNPG Helm repo (`cloudnative-pg.github.io/charts`) must be reachable from the control node at install time. [Risk: offline/air-gapped clusters] → Mitigation: same risk exists for all Helm-based kits; not new.
+
+- **PV reattachment on start**: CNPG reattaches existing PVs by matching the `Cluster` CR name. If the CR name changes between stop/start, data will not be found. [Risk: user renames cluster] → Mitigation: the CR name is hardcoded to `postgres` in the template, not user-configurable.
+
+- **Instance count and PVs**: Each instance gets its own PV. If `--instances` decreases between stop/start, orphaned PVs are left behind. [Risk: wasted storage] → Mitigation: `platform-pvs-delete` on uninstall cleans all PVs; acceptable for test environments.
+
+## Open Questions
+
+- None — all design decisions resolved during explore phase.

--- a/openspec/changes/archive/2026-06-03-add-postgres/proposal.md
+++ b/openspec/changes/archive/2026-06-03-add-postgres/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+easy-db-lab supports Cassandra and ClickHouse as database workloads, but PostgreSQL — the world's most widely deployed open-source relational database — is missing. Adding a postgres kit lets users run SQL workloads, benchmark Postgres performance, and query it via Presto alongside other databases.
+
+## What Changes
+
+- New `postgres` kit deployed via the CloudNativePG (CNPG) operator on K8s db nodes
+- `postgres sql` command for interactive SQL execution via JDBC
+- Presto integration: `postgres` catalog auto-injected when postgres and presto are both running
+- PostgreSQL JDBC driver added as a runtime dependency
+- ClickHouse `--clickhouse-version` arg renamed to `--version` (consistency fix, no behavior change)
+
+## Capabilities
+
+### New Capabilities
+
+- `postgres`: Deploy and manage PostgreSQL clusters via the CloudNativePG operator; supports configurable instance count (replication), persistent storage, SQL execution, and Presto catalog integration.
+
+### Modified Capabilities
+
+- `presto`: PostgreSQL is now a supported catalog source alongside Cassandra and ClickHouse.
+
+## Impact
+
+- New files: `kits/postgres/` directory (kit.yaml, templates), `kits/presto/catalogs/postgres.properties.template`
+- `gradle/libs.versions.toml` and `build.gradle.kts`: add `org.postgresql:postgresql` JDBC driver
+- `kits/clickhouse/kit.yaml`: `--clickhouse-version` renamed to `--version`
+- `KitInfoTest.kt`: updated assertion for renamed ClickHouse flag (already applied)
+- No breaking changes to existing kits or commands

--- a/openspec/changes/archive/2026-06-03-add-postgres/specs/postgres/spec.md
+++ b/openspec/changes/archive/2026-06-03-add-postgres/specs/postgres/spec.md
@@ -1,0 +1,71 @@
+## ADDED Requirements
+
+### Requirement: K8s-Based Deployment via CloudNativePG
+
+The system MUST deploy PostgreSQL clusters on K8s db nodes via the CloudNativePG (CNPG) operator. The operator SHALL be installed via Helm (`cloudnative-pg/cloudnative-pg` chart into the `cnpg-system` namespace). The PostgreSQL cluster SHALL be defined as a CNPG `Cluster` custom resource named `postgres`.
+
+#### Scenario: Fresh install and start
+
+- **GIVEN** a running cluster with K3s, **WHEN** the user runs `kit install postgres` and `postgres start`, **THEN** the CNPG operator is installed and a PostgreSQL Cluster CR is deployed on db nodes.
+
+#### Scenario: Operator already present
+
+- **WHEN** the user runs `kit install postgres` on a cluster where CNPG is already installed, **THEN** the install succeeds without error.
+
+### Requirement: Configurable Instance Count
+
+The `postgres start` command SHALL accept a `--instances` argument (default: `1`) controlling how many PostgreSQL instances CNPG deploys. When `--instances` is greater than 1, CNPG deploys a primary and read replicas.
+
+#### Scenario: Single instance default
+
+- **WHEN** the user runs `postgres start` with no flags, **THEN** a single PostgreSQL instance is deployed.
+
+#### Scenario: Multi-instance replication
+
+- **WHEN** the user runs `postgres start --instances 3`, **THEN** CNPG deploys 1 primary and 2 read replicas.
+
+### Requirement: Data Lifecycle
+
+Stop MUST preserve data; data is only deleted on uninstall. Starting after a stop MUST resume the existing dataset without any additional user steps.
+
+#### Scenario: Stop preserves data
+
+- **WHEN** data is written to PostgreSQL, `postgres stop` is run, and then `postgres start` is run again, **THEN** the previously written data is accessible without any restore step.
+
+#### Scenario: Uninstall cleans up
+
+- **WHEN** the user runs `postgres uninstall`, **THEN** the CNPG operator is removed and all PersistentVolumes for db nodes are deleted.
+
+#### Scenario: Fresh start creates storage
+
+- **WHEN** `postgres start` is run after a fresh install with no prior starts, **THEN** PVs are created via `platform-pvs` and the Cluster CR is deployed successfully.
+
+### Requirement: SQL Execution
+
+The `postgres sql` command SHALL execute SQL statements against a running PostgreSQL cluster. SQL execution is provided via the `sql` capability declared in `postgres/kit.yaml` — see REQ-KCAP-002.
+
+The PostgreSQL JDBC driver (`org.postgresql:postgresql`) auto-registers via ServiceLoader. The `driver-class` field in the `sql` capability SHALL be left empty.
+
+#### Scenario: Query execution
+
+- **WHEN** the user runs `postgres sql "SELECT version()"`, **THEN** the query is submitted via JDBC and results are displayed in tabular format.
+
+#### Scenario: File-based query
+
+- **WHEN** the user runs `postgres sql --file query.sql`, **THEN** the SQL from the file is executed.
+
+#### Scenario: No db nodes
+
+- **WHEN** no db nodes exist in cluster state, **THEN** an error is emitted before any connection is made.
+
+### Requirement: Presto Integration
+
+When both the `postgres` and `presto` kits are running, Presto SHALL automatically expose a `postgres` catalog using the `postgresql` connector, pointing to the CNPG primary service (`postgres-rw.default.svc.cluster.local:5432`).
+
+#### Scenario: Catalog injection
+
+- **GIVEN** both `postgres start` and `presto start` have been run, **WHEN** Presto's `update-catalogs.sh` hook executes, **THEN** a `postgres` catalog is present in Presto and `SHOW CATALOGS` includes `postgres`.
+
+#### Scenario: Catalog absent without postgres
+
+- **WHEN** only presto is running (no postgres kit), **THEN** no `postgres` catalog appears in Presto.

--- a/openspec/changes/archive/2026-06-03-add-postgres/specs/presto/spec.md
+++ b/openspec/changes/archive/2026-06-03-add-postgres/specs/presto/spec.md
@@ -1,0 +1,23 @@
+## MODIFIED Requirements
+
+### Requirement: Catalog Sources
+
+The system SHALL support automatic catalog injection for the following database kits when they are running alongside Presto: Cassandra, ClickHouse, and PostgreSQL.
+
+A catalog properties file MUST exist in `kits/presto/catalogs/<kit-name>.properties.template` for each supported database kit. The `update-catalogs.sh` hook reads `RUNNING_KITS` and injects catalogs for any kit that has a matching properties file.
+
+#### Scenario: Cassandra catalog
+
+- **GIVEN** both `cassandra` and `presto` are running, **WHEN** `update-catalogs.sh` executes, **THEN** a `cassandra` catalog is present in Presto.
+
+#### Scenario: ClickHouse catalog
+
+- **GIVEN** both `clickhouse` and `presto` are running, **WHEN** `update-catalogs.sh` executes, **THEN** a `clickhouse` catalog is present in Presto.
+
+#### Scenario: PostgreSQL catalog
+
+- **GIVEN** both `postgres` and `presto` are running, **WHEN** `update-catalogs.sh` executes, **THEN** a `postgres` catalog is present in Presto using the `postgresql` connector pointed at `postgres-rw.default.svc.cluster.local:5432`.
+
+#### Scenario: No catalog for absent kit
+
+- **WHEN** a database kit is not running, **THEN** its catalog is not injected into Presto.

--- a/openspec/changes/archive/2026-06-03-add-postgres/tasks.md
+++ b/openspec/changes/archive/2026-06-03-add-postgres/tasks.md
@@ -1,0 +1,25 @@
+## 1. Dependencies
+
+- [x] 1.1 Add `postgresql-jdbc` version entry to `gradle/libs.versions.toml`
+- [x] 1.2 Add `postgresql-jdbc` library alias to `gradle/libs.versions.toml` libraries section
+- [x] 1.3 Add `implementation(libs.postgresql.jdbc)` to `build.gradle.kts`
+
+## 2. PostgreSQL Kit — Core Files
+
+- [x] 2.1 Create `kits/postgres/kit.yaml` with install/start/stop/uninstall phases, `--version` and `--instances` and `--size` args, JDBC endpoint on port 30432, metrics on 30987, and `sql` capability
+- [x] 2.2 Create `kits/postgres/postgres-cluster.yaml.template` — CNPG `Cluster` CR with `__INSTANCES__`, `__POSTGRES_VERSION__`, `__STORAGE_SIZE__` template variables
+- [x] 2.3 Create `kits/postgres/nodeport-service.yaml.template` — NodePort 30432 (postgres), 30987 (metrics)
+- [x] 2.4 Create `kits/postgres/README.md.template` with connection info and usage examples
+
+## 3. Presto Integration
+
+- [x] 3.1 Create `kits/presto/catalogs/postgres.properties.template` with `connector.name=postgresql` and CNPG primary service URL
+
+## 4. Tests
+
+- [x] 4.1 Add test in `KitRunnerCommandFactoryTest` verifying that the `postgres` kit registers a `sql` subcommand when a JDBC endpoint and `sql` capability are declared
+- [x] 4.2 Verify existing ClickHouse `--version` flag rename test passes (`KitInfoTest` — already updated)
+
+## 5. Build Verification
+
+- [x] 5.1 Run `./gradlew ktlintFormat && ./gradlew test && ./gradlew detekt` — all checks pass

--- a/openspec/changes/postgres-extensions/.openspec.yaml
+++ b/openspec/changes/postgres-extensions/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-09

--- a/openspec/changes/postgres-extensions/design.md
+++ b/openspec/changes/postgres-extensions/design.md
@@ -1,0 +1,72 @@
+## Context
+
+The postgres kit currently deploys a vanilla `ghcr.io/cloudnative-pg/postgresql` image. CNPG is image-based — extensions that require native libraries (pg_duckdb, PostGIS, TimescaleDB, etc.) must be compiled into the image. Three fields in the CNPG Cluster CR control extension configuration: `spec.imageName`, `spec.postgresql.parameters.shared_preload_libraries`, and `spec.bootstrap.initdb.postInitSQL`. The postgres kit currently hardcodes all three and provides no way for users to vary them.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Let users deploy postgres with any extension that ships a CNPG-compatible image
+- Ship built-in aliases for common extensions (duckdb, postgis, timescaledb) so the common case requires no image lookup
+- Allow combining a custom image with alias-provided preload/CREATE EXTENSION config
+- Make available aliases discoverable via `postgres extensions`
+
+**Non-Goals:**
+- Supporting extensions that require a pinned extension version in the image tag (e.g. pgvecto.rs `:pg17-v0.3.0`) as built-in aliases — use `--image` for those
+- Installing extensions into a running cluster post-start
+- Validating CNPG compatibility of user-supplied images at CLI time
+
+## Decisions
+
+### extensions.yaml as a standalone data file
+
+The alias registry lives in `src/main/resources/.../kits/postgres/extensions.yaml` alongside `kit.yaml`. Each entry contains: `description`, `image` (with `__PG_MAJOR__` placeholder), optional `shared_preload_libraries` list, and `create_extensions` list.
+
+`__PG_MAJOR__` is the only version placeholder. This matches the existing template system and covers every known extension that publishes stable floating tags by postgres major version. Extensions requiring a pinned extension version in the tag are not eligible for built-in aliases.
+
+**Alternative considered**: Encoding aliases in `kit.yaml`. Rejected — kit.yaml is behavioral config; a pure data registry belongs in a separate file and is easier to evolve independently.
+
+### Flag contract
+
+Four new flags on `postgres start`:
+
+| Flag | Description |
+|---|---|
+| `--extension <alias>` | Resolves alias from extensions.yaml; repeatable |
+| `--image <image>` | Overrides the image (from alias or default) |
+| `--shared-preload-libraries <lib>` | Appended to alias contributions; repeatable |
+| `--create-extension <name>` | Appended to alias contributions; repeatable |
+
+**Alternative considered**: A single `--extensions` list flag. Rejected — conflates alias lookup with raw CREATE EXTENSION names, and complicates the escape hatch story.
+
+### Option B: --image overrides, --extension still contributes non-image config
+
+When `--image` is provided alongside `--extension`, the image from the alias is ignored but its `shared_preload_libraries` and `create_extensions` still apply. This lets users bring a combined custom image while reusing known alias config:
+
+```bash
+postgres start --image my-registry/pg-custom:pg17 --extension duckdb --extension postgis
+```
+
+**Alternative considered**: Mutual exclusion between `--extension` and `--image`. Rejected — forces users who build combined images to re-specify all preload/extension config manually.
+
+### Multi-alias image conflict → error
+
+If two `--extension` aliases each define a different image and `--image` is not provided, the command fails with an actionable error explaining the user must build a combined image and supply it via `--image`.
+
+### postgres-cluster.yaml.template gains optional fields
+
+The template gains three new optional blocks rendered only when values are present:
+- `spec.imageName` — defaults to `ghcr.io/cloudnative-pg/postgresql:__POSTGRES_VERSION__`; overridden by resolved image
+- `spec.postgresql.parameters.shared_preload_libraries` — only emitted when non-empty
+- `spec.bootstrap.initdb.postInitSQL` — only emitted when CREATE EXTENSION list is non-empty
+
+Template rendering stays in the existing TemplateService pattern — no new rendering engine.
+
+### postgres extensions subcommand
+
+A new `postgres extensions` command (no sub-subcommand) reads `extensions.yaml` from the classpath and prints a table of alias → image template, preload libraries, extensions. Output via `println()` — read-only display command, no events.
+
+## Risks / Trade-offs
+
+- **Image tag staleness** — built-in aliases use floating `pg{V}` tags. If an upstream registry changes tag conventions, the alias breaks. Mitigation: document that aliases may need updates; `--image` always works as an escape hatch.
+- **CNPG image compatibility** — third-party images may not follow CNPG's uid/gid conventions. Mitigation: document which aliases are CNPG-officially-published vs third-party; fail fast at CNPG apply time with a clear pod error.
+- **shared_preload_libraries ordering** — PostgreSQL is sensitive to some preload library ordering. Mitigation: for the current alias set this is not an issue; if it becomes one, the user can use `--shared-preload-libraries` to supply the correct order.

--- a/openspec/changes/postgres-extensions/proposal.md
+++ b/openspec/changes/postgres-extensions/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+The postgres kit deploys a vanilla PostgreSQL image, but many real-world testing scenarios require extensions that are compiled into the image (pg_duckdb, PostGIS, TimescaleDB). Users currently have no way to deploy PostgreSQL with extensions without manually constructing CNPG Cluster CRs.
+
+## What Changes
+
+- Add `extensions.yaml` to the postgres kit resource directory — a registry mapping alias names to image template, shared_preload_libraries, and CREATE EXTENSION statements
+- Add `--extension <alias>` flag to `postgres start` — selects a built-in alias; repeatable
+- Add `--image <image>` flag to `postgres start` — overrides the image from any alias or the default
+- Add `--shared-preload-libraries <lib>` flag to `postgres start` — appends to alias-provided preload config; repeatable
+- Add `--create-extension <name>` flag to `postgres start` — appends to alias-provided CREATE EXTENSION list; repeatable
+- Add `postgres extensions` subcommand — lists all aliases from `extensions.yaml` in a table
+- Update `postgres-cluster.yaml.template` to support the new image, preload, and initdb fields
+- Update user docs for the postgres kit
+
+## Capabilities
+
+### New Capabilities
+
+- `postgres-extensions`: Registry-driven extension support for the postgres kit — alias resolution, flag contract, image override behavior, and the `postgres extensions` list subcommand
+
+### Modified Capabilities
+
+- `postgres`: The postgres kit gains new `start` flags and a new subcommand; the Cluster CR template gains new optional fields
+
+## Impact
+
+- `src/main/resources/com/rustyrazorblade/easydblab/kits/postgres/` — new `extensions.yaml`, updated `postgres-cluster.yaml.template`
+- Kotlin command class for `postgres start` — new flags, extension resolution logic
+- New `postgres extensions` command class
+- `docs/user-guide/install-postgres.md` — document new flags and aliases

--- a/openspec/changes/postgres-extensions/specs/postgres-extensions/spec.md
+++ b/openspec/changes/postgres-extensions/specs/postgres-extensions/spec.md
@@ -1,0 +1,73 @@
+# PostgreSQL Extensions
+
+Registry-driven extension support for the postgres kit. Provides built-in aliases that resolve to a CNPG-compatible image, shared_preload_libraries config, and CREATE EXTENSION statements. Also provides escape-hatch flags for custom images and unlisted extensions.
+
+## ADDED Requirements
+
+### Requirement: Extension Registry
+
+The postgres kit SHALL include an `extensions.yaml` file defining built-in extension aliases. Each alias SHALL specify: `description` (string), `image` (string with `__PG_MAJOR__` placeholder), optional `shared_preload_libraries` (list), and `create_extensions` (list). The registry SHALL include aliases for at minimum: `duckdb`, `postgis`, and `timescaledb`.
+
+#### Scenario: Registry is present in kit resources
+- **WHEN** the postgres kit is installed
+- **THEN** `extensions.yaml` is present alongside `kit.yaml` in the kit resource directory
+
+#### Scenario: Registry contains duckdb alias
+- **WHEN** `extensions.yaml` is loaded
+- **THEN** the `duckdb` alias resolves to image `ghcr.io/duckdb/pg_duckdb:pg__PG_MAJOR__`, shared_preload_libraries `[pg_duckdb]`, and create_extensions `[pg_duckdb]`
+
+### Requirement: --extension Flag Resolves Alias
+
+`postgres start` SHALL accept a repeatable `--extension <alias>` flag. When provided, the alias SHALL be resolved from `extensions.yaml`. The resolved image SHALL be used unless `--image` is also provided. Resolved `shared_preload_libraries` and `create_extensions` SHALL always be applied regardless of whether `--image` overrides the image.
+
+#### Scenario: Single alias sets image and creates extension
+- **WHEN** the user runs `postgres start --extension duckdb`
+- **THEN** the CNPG Cluster CR uses the duckdb image, `pg_duckdb` is in shared_preload_libraries, and `CREATE EXTENSION pg_duckdb` is run on init
+
+#### Scenario: Unknown alias fails fast
+- **WHEN** the user runs `postgres start --extension nonexistent`
+- **THEN** an error is emitted before any K8s resources are applied
+
+### Requirement: --image Flag Overrides Image
+
+`postgres start` SHALL accept an `--image <image>` flag that overrides the container image regardless of what any alias specifies. When combined with `--extension`, the alias image is ignored but its preload and CREATE EXTENSION config still applies.
+
+#### Scenario: Custom image with alias config
+- **WHEN** the user runs `postgres start --image my-registry/pg-custom:pg17 --extension duckdb --extension postgis`
+- **THEN** the CNPG Cluster CR uses `my-registry/pg-custom:pg17` as the image, and both pg_duckdb and postgis are in the preload and CREATE EXTENSION list
+
+#### Scenario: --image alone overrides default
+- **WHEN** the user runs `postgres start --image my-registry/pg-custom:pg17`
+- **THEN** the CNPG Cluster CR uses `my-registry/pg-custom:pg17` and no extensions are added
+
+### Requirement: Multi-Alias Image Conflict Detection
+
+When multiple `--extension` aliases each define a different image and `--image` is not provided, `postgres start` SHALL fail with an error naming the conflicting aliases and instructing the user to provide `--image`.
+
+#### Scenario: Two aliases with different images and no --image
+- **WHEN** the user runs `postgres start --extension duckdb --extension postgis` without `--image`
+- **THEN** an error is emitted naming both aliases and instructing the user to provide `--image` with a combined image
+
+#### Scenario: Two aliases with different images and --image provided
+- **WHEN** the user runs `postgres start --extension duckdb --extension postgis --image my-registry/combined:pg17`
+- **THEN** the command succeeds using the provided image with both extensions' preload and CREATE EXTENSION config applied
+
+### Requirement: Escape-Hatch Flags
+
+`postgres start` SHALL accept `--shared-preload-libraries <lib>` (repeatable) and `--create-extension <name>` (repeatable) flags. These SHALL be appended to whatever any alias contributes, allowing users to add config beyond what a built-in alias provides or to use a fully custom image with no alias.
+
+#### Scenario: Pure escape hatch with no alias
+- **WHEN** the user runs `postgres start --image my-registry/pg-custom:pg17 --shared-preload-libraries pg_duckdb --create-extension pg_duckdb`
+- **THEN** the CNPG Cluster CR uses the custom image, includes `pg_duckdb` in shared_preload_libraries, and runs `CREATE EXTENSION pg_duckdb` on init
+
+#### Scenario: Escape hatch augments alias
+- **WHEN** the user runs `postgres start --extension duckdb --shared-preload-libraries my_extra_lib`
+- **THEN** `my_extra_lib` is appended to the preload libraries from the duckdb alias
+
+### Requirement: postgres extensions Subcommand
+
+The `postgres extensions` subcommand SHALL display all aliases from `extensions.yaml` in a table showing: alias name, image template, preload libraries, and CREATE EXTENSION list. This is a read-only display command.
+
+#### Scenario: List shows all built-in aliases
+- **WHEN** the user runs `postgres extensions`
+- **THEN** a table is printed listing all aliases defined in `extensions.yaml` including at minimum duckdb, postgis, and timescaledb

--- a/openspec/changes/postgres-extensions/specs/postgres/spec.md
+++ b/openspec/changes/postgres-extensions/specs/postgres/spec.md
@@ -1,0 +1,16 @@
+# PostgreSQL (delta)
+
+## MODIFIED Requirements
+
+### Requirement: REQ-PG-001: K8s-Based Deployment via CloudNativePG
+
+The system MUST deploy PostgreSQL clusters on K8s db nodes via the CloudNativePG (CNPG) operator. The operator SHALL be installed via Helm (`cloudnative-pg/cloudnative-pg` chart into the `cnpg-system` namespace). The PostgreSQL cluster SHALL be defined as a CNPG `Cluster` custom resource named `postgres`. The container image, shared_preload_libraries, and postInitSQL MAY be configured via extension flags — see the `postgres-extensions` spec.
+
+#### Scenario: Default deployment uses standard image
+- **GIVEN** a running cluster with K3s
+- **WHEN** the user runs `kit install postgres` and `postgres start` with no extension flags
+- **THEN** the CNPG operator is installed and a PostgreSQL Cluster CR is deployed using the default `ghcr.io/cloudnative-pg/postgresql` image with no shared_preload_libraries and no postInitSQL
+
+#### Scenario: Install succeeds when CNPG is already installed
+- **WHEN** the user runs `kit install postgres` on a cluster where CNPG is already installed
+- **THEN** the install succeeds without error

--- a/openspec/changes/postgres-extensions/tasks.md
+++ b/openspec/changes/postgres-extensions/tasks.md
@@ -1,0 +1,43 @@
+## 1. Extension Registry
+
+- [x] 1.1 Create `extensions.yaml` in `src/main/resources/.../kits/postgres/` with aliases for `duckdb`, `postgis`, and `timescaledb` using the structure defined in design.md
+- [x] 1.2 Create `ExtensionAlias` data class (kotlinx.serialization) with fields: `description`, `image`, `sharedPreloadLibraries`, `createExtensions`
+- [x] 1.3 Create `ExtensionRegistry` class that loads and parses `extensions.yaml` from the classpath
+- [x] 1.4 Write unit tests for `ExtensionRegistry`: verify all three aliases load correctly, verify unknown alias returns null/throws
+
+## 2. Extension Resolution Logic
+
+- [x] 2.1 Create `ExtensionResolver` that merges multiple `--extension` aliases with `--image`, `--shared-preload-libraries`, and `--create-extension` flags into a resolved `ExtensionConfig` (image, preload list, create-extension list)
+- [x] 2.2 Implement multi-alias image conflict detection: when two aliases define different images and no `--image` is provided, throw with an actionable error message naming the conflicting aliases
+- [x] 2.3 Implement `__PG_MAJOR__` substitution in the resolved image string
+- [x] 2.4 Write unit tests for `ExtensionResolver`: single alias, `--image` override, multi-alias same image, multi-alias conflict, escape-hatch flags augmenting alias, pure escape hatch with no alias
+
+## 3. Template Update
+
+- [x] 3.1 Update `postgres-cluster.yaml.template` to accept optional `__IMAGE__`, `__SHARED_PRELOAD_LIBRARIES__`, and `__POST_INIT_SQL__` placeholders
+- [x] 3.2 Ensure the template renders correctly when these fields are absent (default image, no preload section, no postInitSQL section)
+- [x] 3.3 Write `TemplateService`-based tests verifying the template renders correctly for: no extensions, single extension, multiple extensions
+
+## 4. postgres start Command Flags
+
+- [x] 4.1 Add `--extension`, `--image`, `--shared-preload-libraries`, and `--create-extension` flags to the postgres `start` command class
+- [x] 4.2 Wire `ExtensionResolver` into the start command; pass resolved `ExtensionConfig` into template variable construction
+- [x] 4.3 Verify `postgres start` with no extension flags still deploys correctly (no regression)
+
+## 5. postgres extensions Subcommand
+
+- [x] 5.1 Create `PostgresExtensions` command class that reads `extensions.yaml` and prints a table of alias, image template, preload libraries, and create_extensions via `println()`
+- [x] 5.2 Register the command under the `postgres` subcommand group
+- [x] 5.3 Write a test verifying the command produces output containing all three built-in alias names
+
+## 6. Extension Dashboards (requires live cluster per extension)
+
+- [ ] 6.1 Run `postgres start --extension duckdb` against a live cluster; wait for metrics to flow; run `bin/export-workload-metrics postgres`; author `src/main/resources/.../kits/postgres/dashboards/duckdb.json` from the catalog
+- [ ] 6.2 Run `postgres start --extension postgis` against a live cluster; wait for metrics to flow; run `bin/export-workload-metrics postgres`; author `src/main/resources/.../kits/postgres/dashboards/postgis.json` from the catalog
+- [ ] 6.3 Run `postgres start --extension timescaledb` against a live cluster; wait for metrics to flow; run `bin/export-workload-metrics postgres`; author `src/main/resources/.../kits/postgres/dashboards/timescaledb.json` from the catalog
+- [ ] 6.4 Author `src/main/resources/.../kits/postgres/dashboards/postgres.json` — base postgres metrics dashboard (connection count, query throughput, cache hit ratio, replication lag); requires live cluster without extensions
+
+## 7. Documentation
+
+- [x] 7.1 Update `docs/user-guide/install-postgres.md` with a new Extensions section documenting `--extension`, `--image`, `--shared-preload-libraries`, `--create-extension`, and `postgres extensions`
+- [x] 7.2 Add examples for: single alias (`--extension duckdb`), custom image with alias config, pure escape hatch

--- a/openspec/specs/postgres/spec.md
+++ b/openspec/specs/postgres/spec.md
@@ -1,0 +1,54 @@
+# PostgreSQL
+
+Manages the PostgreSQL kit lifecycle via the CloudNativePG operator and provides SQL execution against a running PostgreSQL cluster.
+
+## Requirements
+
+### REQ-PG-001: K8s-Based Deployment via CloudNativePG
+
+The system MUST deploy PostgreSQL clusters on K8s db nodes via the CloudNativePG (CNPG) operator. The operator SHALL be installed via Helm (`cloudnative-pg/cloudnative-pg` chart into the `cnpg-system` namespace). The PostgreSQL cluster SHALL be defined as a CNPG `Cluster` custom resource named `postgres`.
+
+**Scenarios:**
+
+- **GIVEN** a running cluster with K3s, **WHEN** the user runs `kit install postgres` and `postgres start`, **THEN** the CNPG operator is installed and a PostgreSQL Cluster CR is deployed on db nodes.
+- **WHEN** the user runs `kit install postgres` on a cluster where CNPG is already installed, **THEN** the install succeeds without error.
+
+### REQ-PG-002: Configurable Instance Count
+
+The `postgres start` command SHALL accept a `--instances` argument (default: `1`) controlling how many PostgreSQL instances CNPG deploys. When `--instances` is greater than 1, CNPG deploys a primary and read replicas.
+
+**Scenarios:**
+
+- **WHEN** the user runs `postgres start` with no flags, **THEN** a single PostgreSQL instance is deployed.
+- **WHEN** the user runs `postgres start --instances 3`, **THEN** CNPG deploys 1 primary and 2 read replicas.
+
+### REQ-PG-003: Data Lifecycle
+
+Stop MUST preserve data; data is only deleted on uninstall. Starting after a stop MUST resume the existing dataset without any additional user steps.
+
+**Scenarios:**
+
+- **WHEN** data is written to PostgreSQL, `postgres stop` is run, and then `postgres start` is run again, **THEN** the previously written data is accessible without any restore step.
+- **WHEN** the user runs `postgres uninstall`, **THEN** the CNPG operator is removed and all PersistentVolumes for db nodes are deleted.
+- **WHEN** `postgres start` is run after a fresh install with no prior starts, **THEN** PVs are created via `platform-pvs` and the Cluster CR is deployed successfully.
+
+### REQ-PG-004: SQL Execution
+
+The `postgres sql` command SHALL execute SQL statements against a running PostgreSQL cluster. SQL execution is provided via the `sql` capability declared in `postgres/kit.yaml` — see REQ-KCAP-002.
+
+The PostgreSQL JDBC driver (`org.postgresql:postgresql`) auto-registers via ServiceLoader. The `driver-class` field in the `sql` capability SHALL be left empty.
+
+**Scenarios:**
+
+- **WHEN** the user runs `postgres sql "SELECT version()"`, **THEN** the query is submitted via JDBC and results are displayed in tabular format.
+- **WHEN** the user runs `postgres sql --file query.sql`, **THEN** the SQL from the file is executed.
+- **WHEN** no db nodes exist in cluster state, **THEN** an error is emitted before any connection is made.
+
+### REQ-PG-005: Presto Integration
+
+When both the `postgres` and `presto` kits are running, Presto SHALL automatically expose a `postgres` catalog using the `postgresql` connector, pointing to the CNPG primary service (`postgres-rw.default.svc.cluster.local:5432`).
+
+**Scenarios:**
+
+- **GIVEN** both `postgres start` and `presto start` have been run, **WHEN** Presto's `update-catalogs.sh` hook executes, **THEN** a `postgres` catalog is present in Presto and `SHOW CATALOGS` includes `postgres`.
+- **WHEN** only presto is running (no postgres kit), **THEN** no `postgres` catalog appears in Presto.

--- a/openspec/specs/presto/spec.md
+++ b/openspec/specs/presto/spec.md
@@ -29,3 +29,16 @@ SHALL be set to `com.facebook.presto.jdbc.PrestoDriver` to force-load it.
   **THEN** the query is submitted via JDBC and results are displayed in tabular format.
 - **WHEN** the user runs `presto sql --file query.sql`, **THEN** the SQL from the file is executed.
 - **WHEN** no app nodes exist in cluster state, **THEN** an error is emitted before any connection is made.
+
+### REQ-PRS-003: Catalog Sources
+
+The system SHALL support automatic catalog injection for the following database kits when they are running alongside Presto: Cassandra, ClickHouse, and PostgreSQL.
+
+A catalog properties file MUST exist in `kits/presto/catalogs/<kit-name>.properties.template` for each supported database kit. The `update-catalogs.sh` hook reads `RUNNING_KITS` and injects catalogs for any kit that has a matching properties file.
+
+**Scenarios:**
+
+- **GIVEN** both `cassandra` and `presto` are running, **WHEN** `update-catalogs.sh` executes, **THEN** a `cassandra` catalog is present in Presto.
+- **GIVEN** both `clickhouse` and `presto` are running, **WHEN** `update-catalogs.sh` executes, **THEN** a `clickhouse` catalog is present in Presto.
+- **GIVEN** both `postgres` and `presto` are running, **WHEN** `update-catalogs.sh` executes, **THEN** a `postgres` catalog is present in Presto using the `postgresql` connector pointed at `postgres-rw.default.svc.cluster.local:5432`.
+- **WHEN** a database kit is not running, **THEN** its catalog is not injected into Presto.

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Init.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Init.kt
@@ -88,7 +88,7 @@ class Init : PicoBaseCommand() {
         names = ["--instance", "-i"],
         description = ["Instance Type. Set EASY_DB_LAB_INSTANCE_TYPE to set a default."],
     )
-    var instanceType: String = System.getenv("EASY_DB_LAB_INSTANCE_TYPE") ?: "r3.2xlarge"
+    var instanceType: String = System.getenv("EASY_DB_LAB_INSTANCE_TYPE") ?: "i4i.xlarge"
 
     @Option(
         names = ["--stress-instance", "-si", "--si"],

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Up.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Up.kt
@@ -288,6 +288,13 @@ class Up : PicoBaseCommand() {
         val result = executeProvisioning(instanceConfig, servicesConfig, existingHosts)
         reportProvisioningFailures(result)
 
+        // Persist all discovered+provisioned hosts (existing hosts are in result.hosts but
+        // onHostsCreated is only fired for newly created ones, so we sync the full set here).
+        synchronized(stateLock) {
+            workingState.updateHosts(result.hosts)
+            clusterStateManager.save(workingState)
+        }
+
         finalizeInfrastructureState(vpcId, subnetIds, securityGroupId, igwId)
 
         printProvisioningSuccessMessage()

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/install/BaseInstallCommand.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/install/BaseInstallCommand.kt
@@ -54,7 +54,8 @@ abstract class BaseInstallCommand : PicoBaseCommand() {
 
             val installYamlContent = resolver.readInstallYamlContent(source)
             if (installYamlContent != null) {
-                File(tempDir, Constants.Kit.CONFIG_FILE).writeText(installYamlContent)
+                val renderedYaml = patchKitYaml(installYamlContent, extraVars)
+                File(tempDir, Constants.Kit.CONFIG_FILE).writeText(renderedYaml)
             }
 
             // Persist all resolved kit arg values so later phases (start, stop, etc.) can
@@ -90,4 +91,64 @@ abstract class BaseInstallCommand : PicoBaseCommand() {
 
         eventBus.emit(Event.Install.ScaffoldComplete(kit = kitName, outputDir = outputDir.path))
     }
+
+    /**
+     * Rewrites YAML `port:` lines in [content] whose current value matches a kit.yaml
+     * default port, substituting the override value from [extraVars].
+     *
+     * Kit templates declare static default port values in kit.yaml (e.g. `port: 30432`).
+     * When an extension overrides the ports via POSTGRES_PORT / METRICS_PORT, the written
+     * workspace kit.yaml must reflect those values so that endpoint resolution and the
+     * `sql` subcommand connect to the correct NodePort. The source kit.yaml is valid YAML
+     * (it uses integer literals), so this method replaces default values with overridden
+     * ones line-by-line, targeting only `port: <integer>` scalar lines.
+     *
+     * A substitution is applied when the current port value in the YAML exactly matches
+     * the default stored under the same variable name (POSTGRES_PORT or METRICS_PORT) in
+     * [extraVars] is not needed — instead we use a direct mapping from variable name to
+     * the parsed override integer port.
+     */
+    internal fun patchKitYaml(
+        content: String,
+        extraVars: Map<String, String>,
+    ): String {
+        val postgresPort = extraVars["POSTGRES_PORT"]?.toIntOrNull()
+        val metricsPort = extraVars["METRICS_PORT"]?.toIntOrNull()
+        if (postgresPort == null && metricsPort == null) return content
+
+        return content
+            .lines()
+            .map { line ->
+                val trimmed = line.trimStart()
+                if (!trimmed.startsWith("port:")) return@map line
+
+                val currentPort = trimmed.removePrefix("port:").trim().toIntOrNull() ?: return@map line
+                val indent = " ".repeat(line.length - trimmed.length)
+
+                // Map from known default ports to their override values.
+                // POSTGRES_PORT defaults: 30432. METRICS_PORT defaults: 30987.
+                // When the kit.yaml line holds a default that is being overridden, replace it.
+                val newPort =
+                    when {
+                        postgresPort != null && isDefaultPostgresPort(currentPort) -> postgresPort
+                        metricsPort != null && isDefaultMetricsPort(currentPort) -> metricsPort
+                        else -> return@map line
+                    }
+
+                "${indent}port: $newPort"
+            }.joinToString("\n")
+    }
+
+    /**
+     * Returns true if [port] is a well-known postgres NodePort default that may be
+     * overridden by the POSTGRES_PORT variable. The set of well-known defaults matches
+     * the port values used in the extensions.yaml registry.
+     */
+    private fun isDefaultPostgresPort(port: Int): Boolean = port in setOf(30432, 30433, 30434)
+
+    /**
+     * Returns true if [port] is a well-known metrics NodePort default that may be
+     * overridden by the METRICS_PORT variable.
+     */
+    private fun isDefaultMetricsPort(port: Int): Boolean = port in setOf(30987, 30988, 30989)
 }

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/install/KitExtensionsCommand.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/install/KitExtensionsCommand.kt
@@ -1,0 +1,44 @@
+package com.rustyrazorblade.easydblab.commands.install
+
+import com.rustyrazorblade.easydblab.services.ExtensionRegistry
+import picocli.CommandLine
+import java.io.File
+import java.util.concurrent.Callable
+
+/**
+ * Lists all available extension aliases from the kit's extensions.yaml.
+ *
+ * Displays alias name, image template, shared_preload_libraries, and CREATE EXTENSION
+ * statements so users can discover which extensions are available and what they configure.
+ */
+@CommandLine.Command(
+    name = "extensions",
+    description = ["List available extension aliases"],
+)
+class KitExtensionsCommand(
+    private val kitDir: File,
+) : Callable<Int> {
+    override fun call(): Int {
+        val extensionsFile = File(kitDir, "extensions.yaml")
+        val registry = ExtensionRegistry.fromFile(extensionsFile)
+        val all = registry.all()
+
+        if (all.isEmpty()) {
+            println("No extension aliases found in ${extensionsFile.absolutePath}")
+            return 0
+        }
+
+        val nameWidth = all.keys.maxOf { it.length }.coerceAtLeast(5)
+        val header = "%-${nameWidth}s  %-50s  %-30s  %s".format("ALIAS", "IMAGE", "PRELOAD LIBRARIES", "CREATE EXTENSIONS")
+        println(header)
+        println("-".repeat(header.length))
+
+        for ((name, alias) in all.entries.sortedBy { it.key }) {
+            val preload = alias.sharedPreloadLibraries.joinToString(",").ifEmpty { "-" }
+            val create = alias.createExtensions.joinToString(",").ifEmpty { "-" }
+            println("%-${nameWidth}s  %-50s  %-30s  %s".format(name, alias.image, preload, create))
+        }
+
+        return 0
+    }
+}

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/install/KitInstallCommand.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/install/KitInstallCommand.kt
@@ -3,6 +3,8 @@ package com.rustyrazorblade.easydblab.commands.install
 import com.rustyrazorblade.easydblab.Constants
 import com.rustyrazorblade.easydblab.configuration.ServerType
 import com.rustyrazorblade.easydblab.events.Event
+import com.rustyrazorblade.easydblab.services.ExtensionRegistry
+import com.rustyrazorblade.easydblab.services.ExtensionResolver
 import com.rustyrazorblade.easydblab.services.InstallTemplateResolver
 import com.rustyrazorblade.easydblab.services.KitConfig
 import com.rustyrazorblade.easydblab.services.KitType
@@ -67,12 +69,13 @@ class KitInstallCommand(
             }
         }
 
+        val extensionVars = buildExtensionVars()
         val storageSize = argValues.remove("STORAGE_SIZE").orEmpty()
         renderAndWrite(
             source = source,
             kitName = instanceName,
             storageSize = storageSize,
-            extraVars = argValues.toMap(),
+            extraVars = extensionVars + argValues.toMap(),
         )
 
         if (config.install.isNotEmpty()) {
@@ -129,14 +132,67 @@ class KitInstallCommand(
     }
 
     /**
-     * Computes the directory name for the installed kit. For kits with a kit-ref arg,
-     * the directory is named `<kit>-<target>` so the same bench kit can be installed
-     * against multiple databases simultaneously (e.g. sysbench-clickhouse, sysbench-mysql).
-     * For kits without a kit-ref arg, the directory is the kit's own name.
+     * Computes the directory name for the installed kit.
+     *
+     * - Kit-ref arg: `<kit>-<target>` (e.g. sysbench-clickhouse) so the same bench kit can
+     *   target multiple databases simultaneously.
+     * - Extension arg: `<kit>-<extension>` (e.g. postgres-duckdb) so the same kit can be
+     *   installed with different extensions simultaneously.
+     * - Otherwise: the kit's own name.
      */
-    private fun resolveInstanceName(): String =
+    private fun resolveInstanceName(): String {
         config.kitRefArg
             ?.let { argValues[it.variable]?.takeIf { v -> v.isNotBlank() } }
-            ?.let { "${config.name}-$it" }
-            ?: config.name
+            ?.let { return "${config.name}-$it" }
+        config.extensionArg
+            ?.let { argValues[it.variable]?.takeIf { v -> v.isNotBlank() } }
+            ?.let { return "${config.name}-$it" }
+        return config.name
+    }
+
+    /**
+     * Resolves extension flags into IMAGE, SHARED_PRELOAD_LIBRARIES, and POST_INIT_SQL
+     * template variables. Returns an empty map for kits that don't declare an extension arg.
+     */
+    private fun buildExtensionVars(): Map<String, String> {
+        val extArg = config.extensionArg ?: return emptyMap()
+        val registry =
+            when (source) {
+                is InstallTemplateResolver.TemplateSource.Directory ->
+                    ExtensionRegistry.fromFile(File(source.dir, "extensions.yaml"))
+                is InstallTemplateResolver.TemplateSource.Builtin ->
+                    ExtensionRegistry.fromClasspath(source.name)
+            }
+        val extensionName = argValues[extArg.variable]?.takeIf { it.isNotBlank() }
+        val versionVarName = config.args.firstOrNull { it.flag == "--version" }?.variable ?: "POSTGRES_VERSION"
+        val postgresVersion = argValues[versionVarName] ?: "17"
+        val extConfig =
+            ExtensionResolver(registry, postgresVersion).resolve(
+                extensions = if (extensionName != null) listOf(extensionName) else emptyList(),
+                imageOverride = null,
+                additionalPreload = emptyList(),
+                additionalCreate = emptyList(),
+            )
+        val postInitSql =
+            if (extConfig.createExtensions.isEmpty()) {
+                "[]"
+            } else {
+                "[${extConfig.createExtensions.joinToString(", ") { "\"CREATE EXTENSION $it\"" }}]"
+            }
+        return mapOf(
+            "IMAGE" to extConfig.image,
+            "SHARED_PRELOAD_LIBRARIES" to
+                if (extConfig.sharedPreloadLibraries.isEmpty()) {
+                    "[]"
+                } else {
+                    "[${extConfig.sharedPreloadLibraries.joinToString(", ") { "\"$it\"" }}]"
+                },
+            "POST_INIT_SQL" to postInitSql,
+            "PG_MAJOR_VERSION" to postgresVersion.substringBefore("."),
+            "POSTGRES_UID" to extConfig.postgresUid.toString(),
+            "POSTGRES_GID" to extConfig.postgresGid.toString(),
+            "POSTGRES_PORT" to extConfig.postgresPort.toString(),
+            "METRICS_PORT" to extConfig.metricsPort.toString(),
+        )
+    }
 }

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/install/KitInstallCommandFactory.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/install/KitInstallCommandFactory.kt
@@ -73,7 +73,7 @@ class KitInstallCommandFactory(
         val resolvedDefault = resolveDefault(arg.default, templateVars)
         val picoType =
             when (arg.type) {
-                KitArgSpec.ArgType.STRING, KitArgSpec.ArgType.KIT_REF -> String::class.java
+                KitArgSpec.ArgType.STRING, KitArgSpec.ArgType.KIT_REF, KitArgSpec.ArgType.EXTENSION -> String::class.java
                 KitArgSpec.ArgType.BOOLEAN -> Boolean::class.java
                 KitArgSpec.ArgType.FLOAT -> Double::class.java
                 KitArgSpec.ArgType.INT -> Int::class.java

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/install/KitRunnerCommand.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/install/KitRunnerCommand.kt
@@ -33,6 +33,7 @@ class KitRunnerCommand(
         description = ["Name passed to the phase script as BACKUP_NAME (default: timestamp)"],
     )
     var name: String = "backup-${LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss"))}"
+
     private val grafanaDashboardService: GrafanaDashboardService by inject()
     private val workloadStepExecutor: WorkloadStepExecutor by inject()
     private val metricsRegistryService: MetricsRegistryService by inject()
@@ -211,7 +212,12 @@ class KitRunnerCommand(
             Constants.Kit.PHASE_START -> {
                 clusterStateManager.addRunningWorkload(kitName)
                 kitHookExecutor.firePostKitStart(kitName)
-                val scrapeTargets = config.metrics.filterIsInstance<KitMetrics.Scrape>()
+                val resolvedArgs = readResolvedArgs()
+                val metricsPortOverride = resolvedArgs["METRICS_PORT"]?.toIntOrNull()
+                val scrapeTargets =
+                    config.metrics.filterIsInstance<KitMetrics.Scrape>().map { target ->
+                        if (metricsPortOverride != null) target.copy(port = metricsPortOverride) else target
+                    }
                 if (scrapeTargets.isNotEmpty()) {
                     metricsRegistryService
                         .register(

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/install/KitRunnerCommandFactory.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/install/KitRunnerCommandFactory.kt
@@ -47,6 +47,10 @@ class KitRunnerCommandFactory {
             }
         }
 
+        if (File(kitDir, "extensions.yaml").isFile) {
+            groupCL.addSubcommand("extensions", buildExtensionsCommand(kitDir))
+        }
+
         return groupCL
     }
 
@@ -141,6 +145,13 @@ class KitRunnerCommandFactory {
         val command = KitRunnerCommand(kitName, kitDir, phaseName)
         val spec = CommandSpec.forAnnotatedObject(command, CommandLine.defaultFactory()).name(phaseName)
         spec.usageMessage().description("Run $kitName/$phaseName")
+        spec.mixinStandardHelpOptions(true)
+        return CommandLine(spec)
+    }
+
+    private fun buildExtensionsCommand(kitDir: File): CommandLine {
+        val command = KitExtensionsCommand(kitDir)
+        val spec = CommandLine.Model.CommandSpec.forAnnotatedObject(command, CommandLine.defaultFactory())
         spec.mixinStandardHelpOptions(true)
         return CommandLine(spec)
     }

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/install/KitStatusCommand.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/install/KitStatusCommand.kt
@@ -93,7 +93,10 @@ class KitStatusCommand(
             KitRuntime.RuntimeType.STATEFULSET,
             KitRuntime.RuntimeType.PODS,
             -> {
-                val selector = runtime.selector.ifBlank { "app.kubernetes.io/name=$kitName" }
+                val selector =
+                    runtime.selector
+                        .replace("\${KIT_NAME}", kitName)
+                        .ifBlank { "app.kubernetes.io/name=$kitName" }
                 val pods = kubeService.listPodsByLabel(selector, namespace).getOrElse { emptyList() }
                 if (pods.isEmpty()) {
                     KitRunningState.Stopped

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/ClusterState.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/ClusterState.kt
@@ -79,7 +79,7 @@ data class InfrastructureState(
 data class InitConfig(
     val cassandraInstances: Int = 3,
     val stressInstances: Int = 0,
-    val instanceType: String = "r3.2xlarge",
+    val instanceType: String = "i4i.xlarge",
     val stressInstanceType: String = "c6id.2xlarge",
     val azs: List<String> = listOf(),
     val ami: String = "",

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/otel/OtelManifestBuilder.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/otel/OtelManifestBuilder.kt
@@ -71,7 +71,9 @@ class OtelManifestBuilder(
             val port = data["port"]?.toIntOrNull() ?: return@mapNotNull null
             val path = data["path"] ?: "/metrics"
             val username = data["username"] ?: ""
-            WorkloadScrapeConfig(jobName = jobName, port = port, path = path, username = username)
+            // Falls back to jobName for ConfigMaps written before the kit-name key was added
+            val kitName = data["kit-name"] ?: jobName
+            WorkloadScrapeConfig(kitName = kitName, jobName = jobName, port = port, path = path, username = username)
         }
     }
 
@@ -170,12 +172,21 @@ class OtelManifestBuilder(
         val jobs =
             configs.map { config ->
                 PrometheusScrapeJob(
-                    jobName = config.jobName,
+                    // kitName is unique per instance (e.g. "postgres-duckdb") and used as the OTel
+                    // job_name to prevent duplicate scrape_configs when multiple kit instances share
+                    // the same jobName (e.g. all postgres extensions declare job "postgres").
+                    jobName = config.kitName,
                     scrapeInterval = SCRAPE_INTERVAL,
                     staticConfigs = listOf(PrometheusStaticConfig(targets = listOf("localhost:${config.port}"))),
                     metricsPath = config.path,
                     relabelConfigs =
                         listOf(
+                            // Preserve the logical job name from kit.yaml as the `job` label so
+                            // Prometheus queries like job="postgres" continue to work across instances.
+                            PrometheusRelabelConfig(
+                                targetLabel = "job",
+                                replacement = config.jobName,
+                            ),
                             PrometheusRelabelConfig(
                                 targetLabel = "instance",
                                 replacement = "\${env:HOSTNAME}:${config.port}",

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/otel/WorkloadScrapeConfig.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/otel/WorkloadScrapeConfig.kt
@@ -3,12 +3,17 @@ package com.rustyrazorblade.easydblab.configuration.otel
 /**
  * Scrape target for a running K8s workload, read from the metrics registry ConfigMaps.
  *
+ * [kitName] becomes the OTel scrape job name to ensure uniqueness across multiple kit instances
+ * that share the same [jobName] (e.g., postgres-duckdb vs postgres-postgis both declare job "postgres").
+ * The [jobName] is preserved as the `job` label in metrics via a relabel rule.
+ *
  * Note: only username-based basic auth is supported. Password is intentionally omitted —
  * Trino's FIXED auth mode requires only a username with no real password. If a future kit
  * needs password-based scrape auth, extend this class, KitMetrics.Scrape, PrometheusBasicAuth,
  * and OtelManifestBuilder.buildConfigMap() together.
  */
 data class WorkloadScrapeConfig(
+    val kitName: String,
     val jobName: String,
     val port: Int,
     val path: String,

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/InstallStep.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/InstallStep.kt
@@ -42,6 +42,7 @@ sealed interface InstallStep {
     @SerialName("manifest")
     data class Manifest(
         val template: String,
+        val interpolate: Boolean = false,
     ) : InstallStep
 
     @Serializable

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/KitConfig.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/KitConfig.kt
@@ -220,6 +220,7 @@ data class KitConfig(
     val capabilities: List<KitCapability> = emptyList(),
 ) {
     val kitRefArg: KitArgSpec? get() = args.firstOrNull { it.type == KitArgSpec.ArgType.KIT_REF }
+    val extensionArg: KitArgSpec? get() = args.firstOrNull { it.type == KitArgSpec.ArgType.EXTENSION }
 
     fun stepsForPhase(phaseName: String): List<InstallStep> =
         when (phaseName) {
@@ -283,6 +284,9 @@ data class KitArgSpec(
 
         @SerialName("kit-ref")
         KIT_REF,
+
+        @SerialName("extension")
+        EXTENSION,
     }
 }
 

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/MetricsRegistryService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/MetricsRegistryService.kt
@@ -22,10 +22,12 @@ interface MetricsRegistryService {
 /**
  * Manages the per-kit metrics ConfigMaps that drive OTel collector Prometheus scrape jobs.
  *
- * On [register], writes one ConfigMap named `easydblab-metrics-<job>` per scrape target,
+ * On [register], writes one ConfigMap named `easydblab-metrics-<kitName>-<job>` per scrape target,
  * each carrying [Constants.K8s.WORKLOAD_METRICS_LABEL] and [Constants.K8s.KIT_LABEL] so
  * [OtelSyncService] can regenerate the collector config and [deregister] can bulk-delete
- * all targets for a kit by label selector.
+ * all targets for a kit by label selector. Including [kitName] in the ConfigMap name ensures
+ * multiple kit instances with the same job name (e.g. postgres-duckdb and postgres-postgis
+ * both declaring job "postgres") get separate ConfigMaps and separate OTel scrape jobs.
  */
 class DefaultMetricsRegistryService(
     private val k8sService: K8sService,
@@ -57,7 +59,7 @@ class DefaultMetricsRegistryService(
 
             for (target in targets) {
                 val jobName = target.job.ifBlank { kitName }
-                val configMapName = "$CONFIG_MAP_PREFIX$jobName"
+                val configMapName = "$CONFIG_MAP_PREFIX$kitName-$jobName"
                 k8sService
                     .createConfigMap(
                         controlHost = controlHost,
@@ -65,6 +67,7 @@ class DefaultMetricsRegistryService(
                         name = configMapName,
                         data =
                             buildMap {
+                                put("kit-name", kitName)
                                 put("job-name", jobName)
                                 put("port", target.port.toString())
                                 put("path", target.path)
@@ -82,6 +85,7 @@ class DefaultMetricsRegistryService(
             eventBus.emit(Event.Kit.MetricsRegistered(kit = kitName, ports = targets.map { it.port }))
         }.onFailure {
             deregister(controlHost, kitName)
+                .onFailure { e -> log.warn(e) { "Cleanup deregister also failed for $kitName" } }
         }
 
     override fun deregister(

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/PostgresExtensions.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/PostgresExtensions.kt
@@ -1,0 +1,165 @@
+package com.rustyrazorblade.easydblab.services
+
+import com.charleskorn.kaml.Yaml
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import java.io.File
+
+/**
+ * A single extension alias entry in the postgres extensions registry.
+ * Aliases map a short name (e.g. "duckdb") to the CNPG image and PostgreSQL config
+ * required to activate that extension.
+ *
+ * `__PG_MAJOR__` in [image] is substituted at resolve time with the installed postgres major version.
+ */
+@Serializable
+data class ExtensionAlias(
+    val description: String,
+    val image: String,
+    @SerialName("shared_preload_libraries")
+    val sharedPreloadLibraries: List<String> = emptyList(),
+    @SerialName("create_extensions")
+    val createExtensions: List<String> = emptyList(),
+    @SerialName("postgres_uid")
+    val postgresUid: Int = 26,
+    @SerialName("postgres_gid")
+    val postgresGid: Int = 26,
+    @SerialName("postgres_port")
+    val postgresPort: Int = 30432,
+    @SerialName("metrics_port")
+    val metricsPort: Int = 30987,
+)
+
+@Serializable
+private data class ExtensionsFile(
+    val extensions: Map<String, ExtensionAlias>,
+)
+
+private val extensionYaml = Yaml.default
+
+/**
+ * Registry of known postgres extension aliases loaded from `extensions.yaml`.
+ *
+ * Provides lookup by alias name and enumeration for the `postgres extensions` subcommand.
+ * Built-in aliases live in the classpath; after install they are copied to the kit directory
+ * where [fromFile] loads them at runtime.
+ */
+class ExtensionRegistry private constructor(
+    private val aliases: Map<String, ExtensionAlias>,
+) {
+    fun lookup(name: String): ExtensionAlias? = aliases[name]
+
+    fun all(): Map<String, ExtensionAlias> = aliases
+
+    companion object {
+        fun fromFile(file: File): ExtensionRegistry {
+            if (!file.isFile) return ExtensionRegistry(emptyMap())
+            val parsed = extensionYaml.decodeFromString(ExtensionsFile.serializer(), file.readText())
+            return ExtensionRegistry(parsed.extensions)
+        }
+
+        fun fromString(content: String): ExtensionRegistry {
+            val parsed = extensionYaml.decodeFromString(ExtensionsFile.serializer(), content)
+            return ExtensionRegistry(parsed.extensions)
+        }
+
+        fun fromClasspath(kitName: String = "postgres"): ExtensionRegistry {
+            val resourcePath = "com/rustyrazorblade/easydblab/kits/$kitName/extensions.yaml"
+            val content =
+                ExtensionRegistry::class.java.classLoader
+                    .getResourceAsStream(resourcePath)
+                    ?.bufferedReader()
+                    ?.readText()
+                    ?: return ExtensionRegistry(emptyMap())
+            return fromString(content)
+        }
+
+        fun empty(): ExtensionRegistry = ExtensionRegistry(emptyMap())
+    }
+}
+
+/**
+ * Resolved extension configuration produced by [ExtensionResolver].
+ *
+ * Contains the final image name (with `__PG_MAJOR__` substituted) and the combined
+ * set of preload libraries and `CREATE EXTENSION` statements from all activated aliases
+ * plus any escape-hatch flags.
+ */
+data class ExtensionConfig(
+    val image: String,
+    val sharedPreloadLibraries: List<String>,
+    val createExtensions: List<String>,
+    val postgresUid: Int = 26,
+    val postgresGid: Int = 26,
+    val postgresPort: Int = 30432,
+    val metricsPort: Int = 30987,
+)
+
+/**
+ * Resolves postgres extension flags into a concrete [ExtensionConfig].
+ *
+ * Merges alias entries from the registry with escape-hatch flags (`--image`,
+ * `--shared-preload-libraries`, `--create-extension`). Detects image conflicts when
+ * multiple aliases each define different images and no `--image` override is provided.
+ */
+class ExtensionResolver(
+    private val registry: ExtensionRegistry,
+    private val postgresVersion: String,
+) {
+    /**
+     * Resolves all extension inputs into an [ExtensionConfig].
+     *
+     * @param extensions alias names from `--extension` flags
+     * @param imageOverride explicit image from `--image` flag, overrides any alias image
+     * @param additionalPreload extra libraries from `--shared-preload-libraries` flags
+     * @param additionalCreate extra extension names from `--create-extension` flags
+     */
+    fun resolve(
+        extensions: List<String>,
+        imageOverride: String?,
+        additionalPreload: List<String>,
+        additionalCreate: List<String>,
+    ): ExtensionConfig {
+        val aliases =
+            extensions.map { name ->
+                registry.lookup(name) ?: error("Unknown extension alias: '$name'. Run 'postgres extensions' to see available aliases.")
+            }
+
+        val resolvedImage =
+            when {
+                imageOverride != null -> imageOverride
+                aliases.isEmpty() -> "ghcr.io/cloudnative-pg/postgresql:$postgresVersion"
+                else -> {
+                    val distinctImages = aliases.map { it.image }.distinct()
+                    if (distinctImages.size > 1) {
+                        val conflicting = extensions.zip(aliases).joinToString(", ") { (name, alias) -> "$name (${alias.image})" }
+                        error(
+                            "Multiple extensions define different images: $conflicting. " +
+                                "Build a combined image and pass it via --image.",
+                        )
+                    }
+                    distinctImages.first()
+                }
+            }
+
+        val pgMajor = postgresVersion.substringBefore('.')
+        val finalImage = resolvedImage.replace("__PG_MAJOR__", pgMajor)
+
+        val preload = (aliases.flatMap { it.sharedPreloadLibraries } + additionalPreload).distinct()
+        val create = (aliases.flatMap { it.createExtensions } + additionalCreate).distinct()
+        val uid = aliases.firstOrNull()?.postgresUid ?: 26
+        val gid = aliases.firstOrNull()?.postgresGid ?: 26
+        val postgresPort = aliases.firstOrNull()?.postgresPort ?: 30432
+        val metricsPort = aliases.firstOrNull()?.metricsPort ?: 30987
+
+        return ExtensionConfig(
+            image = finalImage,
+            sharedPreloadLibraries = preload,
+            createExtensions = create,
+            postgresUid = uid,
+            postgresGid = gid,
+            postgresPort = postgresPort,
+            metricsPort = metricsPort,
+        )
+    }
+}

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/WorkloadStepExecutor.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/WorkloadStepExecutor.kt
@@ -126,7 +126,8 @@ class WorkloadStepExecutor(
                     require(manifestFile.isFile) {
                         "Manifest file not found: ${manifestFile.absolutePath}. Run 'install ${ctx.kitName}' first."
                     }
-                    kubectlService.applyContent(host = host, yamlContent = manifestFile.readText())
+                    val content = if (step.interpolate) interp(manifestFile.readText()) else manifestFile.readText()
+                    kubectlService.applyContent(host = host, yamlContent = content)
                 }
 
                 is InstallStep.ManifestUrl -> {

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/sql/SqlQueryService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/sql/SqlQueryService.kt
@@ -26,6 +26,31 @@ fun interface JdbcConnectionFactory {
     ): Connection
 }
 
+/**
+ * Ensures all bundled JDBC drivers are registered with [DriverManager].
+ *
+ * In a fat JAR (shadow JAR), the ServiceLoader mechanism that normally
+ * auto-registers JDBC drivers via META-INF/services/java.sql.Driver may not
+ * work correctly when multiple drivers are present. Explicitly loading each
+ * driver class forces its static initializer to run, which registers the
+ * driver instance with [DriverManager]. This is the canonical JDBC 4.0
+ * workaround for fat JAR environments.
+ */
+fun ensureJdbcDriversLoaded() {
+    listOf(
+        "org.postgresql.Driver",
+        "com.mysql.cj.jdbc.Driver",
+        "com.clickhouse.jdbc.ClickHouseDriver",
+        "com.facebook.presto.jdbc.PrestoDriver",
+        "io.trino.jdbc.TrinoDriver",
+    ).forEach { driverClass ->
+        runCatching { Class.forName(driverClass) }
+    }
+}
+
 /** Default factory that delegates to [DriverManager.getConnection]. */
 val defaultJdbcConnectionFactory: JdbcConnectionFactory =
-    JdbcConnectionFactory { url, props -> DriverManager.getConnection(url, props) }
+    JdbcConnectionFactory { url, props ->
+        ensureJdbcDriversLoaded()
+        DriverManager.getConnection(url, props)
+    }

--- a/src/main/resources/com/rustyrazorblade/easydblab/kits/postgres/CLAUDE.md
+++ b/src/main/resources/com/rustyrazorblade/easydblab/kits/postgres/CLAUDE.md
@@ -1,0 +1,35 @@
+# PostgreSQL Kit
+
+Notes for developers maintaining the postgres kit.
+
+## Extension Model — One Image Per Installation
+
+**Each extension uses a different pre-built container image.** A postgres installation can only have one extension active at a time because CNPG runs a single image per cluster. The `--extension` flag on `kit install postgres` selects exactly one alias; there is no multi-extension CLI path.
+
+The `ExtensionResolver` contains conflict-detection logic for multiple aliases, but this is unreachable from the CLI — `ArgType.EXTENSION` maps to a single `String`, not a list. Do not add multi-extension scenarios to unit tests or docs without first wiring up multi-value PicoCLI support.
+
+## CNPG Extension Images
+
+### Non-Semver Tags — ImageCatalog Bypass
+
+CNPG 1.29+ validates image tags as semver and rejects tags like `v1.1.1` or `17-v1.1.1`. To use an extension image with a non-semver tag:
+
+1. Define an `ImageCatalog` resource in `postgres-cluster.yaml.template` listing the image under the postgres major version.
+2. Reference it via `imageCatalogRef` on the Cluster spec instead of `imageName`.
+
+See the `ImageCatalog` block in `postgres-cluster.yaml.template` for the reference implementation.
+
+### Custom Postgres UID/GID
+
+The CNPG Cluster defaults to UID/GID 26 (the `postgres` user in the CNPG base image). Extension images built on Docker Hub's official `postgres` image use UID 999. A mismatch causes `initdb: could not look up effective user ID` at cluster init and the pod never becomes Ready.
+
+Set `postgres_uid` and `postgres_gid` in `extensions.yaml` for any extension image that is NOT based on the CNPG base image. These values flow through `ExtensionResolver` → `ExtensionConfig` → `__POSTGRES_UID__`/`__POSTGRES_GID__` substitution in `postgres-cluster.yaml.template`.
+
+Known UIDs:
+- CNPG base image (`ghcr.io/cloudnative-pg/postgresql`): UID 26 (default, no override needed)
+- Docker Hub `postgres` base (`pgduckdb/pgduckdb`): UID 999
+- `timescale/timescaledb-ha`: UID 1000 (Ubuntu-based, postgres user)
+
+## Waiting for Postgres Pods
+
+Always use `cnpg.io/podRole=instance` as the label selector when waiting for running postgres pods. **Do NOT use `cnpg.io/cluster=<name>`** — that label matches both running instance pods AND completed initdb job pods, causing `kubectl wait --for=condition=Ready` to time out on the completed job pod which can never become Ready.

--- a/src/main/resources/com/rustyrazorblade/easydblab/kits/postgres/README.md.template
+++ b/src/main/resources/com/rustyrazorblade/easydblab/kits/postgres/README.md.template
@@ -1,0 +1,48 @@
+# PostgreSQL on __CLUSTER_NAME__ cluster
+
+Workload: PostgreSQL via CloudNativePG operator
+Version: __POSTGRES_VERSION__
+Instances: __INSTANCES__
+Storage per instance: __STORAGE_SIZE__
+DB nodes: __DB_NODE_COUNT__
+Region: __REGION__
+
+## Connection
+
+```
+Host:     <db-node-ip>
+Port:     30432
+Database: postgres
+User:     postgres
+Password: postgres
+```
+
+```bash
+psql -h <db-node-ip> -p 30432 -U postgres -d postgres
+```
+
+## SQL via easy-db-lab
+
+```bash
+easy-db-lab postgres sql "SELECT version()"
+easy-db-lab postgres sql --file query.sql
+```
+
+## Lifecycle
+
+```bash
+easy-db-lab postgres start    # provision PVs, deploy CNPG Cluster CR, wait for ready
+easy-db-lab postgres stop     # remove Cluster CR (data retained on PVs)
+easy-db-lab postgres start    # reattach to existing PVs, data intact
+easy-db-lab postgres uninstall  # remove operator and delete PVs
+```
+
+## Presto integration
+
+When both postgres and presto are running, a `postgres` catalog is automatically
+available in Presto:
+
+```sql
+SHOW TABLES FROM postgres.public;
+SELECT count(*) FROM postgres.public.my_table;
+```

--- a/src/main/resources/com/rustyrazorblade/easydblab/kits/postgres/dashboards/duckdb.json
+++ b/src/main/resources/com/rustyrazorblade/easydblab/kits/postgres/dashboards/duckdb.json
@@ -1,0 +1,449 @@
+{
+  "uid": "postgres-duckdb",
+  "title": "DuckDB Analytics (pg_duckdb)",
+  "description": "DuckDB analytical execution signatures in PostgreSQL: temp file spill, seq scan dominance, buffer pressure. pg_duckdb has no native Prometheus metrics — this dashboard exposes its behavior through PostgreSQL stats.",
+  "graphTooltip": 1,
+  "schemaVersion": 36,
+  "time": { "from": "now-1h", "to": "now" },
+  "refresh": "15s",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "liveNow": false,
+  "links": [
+    {
+      "title": "PostgreSQL Overview",
+      "type": "link",
+      "url": "/d/postgres-overview",
+      "targetBlank": false,
+      "icon": "external link"
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "datasource", "uid": "grafana" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": { "limit": 100, "matchAny": false, "tags": [], "type": "dashboard" },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "templating": {
+    "list": [
+      {
+        "current": { "text": "VictoriaMetrics", "value": "VictoriaMetrics" },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "type": "datasource"
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "row",
+      "title": "DuckDB Execution Signals",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "panels": []
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Temp Files Created (total)",
+      "description": "DuckDB spills intermediate results to PostgreSQL temp files when working memory is exhausted during large sorts, hash joins, or hash aggregates. Each temp file = one analytical spill event.",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 1 },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 10 }, { "color": "red", "value": 100 }] },
+          "unit": "none",
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "cnpg_pg_stat_database_temp_files_total{job=\"postgres\",host_name=\"db0\",datname=\"postgres\"}",
+          "refId": "A",
+          "legendFormat": "temp files"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Temp Data Spilled (total)",
+      "description": "Cumulative bytes DuckDB has spilled to disk for temp files. Large values indicate analytical queries are exceeding available work_mem.",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 1 },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 104857600 }, { "color": "red", "value": 1073741824 }] },
+          "unit": "bytes",
+          "decimals": 1
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "cnpg_pg_stat_database_temp_bytes_total{job=\"postgres\",host_name=\"db0\",datname=\"postgres\"}",
+          "refId": "A",
+          "legendFormat": "temp bytes"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Seq Scan Ratio",
+      "description": "tup_returned / tup_fetched. OLTP with indexes gives a ratio near 1. DuckDB analytical full-table scans push this ratio to 10x–1000x. A high value here means analytical queries are dominating.",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 1 },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 5 }, { "color": "red", "value": 50 }] },
+          "unit": "none",
+          "decimals": 1
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum(rate(cnpg_pg_stat_database_tup_returned_total{job=\"postgres\",host_name=\"db0\",datname=\"postgres\"}[2m])) / clamp_min(sum(rate(cnpg_pg_stat_database_tup_fetched_total{job=\"postgres\",host_name=\"db0\",datname=\"postgres\"}[2m])), 1)",
+          "refId": "A",
+          "legendFormat": "ratio"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "stat",
+      "title": "Buffer Cache Hit Ratio",
+      "description": "DuckDB full table scans evict index and OLTP data from shared_buffers. A drop here during analytical queries shows DuckDB's cache footprint. Optimal OLTP maintains >99%.",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 1 },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "red", "value": null }, { "color": "yellow", "value": 0.90 }, { "color": "green", "value": 0.99 }] },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum(rate(cnpg_pg_stat_database_blks_hit_total{job=\"postgres\",host_name=\"db0\",datname=\"postgres\"}[2m])) / (sum(rate(cnpg_pg_stat_database_blks_hit_total{job=\"postgres\",host_name=\"db0\",datname=\"postgres\"}[2m])) + sum(rate(cnpg_pg_stat_database_blks_read_total{job=\"postgres\",host_name=\"db0\",datname=\"postgres\"}[2m])))",
+          "refId": "A",
+          "legendFormat": ""
+        }
+      ]
+    },
+    {
+      "id": 10,
+      "type": "row",
+      "title": "Analytical vs OLTP Profile",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 5 },
+      "panels": []
+    },
+    {
+      "id": 11,
+      "type": "timeseries",
+      "title": "Tuple Throughput: Analytical vs Index",
+      "description": "tup_returned (green) = rows scanned sequentially — DuckDB does full table scans so this dominates during analytics. tup_fetched (yellow) = rows from index lookups — OLTP with WHERE on indexed columns. A spike in tup_returned with flat tup_fetched is the DuckDB analytical signature.",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 6 },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "rps",
+          "custom": { "lineWidth": 2, "fillOpacity": 15 }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "seq scan (tup_returned/s)" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "#73BF69", "mode": "fixed" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "index lookup (tup_fetched/s)" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "#FADE2A", "mode": "fixed" } }]
+          }
+        ]
+      },
+      "options": {
+        "legend": { "calcs": ["mean", "max", "lastNotNull"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum(rate(cnpg_pg_stat_database_tup_returned_total{job=\"postgres\",host_name=\"db0\",datname=\"postgres\"}[2m]))",
+          "refId": "A",
+          "legendFormat": "seq scan (tup_returned/s)"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum(rate(cnpg_pg_stat_database_tup_fetched_total{job=\"postgres\",host_name=\"db0\",datname=\"postgres\"}[2m]))",
+          "refId": "B",
+          "legendFormat": "index lookup (tup_fetched/s)"
+        }
+      ]
+    },
+    {
+      "id": 20,
+      "type": "row",
+      "title": "Temp File Spill (DuckDB Working Memory)",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 14 },
+      "panels": []
+    },
+    {
+      "id": 21,
+      "type": "timeseries",
+      "title": "Temp File Spill Rate",
+      "description": "Rate of DuckDB spilling to disk. Each spike corresponds to an analytical query that exceeded available memory for sorts, hash joins, or aggregates. A flat zero here means DuckDB is running entirely in memory — increase work_mem to eliminate spills.",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 15 },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "Bps",
+          "custom": { "lineWidth": 2, "fillOpacity": 30 }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "calcs": ["mean", "max", "lastNotNull"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum(rate(cnpg_pg_stat_database_temp_bytes_total{job=\"postgres\",host_name=\"db0\",datname=\"postgres\"}[2m]))",
+          "refId": "A",
+          "legendFormat": "temp bytes/s"
+        }
+      ]
+    },
+    {
+      "id": 22,
+      "type": "timeseries",
+      "title": "Disk Block Reads (Cache Miss)",
+      "description": "Physical disk reads during DuckDB full table scans. When DuckDB scans a large table that doesn't fit in shared_buffers, all blocks must be read from disk. This metric spikes during analytical queries and drops back to near-zero after OLTP resumes.",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 15 },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "rps",
+          "custom": { "lineWidth": 2, "fillOpacity": 20 }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "calcs": ["mean", "max", "lastNotNull"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum(rate(cnpg_pg_stat_database_blks_read_total{job=\"postgres\",host_name=\"db0\",datname=\"postgres\"}[2m]))",
+          "refId": "A",
+          "legendFormat": "disk reads/s"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum(rate(cnpg_pg_stat_database_blks_hit_total{job=\"postgres\",host_name=\"db0\",datname=\"postgres\"}[2m]))",
+          "refId": "B",
+          "legendFormat": "cache hits/s"
+        }
+      ]
+    },
+    {
+      "id": 30,
+      "type": "row",
+      "title": "Background Writer Pressure",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 22 },
+      "panels": []
+    },
+    {
+      "id": 31,
+      "type": "timeseries",
+      "title": "Background Writer Activity",
+      "description": "When DuckDB reads large tables, it evicts OLTP data from shared_buffers. The background writer cleans dirty pages to make room. High buffers_clean here (relative to buffers_alloc) indicates DuckDB is creating cache pressure for concurrent OLTP workloads.",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 23 },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "rps",
+          "custom": { "lineWidth": 1, "fillOpacity": 10 }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "calcs": ["mean", "max", "lastNotNull"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "rate(cnpg_pg_stat_bgwriter_buffers_clean_total{job=\"postgres\",host_name=\"db0\"}[2m])",
+          "refId": "A",
+          "legendFormat": "buffers cleaned/s"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "rate(cnpg_pg_stat_bgwriter_buffers_alloc_total{job=\"postgres\",host_name=\"db0\"}[2m])",
+          "refId": "B",
+          "legendFormat": "buffers allocated/s"
+        }
+      ]
+    },
+    {
+      "id": 32,
+      "type": "timeseries",
+      "title": "Transaction Duration (Analytical vs OLTP)",
+      "description": "DuckDB analytical queries run as single long-running transactions. OLTP transactions commit in microseconds. A high max_tx_duration during analytical load is expected and indicates DuckDB is actively processing. The value drops immediately when the analytical query completes.",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 23 },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "s",
+          "custom": { "lineWidth": 2, "fillOpacity": 10 }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "calcs": ["mean", "max", "lastNotNull"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "max(cnpg_backends_max_tx_duration_seconds{job=\"postgres\",host_name=\"db0\"})",
+          "refId": "A",
+          "legendFormat": "max tx duration (s)"
+        }
+      ]
+    },
+    {
+      "id": 40,
+      "type": "row",
+      "title": "WAL & Transactions",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 30 },
+      "panels": []
+    },
+    {
+      "id": 41,
+      "type": "timeseries",
+      "title": "WAL Generation Rate",
+      "description": "DuckDB read-only analytical queries generate no WAL. If WAL generation drops during what should be an analytical-heavy period, it confirms DuckDB is running read-only queries (SELECT only). WAL resumes when OLTP writes return.",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 31 },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "Bps",
+          "custom": { "lineWidth": 1, "fillOpacity": 10 }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "rate(cnpg_collector_wal_bytes{job=\"postgres\",host_name=\"db0\"}[2m])",
+          "refId": "A",
+          "legendFormat": "WAL bytes/s"
+        }
+      ]
+    },
+    {
+      "id": 42,
+      "type": "timeseries",
+      "title": "Transaction Rate",
+      "description": "DuckDB analytics = low commits/s (one commit per long-running query). OLTP = high commits/s (thousands of short transactions). Watch for a drop in commit rate when DuckDB takes over — this is the DuckDB execution window.",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 31 },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "ops",
+          "custom": { "lineWidth": 1, "fillOpacity": 10 }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "calcs": ["mean", "max", "lastNotNull"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum(rate(cnpg_pg_stat_database_xact_commit_total{job=\"postgres\",host_name=\"db0\",datname=\"postgres\"}[2m]))",
+          "refId": "A",
+          "legendFormat": "commits/s"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum(rate(cnpg_pg_stat_database_xact_rollback_total{job=\"postgres\",host_name=\"db0\",datname=\"postgres\"}[2m]))",
+          "refId": "B",
+          "legendFormat": "rollbacks/s"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/com/rustyrazorblade/easydblab/kits/postgres/dashboards/postgis.json
+++ b/src/main/resources/com/rustyrazorblade/easydblab/kits/postgres/dashboards/postgis.json
@@ -1,0 +1,597 @@
+{
+  "uid": "postgres-postgis",
+  "title": "PostGIS Geospatial",
+  "description": "PostGIS spatial query signatures: cache pressure from GiST index traversal, temp file spill from complex spatial joins, WAL patterns during geometry bulk loads.",
+  "graphTooltip": 1,
+  "schemaVersion": 36,
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "refresh": "15s",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "liveNow": false,
+  "links": [
+    {
+      "title": "PostgreSQL Overview",
+      "type": "link",
+      "url": "/d/postgres-overview",
+      "targetBlank": false,
+      "icon": "external link"
+    },
+    {
+      "title": "DuckDB Analytics",
+      "type": "link",
+      "url": "/d/postgres-duckdb",
+      "targetBlank": false,
+      "icon": "external link"
+    },
+    {
+      "title": "TimescaleDB",
+      "type": "link",
+      "url": "/d/postgres-timescaledb",
+      "targetBlank": false,
+      "icon": "external link"
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "text": "VictoriaMetrics",
+          "value": "VictoriaMetrics"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "type": "datasource"
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "row",
+      "title": "Spatial Query Signatures",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "panels": []
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Cache Hit Ratio",
+      "description": "Spatial indexes (GiST, SP-GiST) are memory-intensive. A low hit ratio means spatial queries are thrashing disk.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 1
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.9
+              },
+              {
+                "color": "green",
+                "value": 0.99
+              }
+            ]
+          }
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(cnpg_pg_stat_database_blks_hit_total{job=\"postgres\",server_port=\"30988\",datname=\"postgres\"}[5m])) / clamp_min(sum(rate(cnpg_pg_stat_database_blks_hit_total{job=\"postgres\",server_port=\"30988\",datname=\"postgres\"}[5m])) + sum(rate(cnpg_pg_stat_database_blks_read_total{job=\"postgres\",server_port=\"30988\",datname=\"postgres\"}[5m])), 1)",
+          "instant": true,
+          "legendFormat": "__auto"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Transactions/sec",
+      "description": "Overall transaction rate including spatial query and data-loading transactions.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 1
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(cnpg_pg_stat_database_xact_commit_total{job=\"postgres\",server_port=\"30988\",datname=\"postgres\"}[2m]))",
+          "instant": true,
+          "legendFormat": "__auto"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Temp Files (total)",
+      "description": "Complex spatial joins (ST_Within, ST_Intersects over large datasets) may spill to temp files when working memory is exhausted.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 1
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 5
+              },
+              {
+                "color": "red",
+                "value": 50
+              }
+            ]
+          }
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "max(cnpg_pg_stat_database_temp_files_total{job=\"postgres\",server_port=\"30988\",host_name=\"db0\",datname=\"postgres\"})",
+          "instant": true,
+          "legendFormat": "__auto"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "stat",
+      "title": "Database Size",
+      "description": "Geometry columns and spatial indexes add significant storage overhead compared to plain relational data.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 1
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "max(cnpg_pg_database_size_bytes{job=\"postgres\",server_port=\"30988\",datname=\"postgres\"})",
+          "instant": true,
+          "legendFormat": "__auto"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "Buffer Cache Hit Ratio",
+      "description": "Spatial GiST index traversal is highly cache-sensitive. Watch for sustained dips below 99%.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 5
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10
+          }
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(cnpg_pg_stat_database_blks_hit_total{job=\"postgres\",server_port=\"30988\",datname=\"postgres\"}[2m])) / clamp_min(sum(rate(cnpg_pg_stat_database_blks_hit_total{job=\"postgres\",server_port=\"30988\",datname=\"postgres\"}[2m])) + sum(rate(cnpg_pg_stat_database_blks_read_total{job=\"postgres\",server_port=\"30988\",datname=\"postgres\"}[2m])), 1)",
+          "legendFormat": "cache hit ratio"
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "type": "timeseries",
+      "title": "Temp Data Spilled",
+      "description": "Bytes spilled to disk during spatial query execution. Indicates work_mem pressure.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 5
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10
+          }
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "rate(cnpg_pg_stat_database_temp_bytes_total{job=\"postgres\",server_port=\"30988\",host_name=\"db0\",datname=\"postgres\"}[2m])",
+          "legendFormat": "spill bytes/s"
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "type": "row",
+      "title": "Write & WAL Patterns",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 13
+      },
+      "panels": []
+    },
+    {
+      "id": 9,
+      "type": "timeseries",
+      "title": "WAL Generation Rate",
+      "description": "PostGIS bulk loads (ST_GeomFromText inserts) generate high WAL volume. Sustained WAL > 10 MB/s suggests geometry-heavy writes.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 14
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10
+          }
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "rate(cnpg_collector_wal_bytes{job=\"postgres\",server_port=\"30988\",host_name=\"db0\"}[2m])",
+          "legendFormat": "WAL bytes/s"
+        }
+      ]
+    },
+    {
+      "id": 10,
+      "type": "timeseries",
+      "title": "Transaction Rate",
+      "description": "Commit and rollback rate over time.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 14
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10
+          }
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(cnpg_pg_stat_database_xact_commit_total{job=\"postgres\",server_port=\"30988\",datname=\"postgres\"}[2m]))",
+          "legendFormat": "commits/s"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(cnpg_pg_stat_database_xact_rollback_total{job=\"postgres\",server_port=\"30988\",datname=\"postgres\"}[2m]))",
+          "legendFormat": "rollbacks/s"
+        }
+      ]
+    },
+    {
+      "id": 11,
+      "type": "row",
+      "title": "Seq Scan & Tuple Throughput",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 22
+      },
+      "panels": []
+    },
+    {
+      "id": 12,
+      "type": "timeseries",
+      "title": "Sequential Scan vs Index Fetch Rate",
+      "description": "PostGIS spatial predicates often drive sequential scans (bounding-box filter \u2192 refine). A high tup_returned:tup_fetched ratio signals heavy sequential scans.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 23
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10
+          }
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(cnpg_pg_stat_database_tup_returned_total{job=\"postgres\",server_port=\"30988\",datname=\"postgres\"}[2m]))",
+          "legendFormat": "rows scanned (seqscan)"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(cnpg_pg_stat_database_tup_fetched_total{job=\"postgres\",server_port=\"30988\",datname=\"postgres\"}[2m]))",
+          "legendFormat": "rows fetched (index)"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/com/rustyrazorblade/easydblab/kits/postgres/dashboards/postgres.json
+++ b/src/main/resources/com/rustyrazorblade/easydblab/kits/postgres/dashboards/postgres.json
@@ -1,0 +1,463 @@
+{
+  "uid": "postgres-overview",
+  "title": "PostgreSQL Overview",
+  "description": "CloudNativePG cluster metrics: connections, transactions, I/O, WAL, and replication",
+  "graphTooltip": 1,
+  "schemaVersion": 36,
+  "time": { "from": "now-1h", "to": "now" },
+  "refresh": "30s",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "liveNow": false,
+  "links": [],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "datasource", "uid": "grafana" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": { "limit": 100, "matchAny": false, "tags": [], "type": "dashboard" },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "templating": {
+    "list": [
+      {
+        "current": { "text": "VictoriaMetrics", "value": "VictoriaMetrics" },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "type": "datasource"
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "row",
+      "title": "PostgreSQL Overview",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "panels": []
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Total Connections",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 3, "w": 4, "x": 0, "y": 1 },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "orientation": "auto", "textMode": "auto", "colorMode": "value", "graphMode": "none" },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 50 }, { "color": "red", "value": 100 }] }, "unit": "none" },
+        "overrides": []
+      },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum(cnpg_backends_total{job=\"postgres\"})", "refId": "A", "legendFormat": "" }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Database Size",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 3, "w": 4, "x": 4, "y": 1 },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "orientation": "auto", "textMode": "auto", "colorMode": "value", "graphMode": "none" },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] }, "unit": "bytes" },
+        "overrides": []
+      },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "max(cnpg_pg_database_size_bytes{job=\"postgres\",datname=\"postgres\"})", "refId": "A", "legendFormat": "" }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Cache Hit Ratio",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 3, "w": 4, "x": 8, "y": 1 },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "orientation": "auto", "textMode": "auto", "colorMode": "value", "graphMode": "none" },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "red", "value": null }, { "color": "yellow", "value": 0.90 }, { "color": "green", "value": 0.99 }] }, "unit": "percentunit" },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum(rate(cnpg_pg_stat_database_blks_hit_total{job=\"postgres\"}[5m])) / (sum(rate(cnpg_pg_stat_database_blks_hit_total{job=\"postgres\"}[5m])) + sum(rate(cnpg_pg_stat_database_blks_read_total{job=\"postgres\"}[5m])))",
+          "refId": "A",
+          "legendFormat": ""
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "stat",
+      "title": "Streaming Replicas",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 3, "w": 4, "x": 12, "y": 1 },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "orientation": "auto", "textMode": "auto", "colorMode": "value", "graphMode": "none" },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] }, "unit": "none" },
+        "overrides": []
+      },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "max(cnpg_pg_replication_streaming_replicas{job=\"postgres\"})", "refId": "A", "legendFormat": "" }
+      ]
+    },
+    {
+      "id": 6,
+      "type": "stat",
+      "title": "Max TX Duration",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 3, "w": 4, "x": 16, "y": 1 },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "orientation": "auto", "textMode": "auto", "colorMode": "value", "graphMode": "none" },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 30 }, { "color": "red", "value": 300 }] }, "unit": "s" },
+        "overrides": []
+      },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "max(cnpg_backends_max_tx_duration_seconds{job=\"postgres\"})", "refId": "A", "legendFormat": "" }
+      ]
+    },
+    {
+      "id": 7,
+      "type": "stat",
+      "title": "Deadlocks (5m)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 3, "w": 4, "x": 20, "y": 1 },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "orientation": "auto", "textMode": "auto", "colorMode": "value", "graphMode": "none" },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "red", "value": 1 }] }, "unit": "none" },
+        "overrides": []
+      },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum(increase(cnpg_pg_stat_database_deadlocks_total{job=\"postgres\"}[5m]))", "refId": "A", "legendFormat": "" }
+      ]
+    },
+    {
+      "id": 10,
+      "type": "row",
+      "title": "Transactions & Activity",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 4 },
+      "panels": []
+    },
+    {
+      "id": 11,
+      "type": "timeseries",
+      "title": "Transaction Rate",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 5 },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "unit": "ops", "custom": { "lineWidth": 1, "fillOpacity": 10 } },
+        "overrides": []
+      },
+      "options": { "legend": { "calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum(rate(cnpg_pg_stat_database_xact_commit_total{job=\"postgres\"}[2m]))", "refId": "A", "legendFormat": "commits/s" },
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum(rate(cnpg_pg_stat_database_xact_rollback_total{job=\"postgres\"}[2m]))", "refId": "B", "legendFormat": "rollbacks/s" }
+      ]
+    },
+    {
+      "id": 12,
+      "type": "timeseries",
+      "title": "Row Operations Rate",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 5 },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "unit": "rps", "custom": { "lineWidth": 1, "fillOpacity": 10 } },
+        "overrides": []
+      },
+      "options": { "legend": { "calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum(rate(cnpg_pg_stat_database_tup_inserted_total{job=\"postgres\"}[2m]))", "refId": "A", "legendFormat": "inserted/s" },
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum(rate(cnpg_pg_stat_database_tup_updated_total{job=\"postgres\"}[2m]))", "refId": "B", "legendFormat": "updated/s" },
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum(rate(cnpg_pg_stat_database_tup_deleted_total{job=\"postgres\"}[2m]))", "refId": "C", "legendFormat": "deleted/s" },
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum(rate(cnpg_pg_stat_database_tup_fetched_total{job=\"postgres\"}[2m]))", "refId": "D", "legendFormat": "fetched/s" }
+      ]
+    },
+    {
+      "id": 13,
+      "type": "timeseries",
+      "title": "Active Connections",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 12 },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "unit": "none", "custom": { "lineWidth": 1, "fillOpacity": 10 } },
+        "overrides": []
+      },
+      "options": { "legend": { "calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum by (datname) (cnpg_backends_total{job=\"postgres\"})", "refId": "A", "legendFormat": "{{datname}}" },
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum(cnpg_backends_waiting_total{job=\"postgres\"})", "refId": "B", "legendFormat": "waiting (lock)" }
+      ]
+    },
+    {
+      "id": 14,
+      "type": "timeseries",
+      "title": "Deadlocks & Conflicts",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 12 },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "unit": "none", "custom": { "lineWidth": 1, "fillOpacity": 10 } },
+        "overrides": []
+      },
+      "options": { "legend": { "calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum(rate(cnpg_pg_stat_database_deadlocks_total{job=\"postgres\"}[5m]))", "refId": "A", "legendFormat": "deadlocks/s" },
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "sum(rate(cnpg_pg_stat_database_conflicts_total{job=\"postgres\"}[5m]))", "refId": "B", "legendFormat": "conflicts/s" }
+      ]
+    },
+    {
+      "id": 20,
+      "type": "row",
+      "title": "I/O & Buffers",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 19 },
+      "panels": []
+    },
+    {
+      "id": 21,
+      "type": "timeseries",
+      "title": "Buffer Cache Hit Ratio",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 20 },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "unit": "percentunit", "min": 0, "max": 1, "custom": { "lineWidth": 1, "fillOpacity": 10 } },
+        "overrides": []
+      },
+      "options": { "legend": { "calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum by (datname) (rate(cnpg_pg_stat_database_blks_hit_total{job=\"postgres\"}[2m])) / (sum by (datname) (rate(cnpg_pg_stat_database_blks_hit_total{job=\"postgres\"}[2m])) + sum by (datname) (rate(cnpg_pg_stat_database_blks_read_total{job=\"postgres\"}[2m])))",
+          "refId": "A",
+          "legendFormat": "{{datname}}"
+        }
+      ]
+    },
+    {
+      "id": 22,
+      "type": "timeseries",
+      "title": "Buffer Writes (bgwriter & checkpointer)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 20 },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "unit": "binBps", "custom": { "lineWidth": 1, "fillOpacity": 10 } },
+        "overrides": []
+      },
+      "options": { "legend": { "calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "rate(cnpg_pg_stat_bgwriter_buffers_clean_total{job=\"postgres\"}[2m]) * 8192", "refId": "A", "legendFormat": "bgwriter" },
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "rate(cnpg_pg_stat_checkpointer_buffers_written_total{job=\"postgres\"}[2m]) * 8192", "refId": "B", "legendFormat": "checkpointer" }
+      ]
+    },
+    {
+      "id": 23,
+      "type": "timeseries",
+      "title": "Checkpoint Duration",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 27 },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "unit": "ms", "custom": { "lineWidth": 1, "fillOpacity": 10 } },
+        "overrides": []
+      },
+      "options": { "legend": { "calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "rate(cnpg_pg_stat_checkpointer_write_time_total{job=\"postgres\"}[5m])", "refId": "A", "legendFormat": "write time (ms/s)" },
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "rate(cnpg_pg_stat_checkpointer_sync_time_total{job=\"postgres\"}[5m])", "refId": "B", "legendFormat": "sync time (ms/s)" }
+      ]
+    },
+    {
+      "id": 24,
+      "type": "timeseries",
+      "title": "Checkpoints Rate",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 27 },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "unit": "cpm", "custom": { "lineWidth": 1, "fillOpacity": 10 } },
+        "overrides": []
+      },
+      "options": { "legend": { "calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "rate(cnpg_pg_stat_checkpointer_checkpoints_timed_total{job=\"postgres\"}[5m]) * 60", "refId": "A", "legendFormat": "scheduled" },
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "rate(cnpg_pg_stat_checkpointer_checkpoints_req_total{job=\"postgres\"}[5m]) * 60", "refId": "B", "legendFormat": "requested" }
+      ]
+    },
+    {
+      "id": 30,
+      "type": "row",
+      "title": "WAL",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 34 },
+      "panels": []
+    },
+    {
+      "id": 31,
+      "type": "timeseries",
+      "title": "WAL Generation Rate",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 35 },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "unit": "Bps", "custom": { "lineWidth": 1, "fillOpacity": 10 } },
+        "overrides": []
+      },
+      "options": { "legend": { "calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "rate(cnpg_collector_wal_bytes{job=\"postgres\"}[2m])", "refId": "A", "legendFormat": "WAL bytes/s" }
+      ]
+    },
+    {
+      "id": 32,
+      "type": "timeseries",
+      "title": "WAL Sync & Write Time",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 35 },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "unit": "µs", "custom": { "lineWidth": 1, "fillOpacity": 10 } },
+        "overrides": []
+      },
+      "options": { "legend": { "calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "rate(cnpg_collector_wal_write_time{job=\"postgres\"}[2m])", "refId": "A", "legendFormat": "write µs/s" },
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "rate(cnpg_collector_wal_sync_time{job=\"postgres\"}[2m])", "refId": "B", "legendFormat": "sync µs/s" }
+      ]
+    },
+    {
+      "id": 33,
+      "type": "timeseries",
+      "title": "WAL Archive Status",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 42 },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "unit": "none", "custom": { "lineWidth": 1, "fillOpacity": 10 } },
+        "overrides": []
+      },
+      "options": { "legend": { "calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "rate(cnpg_pg_stat_archiver_archived_count_total{job=\"postgres\"}[5m])", "refId": "A", "legendFormat": "archived/s" },
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "rate(cnpg_pg_stat_archiver_failed_count_total{job=\"postgres\"}[5m])", "refId": "B", "legendFormat": "failed/s" }
+      ]
+    },
+    {
+      "id": 40,
+      "type": "row",
+      "title": "Replication",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 49 },
+      "panels": []
+    },
+    {
+      "id": 41,
+      "type": "timeseries",
+      "title": "Streaming Replicas",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 50 },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "unit": "none", "custom": { "lineWidth": 1, "fillOpacity": 10 } },
+        "overrides": []
+      },
+      "options": { "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "max(cnpg_pg_replication_streaming_replicas{job=\"postgres\"})", "refId": "A", "legendFormat": "streaming replicas" }
+      ]
+    },
+    {
+      "id": 42,
+      "type": "timeseries",
+      "title": "Replication Lag",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 50 },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "unit": "bytes", "custom": { "lineWidth": 1, "fillOpacity": 10 } },
+        "overrides": []
+      },
+      "options": { "legend": { "calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "max(cnpg_pg_replication_lag{job=\"postgres\"})", "refId": "A", "legendFormat": "replication lag" }
+      ]
+    },
+    {
+      "id": 50,
+      "type": "row",
+      "title": "Database Sizes",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 57 },
+      "panels": []
+    },
+    {
+      "id": 51,
+      "type": "timeseries",
+      "title": "Database Size by DB",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 58 },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "unit": "bytes", "custom": { "lineWidth": 1, "fillOpacity": 10 } },
+        "overrides": []
+      },
+      "options": { "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "max by (datname) (cnpg_pg_database_size_bytes{job=\"postgres\",datname!~\"template.*\"})",
+          "refId": "A",
+          "legendFormat": "{{datname}}"
+        }
+      ]
+    },
+    {
+      "id": 52,
+      "type": "timeseries",
+      "title": "Transaction ID Age (XID Age)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 58 },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "unit": "none", "custom": { "lineWidth": 1, "fillOpacity": 10 } },
+        "overrides": []
+      },
+      "options": { "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "max by (datname) (cnpg_pg_database_xid_age{job=\"postgres\",datname!~\"template.*\"})",
+          "refId": "A",
+          "legendFormat": "{{datname}}"
+        }
+      ]
+    },
+    {
+      "id": 60,
+      "type": "row",
+      "title": "PostgreSQL Logs",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 65 },
+      "panels": []
+    },
+    {
+      "id": 61,
+      "type": "logs",
+      "title": "PostgreSQL Logs",
+      "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs" },
+      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 66 },
+      "options": { "dedupStrategy": "none", "enableLogDetails": true, "prettifyLogMessage": false, "showLabels": false, "showTime": true, "sortOrder": "Descending", "wrapLogMessage": false },
+      "targets": [
+        {
+          "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs" },
+          "expr": "log.file.name:postgres",
+          "refId": "A",
+          "legendFormat": ""
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/com/rustyrazorblade/easydblab/kits/postgres/dashboards/timescaledb.json
+++ b/src/main/resources/com/rustyrazorblade/easydblab/kits/postgres/dashboards/timescaledb.json
@@ -1,0 +1,605 @@
+{
+  "uid": "postgres-timescaledb",
+  "title": "TimescaleDB Time-Series",
+  "description": "TimescaleDB time-series write patterns: WAL generation from chunk fills, insert-dominant tuple throughput, buffer cache for recent-data queries, checkpoint pressure.",
+  "graphTooltip": 1,
+  "schemaVersion": 36,
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "refresh": "15s",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "liveNow": false,
+  "links": [
+    {
+      "title": "PostgreSQL Overview",
+      "type": "link",
+      "url": "/d/postgres-overview",
+      "targetBlank": false,
+      "icon": "external link"
+    },
+    {
+      "title": "DuckDB Analytics",
+      "type": "link",
+      "url": "/d/postgres-duckdb",
+      "targetBlank": false,
+      "icon": "external link"
+    },
+    {
+      "title": "PostGIS Geospatial",
+      "type": "link",
+      "url": "/d/postgres-postgis",
+      "targetBlank": false,
+      "icon": "external link"
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "text": "VictoriaMetrics",
+          "value": "VictoriaMetrics"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "type": "datasource"
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "row",
+      "title": "Time-Series Write Throughput",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "panels": []
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Transactions/sec",
+      "description": "Time-series workloads are append-dominant. High commit rate with low rollback rate is the ideal pattern.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 1
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(cnpg_pg_stat_database_xact_commit_total{job=\"postgres\",server_port=\"30989\",datname=\"postgres\"}[2m]))",
+          "instant": true,
+          "legendFormat": "__auto"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "WAL Write Rate",
+      "description": "TimescaleDB's chunk-based storage generates predictable WAL bursts as new time-chunks are filled.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 1
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "rate(cnpg_collector_wal_bytes{job=\"postgres\",server_port=\"30989\",host_name=\"db0\"}[2m])",
+          "instant": true,
+          "legendFormat": "__auto"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Buffer Cache Hit Ratio",
+      "description": "Time-series queries for recent data should stay in cache. Low hit ratio suggests the working set exceeds shared_buffers.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 1
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.9
+              },
+              {
+                "color": "green",
+                "value": 0.99
+              }
+            ]
+          }
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(cnpg_pg_stat_database_blks_hit_total{job=\"postgres\",server_port=\"30989\",datname=\"postgres\"}[5m])) / clamp_min(sum(rate(cnpg_pg_stat_database_blks_hit_total{job=\"postgres\",server_port=\"30989\",datname=\"postgres\"}[5m])) + sum(rate(cnpg_pg_stat_database_blks_read_total{job=\"postgres\",server_port=\"30989\",datname=\"postgres\"}[5m])), 1)",
+          "instant": true,
+          "legendFormat": "__auto"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "stat",
+      "title": "Database Size",
+      "description": "TimescaleDB grows quickly with continuous time-series ingestion. Size reflects chunks across all hypertables.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 1
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "max(cnpg_pg_database_size_bytes{job=\"postgres\",server_port=\"30989\",datname=\"postgres\"})",
+          "instant": true,
+          "legendFormat": "__auto"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "WAL Generation Rate",
+      "description": "Time-series ingestion produces sustained WAL writes. Each chunk fill and chunk creation appears as a write spike.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 5
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10
+          }
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "rate(cnpg_collector_wal_bytes{job=\"postgres\",server_port=\"30989\",host_name=\"db0\"}[2m])",
+          "legendFormat": "WAL bytes/s"
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "type": "timeseries",
+      "title": "Transaction Rate (Commit vs Rollback)",
+      "description": "Append-only time-series should show commits >> rollbacks. Elevated rollbacks indicate transaction conflicts or chunk creation contention.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 5
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10
+          }
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(cnpg_pg_stat_database_xact_commit_total{job=\"postgres\",server_port=\"30989\",datname=\"postgres\"}[2m]))",
+          "legendFormat": "commits/s"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(cnpg_pg_stat_database_xact_rollback_total{job=\"postgres\",server_port=\"30989\",datname=\"postgres\"}[2m]))",
+          "legendFormat": "rollbacks/s"
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "type": "row",
+      "title": "Buffer & Checkpoint Behavior",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 13
+      },
+      "panels": []
+    },
+    {
+      "id": 9,
+      "type": "timeseries",
+      "title": "Buffer Cache Hit Ratio",
+      "description": "Recent-data queries should show near-100% cache hits. Drops indicate background chunk aging pushing hot data out of cache.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 14
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10
+          }
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(cnpg_pg_stat_database_blks_hit_total{job=\"postgres\",server_port=\"30989\",datname=\"postgres\"}[2m])) / clamp_min(sum(rate(cnpg_pg_stat_database_blks_hit_total{job=\"postgres\",server_port=\"30989\",datname=\"postgres\"}[2m])) + sum(rate(cnpg_pg_stat_database_blks_read_total{job=\"postgres\",server_port=\"30989\",datname=\"postgres\"}[2m])), 1)",
+          "legendFormat": "hit ratio"
+        }
+      ]
+    },
+    {
+      "id": 10,
+      "type": "timeseries",
+      "title": "Checkpoint Write Rate",
+      "description": "TimescaleDB's continuous chunk writes trigger background checkpoints. High checkpoint frequency indicates write pressure.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 14
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10
+          }
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "rate(cnpg_pg_stat_checkpointer_buffers_written_total{job=\"postgres\",server_port=\"30989\",host_name=\"db0\"}[2m])",
+          "legendFormat": "buffers written/s"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "rate(cnpg_pg_stat_bgwriter_buffers_clean_total{job=\"postgres\",server_port=\"30989\",host_name=\"db0\"}[2m])",
+          "legendFormat": "bgwriter clean/s"
+        }
+      ]
+    },
+    {
+      "id": 11,
+      "type": "row",
+      "title": "Tuple Throughput (Insert Dominance)",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 22
+      },
+      "panels": []
+    },
+    {
+      "id": 12,
+      "type": "timeseries",
+      "title": "Insert vs Update vs Delete Rate",
+      "description": "Time-series workloads are insert-dominant. Updates and deletes on hypertable chunks are rare (chunk immutability). Elevated updates suggest non-hypertable workloads.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 23
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10
+          }
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(cnpg_pg_stat_database_tup_inserted_total{job=\"postgres\",server_port=\"30989\",datname=\"postgres\"}[2m]))",
+          "legendFormat": "inserts/s"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(cnpg_pg_stat_database_tup_updated_total{job=\"postgres\",server_port=\"30989\",datname=\"postgres\"}[2m]))",
+          "legendFormat": "updates/s"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(cnpg_pg_stat_database_tup_deleted_total{job=\"postgres\",server_port=\"30989\",datname=\"postgres\"}[2m]))",
+          "legendFormat": "deletes/s"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/com/rustyrazorblade/easydblab/kits/postgres/extensions.yaml
+++ b/src/main/resources/com/rustyrazorblade/easydblab/kits/postgres/extensions.yaml
@@ -1,0 +1,30 @@
+extensions:
+  duckdb:
+    description: "DuckDB analytical query engine via pg_duckdb"
+    image: "pgduckdb/pgduckdb:__PG_MAJOR__-v1.1.1"
+    shared_preload_libraries:
+      - pg_duckdb
+    create_extensions:
+      - pg_duckdb
+    postgres_uid: 999
+    postgres_gid: 999
+    postgres_port: 30432
+    metrics_port: 30987
+  postgis:
+    description: "Geospatial types and functions"
+    image: "ghcr.io/cloudnative-pg/postgis:__PG_MAJOR__"
+    create_extensions:
+      - postgis
+    postgres_port: 30433
+    metrics_port: 30988
+  timescaledb:
+    description: "Time-series storage and query optimization"
+    image: "timescale/timescaledb-ha:pg__PG_MAJOR__"
+    shared_preload_libraries:
+      - timescaledb
+    create_extensions:
+      - timescaledb
+    postgres_uid: 1000
+    postgres_gid: 1000
+    postgres_port: 30434
+    metrics_port: 30989

--- a/src/main/resources/com/rustyrazorblade/easydblab/kits/postgres/kit.yaml
+++ b/src/main/resources/com/rustyrazorblade/easydblab/kits/postgres/kit.yaml
@@ -1,0 +1,101 @@
+name: postgres
+type: db
+description: Deploy PostgreSQL via the CloudNativePG operator
+version: "1.0.0"
+collision-check: true
+metrics:
+  - type: scrape
+    port: 30987
+    path: /metrics
+    job: postgres
+runtime:
+  type: pods
+  selector: "cnpg.io/podRole=instance"
+  namespace: default
+endpoints:
+  - name: "PostgreSQL"
+    node-type: db
+    port: 30432
+    type: postgresql
+    database: postgres
+  - name: "JDBC"
+    node-type: db
+    port: 30432
+    type: jdbc
+    scheme: postgresql
+    path: /postgres
+args:
+  - flag: --version
+    variable: POSTGRES_VERSION
+    description: "PostgreSQL major version (e.g. 17, 16)"
+    type: string
+    default: "17"
+  - flag: --instances
+    variable: INSTANCES
+    description: "Number of PostgreSQL instances (1 = single node, >1 enables replication)"
+    type: int
+    default: "1"
+  - flag: --size
+    variable: STORAGE_SIZE
+    description: Storage size per node (e.g. 100Gi)
+    type: string
+    default: "10Ti"
+  - flag: --extension
+    variable: EXTENSION
+    description: "Extension alias to activate (e.g. duckdb, postgis, timescaledb). Run 'postgres extensions' to list available aliases."
+    type: extension
+    default: ""
+
+install:
+  - type: helm-repo
+    name: cnpg
+    url: https://cloudnative-pg.github.io/charts
+  - type: helm
+    chart: cnpg/cloudnative-pg
+    release: cnpg-operator
+    namespace: cnpg-system
+
+start:
+  - type: platform-pvs
+    node-type: db
+  - type: manifest
+    template: postgres-cluster.yaml
+  - type: shell
+    script: |
+      echo "Waiting for PostgreSQL instance pods to be created..."
+      until kubectl get pods -l cnpg.io/podRole=instance -n default --no-headers 2>/dev/null | grep -q .; do sleep 5; done
+      echo "Pods found, waiting for Ready..."
+      kubectl wait --for=condition=Ready pods \
+        -l cnpg.io/podRole=instance \
+        --namespace default \
+        --timeout=300s
+  - type: manifest
+    template: nodeport-service.yaml
+
+stop:
+  - type: delete
+    kind: Cluster
+    name: ${KIT_NAME}
+    namespace: default
+  - type: delete
+    kind: Service
+    name: ${KIT_NAME}-nodeport
+    namespace: default
+  - type: delete
+    kind: Secret
+    name: ${KIT_NAME}-credentials
+    namespace: default
+  - type: delete
+    kind: ImageCatalog
+    name: ${KIT_NAME}-catalog
+    namespace: default
+
+uninstall:
+  - type: platform-pvs-delete
+  - type: helm-uninstall
+    release: cnpg-operator
+    namespace: cnpg-system
+
+capabilities:
+  - type: sql
+    user: postgres

--- a/src/main/resources/com/rustyrazorblade/easydblab/kits/postgres/metrics-catalog.json
+++ b/src/main/resources/com/rustyrazorblade/easydblab/kits/postgres/metrics-catalog.json
@@ -1,0 +1,15856 @@
+{
+  "workload": "postgres",
+  "exported_at": "2026-06-09T23:40:48Z",
+  "series": [
+    {
+      "name": "cnpg_backends_max_tx_duration_seconds",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "application_name": "cnpg_metrics_exporter",
+        "datname": "postgres",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "state": "active",
+        "url_scheme": "http",
+        "usename": "cnpg_metrics_exporter"
+      }
+    },
+    {
+      "name": "cnpg_backends_max_tx_duration_seconds",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "application_name": "cnpg_metrics_exporter",
+        "datname": "postgres",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "state": "active",
+        "url_scheme": "http",
+        "usename": "cnpg_metrics_exporter"
+      }
+    },
+    {
+      "name": "cnpg_backends_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "application_name": "cnpg_metrics_exporter",
+        "datname": "postgres",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "state": "active",
+        "url_scheme": "http",
+        "usename": "cnpg_metrics_exporter"
+      }
+    },
+    {
+      "name": "cnpg_backends_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "application_name": "cnpg_metrics_exporter",
+        "datname": "postgres",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "state": "active",
+        "url_scheme": "http",
+        "usename": "cnpg_metrics_exporter"
+      }
+    },
+    {
+      "name": "cnpg_backends_waiting_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_backends_waiting_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_cache_hits",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_cache_hits",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_cache_miss",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_cache_miss",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_collector_collection_duration_seconds",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "collector": "Collect.cnpg",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_collector_collection_duration_seconds",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "collector": "Collect.up",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_collector_collection_duration_seconds",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "collector": "Collect.cnpg",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_collector_collection_duration_seconds",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "collector": "Collect.up",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_collector_collections_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_collector_collections_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_collector_fencing_on",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_collector_fencing_on",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_collector_first_recoverability_point",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_collector_first_recoverability_point",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_collector_last_available_backup_timestamp",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_collector_last_available_backup_timestamp",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_collector_last_collection_error",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_collector_last_collection_error",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_collector_last_failed_backup_timestamp",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_collector_last_failed_backup_timestamp",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_collector_lo_pages",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "datname": "postgres",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_collector_lo_pages",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "datname": "postgres",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_collector_manual_switchover_required",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_collector_manual_switchover_required",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_collector_nodes_used",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_collector_nodes_used",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_collector_pg_wal",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http",
+        "value": "count"
+      }
+    },
+    {
+      "name": "cnpg_collector_pg_wal",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http",
+        "value": "keep"
+      }
+    },
+    {
+      "name": "cnpg_collector_pg_wal",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http",
+        "value": "max"
+      }
+    },
+    {
+      "name": "cnpg_collector_pg_wal",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http",
+        "value": "min"
+      }
+    },
+    {
+      "name": "cnpg_collector_pg_wal",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http",
+        "value": "size"
+      }
+    },
+    {
+      "name": "cnpg_collector_pg_wal",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http",
+        "value": "count"
+      }
+    },
+    {
+      "name": "cnpg_collector_pg_wal",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http",
+        "value": "keep"
+      }
+    },
+    {
+      "name": "cnpg_collector_pg_wal",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http",
+        "value": "max"
+      }
+    },
+    {
+      "name": "cnpg_collector_pg_wal",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http",
+        "value": "min"
+      }
+    },
+    {
+      "name": "cnpg_collector_pg_wal",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http",
+        "value": "size"
+      }
+    },
+    {
+      "name": "cnpg_collector_pg_wal_archive_status",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http",
+        "value": "done"
+      }
+    },
+    {
+      "name": "cnpg_collector_pg_wal_archive_status",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http",
+        "value": "ready"
+      }
+    },
+    {
+      "name": "cnpg_collector_pg_wal_archive_status",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http",
+        "value": "done"
+      }
+    },
+    {
+      "name": "cnpg_collector_pg_wal_archive_status",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http",
+        "value": "ready"
+      }
+    },
+    {
+      "name": "cnpg_collector_postgres_version",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "exported_cluster": "postgres",
+        "full": "17.10",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_collector_postgres_version",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "exported_cluster": "postgres",
+        "full": "17.10",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_collector_replica_mode",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_collector_replica_mode",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_collector_sync_replicas",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http",
+        "value": "expected"
+      }
+    },
+    {
+      "name": "cnpg_collector_sync_replicas",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http",
+        "value": "max"
+      }
+    },
+    {
+      "name": "cnpg_collector_sync_replicas",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http",
+        "value": "min"
+      }
+    },
+    {
+      "name": "cnpg_collector_sync_replicas",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http",
+        "value": "observed"
+      }
+    },
+    {
+      "name": "cnpg_collector_sync_replicas",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http",
+        "value": "expected"
+      }
+    },
+    {
+      "name": "cnpg_collector_sync_replicas",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http",
+        "value": "max"
+      }
+    },
+    {
+      "name": "cnpg_collector_sync_replicas",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http",
+        "value": "min"
+      }
+    },
+    {
+      "name": "cnpg_collector_sync_replicas",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http",
+        "value": "observed"
+      }
+    },
+    {
+      "name": "cnpg_collector_up",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "exported_cluster": "postgres",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_collector_up",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "exported_cluster": "postgres",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_collector_wal_buffers_full",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "stats_reset": "2026-06-09T23:39:46.444152Z",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_collector_wal_buffers_full",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "stats_reset": "2026-06-09T23:39:46.444152Z",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_collector_wal_bytes",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "stats_reset": "2026-06-09T23:39:46.444152Z",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_collector_wal_bytes",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "stats_reset": "2026-06-09T23:39:46.444152Z",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_collector_wal_fpi",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "stats_reset": "2026-06-09T23:39:46.444152Z",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_collector_wal_fpi",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "stats_reset": "2026-06-09T23:39:46.444152Z",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_collector_wal_records",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "stats_reset": "2026-06-09T23:39:46.444152Z",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_collector_wal_records",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "stats_reset": "2026-06-09T23:39:46.444152Z",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_collector_wal_sync",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "stats_reset": "2026-06-09T23:39:46.444152Z",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_collector_wal_sync",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "stats_reset": "2026-06-09T23:39:46.444152Z",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_collector_wal_sync_time",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "stats_reset": "2026-06-09T23:39:46.444152Z",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_collector_wal_sync_time",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "stats_reset": "2026-06-09T23:39:46.444152Z",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_collector_wal_write",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "stats_reset": "2026-06-09T23:39:46.444152Z",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_collector_wal_write",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "stats_reset": "2026-06-09T23:39:46.444152Z",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_collector_wal_write_time",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "stats_reset": "2026-06-09T23:39:46.444152Z",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_collector_wal_write_time",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "stats_reset": "2026-06-09T23:39:46.444152Z",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_last_error",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_last_error",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_last_update_timestamp",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_last_update_timestamp",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_database_mxid_age",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "datname": "postgres",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_database_mxid_age",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "datname": "template1",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_database_mxid_age",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "datname": "postgres",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_database_mxid_age",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "datname": "template1",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_database_size_bytes",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "datname": "postgres",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_database_size_bytes",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "datname": "template1",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_database_size_bytes",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "datname": "postgres",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_database_size_bytes",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "datname": "template1",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_database_xid_age",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "datname": "postgres",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_database_xid_age",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "datname": "template1",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_database_xid_age",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "datname": "postgres",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_database_xid_age",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "datname": "template1",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_extensions_update_available",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "datname": "postgres",
+        "default_version": "1.0",
+        "extname": "plpgsql",
+        "host_name": "control0",
+        "installed_version": "1.0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_extensions_update_available",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "datname": "postgres",
+        "default_version": "1.0",
+        "extname": "plpgsql",
+        "host_name": "db0",
+        "installed_version": "1.0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_postmaster_start_time",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_postmaster_start_time",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_replication_in_recovery",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_replication_in_recovery",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_replication_is_wal_receiver_up",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_replication_is_wal_receiver_up",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_replication_lag",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_replication_lag",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_replication_streaming_replicas",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_replication_streaming_replicas",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "allow_alter_system",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "allow_in_place_tablespaces",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "allow_system_table_mods",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "archive_timeout",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "array_nulls",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "authentication_timeout",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "autovacuum",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "autovacuum_analyze_scale_factor",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "autovacuum_analyze_threshold",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "autovacuum_freeze_max_age",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "autovacuum_max_workers",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "autovacuum_multixact_freeze_max_age",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "autovacuum_naptime",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "autovacuum_vacuum_cost_delay",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "autovacuum_vacuum_cost_limit",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "autovacuum_vacuum_insert_scale_factor",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "autovacuum_vacuum_insert_threshold",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "autovacuum_vacuum_scale_factor",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "autovacuum_vacuum_threshold",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "autovacuum_work_mem",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "backend_flush_after",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "bgwriter_delay",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "bgwriter_flush_after",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "bgwriter_lru_maxpages",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "bgwriter_lru_multiplier",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "block_size",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "bonjour",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "check_function_bodies",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "checkpoint_completion_target",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "checkpoint_flush_after",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "checkpoint_timeout",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "checkpoint_warning",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "client_connection_check_interval",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "commit_delay",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "commit_siblings",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "commit_timestamp_buffers",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "cpu_index_tuple_cost",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "cpu_operator_cost",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "cpu_tuple_cost",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "cursor_tuple_fraction",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "data_checksums",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "data_directory_mode",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "data_sync_retry",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "deadlock_timeout",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "debug_assertions",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "debug_discard_caches",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "debug_pretty_print",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "debug_print_parse",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "debug_print_plan",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "debug_print_rewritten",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "default_statistics_target",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "default_transaction_deferrable",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "default_transaction_read_only",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "effective_cache_size",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "effective_io_concurrency",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "enable_async_append",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "enable_bitmapscan",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "enable_gathermerge",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "enable_group_by_reordering",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "enable_hashagg",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "enable_hashjoin",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "enable_incremental_sort",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "enable_indexonlyscan",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "enable_indexscan",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "enable_material",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "enable_memoize",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "enable_mergejoin",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "enable_nestloop",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "enable_parallel_append",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "enable_parallel_hash",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "enable_partition_pruning",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "enable_partitionwise_aggregate",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "enable_partitionwise_join",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "enable_presorted_aggregate",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "enable_seqscan",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "enable_sort",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "enable_tidscan",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "escape_string_warning",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "event_triggers",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "exit_on_error",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "extra_float_digits",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "from_collapse_limit",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "fsync",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "full_page_writes",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "geqo",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "geqo_effort",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "geqo_generations",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "geqo_pool_size",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "geqo_seed",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "geqo_selection_bias",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "geqo_threshold",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "gin_fuzzy_search_limit",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "gin_pending_list_limit",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "gss_accept_delegation",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "hash_mem_multiplier",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "hot_standby",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "hot_standby_feedback",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "huge_page_size",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "idle_in_transaction_session_timeout",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "idle_session_timeout",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "ignore_checksum_failure",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "ignore_invalid_pages",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "ignore_system_indexes",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "in_hot_standby",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "integer_datetimes",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "io_combine_limit",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "jit",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "jit_above_cost",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "jit_debugging_support",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "jit_dump_bitcode",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "jit_expressions",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "jit_inline_above_cost",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "jit_optimize_above_cost",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "jit_profiling_support",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "jit_tuple_deforming",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "join_collapse_limit",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "krb_caseins_users",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "lo_compat_privileges",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "lock_timeout",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "log_autovacuum_min_duration",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "log_checkpoints",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "log_connections",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "log_disconnections",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "log_duration",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "log_executor_stats",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "log_file_mode",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "log_hostname",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "log_lock_waits",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "log_min_duration_sample",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "log_min_duration_statement",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "log_parameter_max_length",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "log_parameter_max_length_on_error",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "log_parser_stats",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "log_planner_stats",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "log_recovery_conflict_waits",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "log_replication_commands",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "log_rotation_age",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "log_rotation_size",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "log_startup_progress_interval",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "log_statement_sample_rate",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "log_statement_stats",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "log_temp_files",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "log_transaction_sample_rate",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "log_truncate_on_rotation",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "logging_collector",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "logical_decoding_work_mem",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "maintenance_io_concurrency",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "maintenance_work_mem",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "max_connections",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "max_files_per_process",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "max_function_args",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "max_identifier_length",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "max_index_keys",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "max_locks_per_transaction",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "max_logical_replication_workers",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "max_notify_queue_pages",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "max_parallel_apply_workers_per_subscription",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "max_parallel_maintenance_workers",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "max_parallel_workers",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "max_parallel_workers_per_gather",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "max_pred_locks_per_page",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "max_pred_locks_per_relation",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "max_pred_locks_per_transaction",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "max_prepared_transactions",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "max_replication_slots",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "max_slot_wal_keep_size",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "max_stack_depth",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "max_standby_archive_delay",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "max_standby_streaming_delay",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "max_sync_workers_per_subscription",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "max_wal_senders",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "max_wal_size",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "max_worker_processes",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "min_dynamic_shared_memory",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "min_parallel_index_scan_size",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "min_parallel_table_scan_size",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "min_wal_size",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "multixact_member_buffers",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "multixact_offset_buffers",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "notify_buffers",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "parallel_leader_participation",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "parallel_setup_cost",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "parallel_tuple_cost",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "port",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "post_auth_delay",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "pre_auth_delay",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "quote_all_identifiers",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "random_page_cost",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "recovery_min_apply_delay",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "recovery_target_inclusive",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "recursive_worktable_factor",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "remove_temp_files_after_crash",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "reserved_connections",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "restart_after_crash",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "row_security",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "scram_iterations",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "segment_size",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "send_abort_for_crash",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "send_abort_for_kill",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "seq_page_cost",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "serializable_buffers",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "server_version_num",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "shared_buffers",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "shared_memory_size",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "shared_memory_size_in_huge_pages",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "ssl",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "ssl_passphrase_command_supports_reload",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "ssl_prefer_server_ciphers",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "standard_conforming_strings",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "statement_timeout",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "subtransaction_buffers",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "summarize_wal",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "superuser_reserved_connections",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "sync_replication_slots",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "synchronize_seqscans",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "syslog_sequence_numbers",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "syslog_split_messages",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "tcp_keepalives_count",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "tcp_keepalives_idle",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "tcp_keepalives_interval",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "tcp_user_timeout",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "temp_buffers",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "temp_file_limit",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "trace_connection_negotiation",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "trace_notify",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "trace_sort",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "track_activities",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "track_activity_query_size",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "track_commit_timestamp",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "track_counts",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "track_io_timing",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "track_wal_io_timing",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "transaction_buffers",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "transaction_deferrable",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "transaction_read_only",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "transaction_timeout",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "transform_null_equals",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "unix_socket_permissions",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "update_process_title",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "vacuum_buffer_usage_limit",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "vacuum_cost_delay",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "vacuum_cost_limit",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "vacuum_cost_page_dirty",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "vacuum_cost_page_hit",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "vacuum_cost_page_miss",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "vacuum_failsafe_age",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "vacuum_freeze_min_age",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "vacuum_freeze_table_age",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "vacuum_multixact_failsafe_age",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "vacuum_multixact_freeze_min_age",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "vacuum_multixact_freeze_table_age",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "wal_block_size",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "wal_buffers",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "wal_decode_buffer_size",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "wal_init_zero",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "wal_keep_size",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "wal_log_hints",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "wal_receiver_create_temp_slot",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "wal_receiver_status_interval",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "wal_receiver_timeout",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "wal_recycle",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "wal_retrieve_retry_interval",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "wal_segment_size",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "wal_sender_timeout",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "wal_skip_threshold",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "wal_summary_keep_time",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "wal_writer_delay",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "wal_writer_flush_after",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "work_mem",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "name": "zero_damaged_pages",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "allow_alter_system",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "allow_in_place_tablespaces",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "allow_system_table_mods",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "archive_timeout",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "array_nulls",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "authentication_timeout",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "autovacuum",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "autovacuum_analyze_scale_factor",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "autovacuum_analyze_threshold",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "autovacuum_freeze_max_age",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "autovacuum_max_workers",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "autovacuum_multixact_freeze_max_age",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "autovacuum_naptime",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "autovacuum_vacuum_cost_delay",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "autovacuum_vacuum_cost_limit",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "autovacuum_vacuum_insert_scale_factor",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "autovacuum_vacuum_insert_threshold",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "autovacuum_vacuum_scale_factor",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "autovacuum_vacuum_threshold",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "autovacuum_work_mem",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "backend_flush_after",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "bgwriter_delay",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "bgwriter_flush_after",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "bgwriter_lru_maxpages",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "bgwriter_lru_multiplier",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "block_size",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "bonjour",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "check_function_bodies",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "checkpoint_completion_target",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "checkpoint_flush_after",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "checkpoint_timeout",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "checkpoint_warning",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "client_connection_check_interval",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "commit_delay",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "commit_siblings",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "commit_timestamp_buffers",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "cpu_index_tuple_cost",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "cpu_operator_cost",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "cpu_tuple_cost",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "cursor_tuple_fraction",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "data_checksums",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "data_directory_mode",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "data_sync_retry",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "deadlock_timeout",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "debug_assertions",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "debug_discard_caches",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "debug_pretty_print",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "debug_print_parse",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "debug_print_plan",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "debug_print_rewritten",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "default_statistics_target",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "default_transaction_deferrable",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "default_transaction_read_only",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "effective_cache_size",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "effective_io_concurrency",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "enable_async_append",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "enable_bitmapscan",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "enable_gathermerge",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "enable_group_by_reordering",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "enable_hashagg",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "enable_hashjoin",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "enable_incremental_sort",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "enable_indexonlyscan",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "enable_indexscan",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "enable_material",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "enable_memoize",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "enable_mergejoin",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "enable_nestloop",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "enable_parallel_append",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "enable_parallel_hash",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "enable_partition_pruning",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "enable_partitionwise_aggregate",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "enable_partitionwise_join",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "enable_presorted_aggregate",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "enable_seqscan",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "enable_sort",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "enable_tidscan",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "escape_string_warning",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "event_triggers",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "exit_on_error",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "extra_float_digits",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "from_collapse_limit",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "fsync",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "full_page_writes",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "geqo",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "geqo_effort",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "geqo_generations",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "geqo_pool_size",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "geqo_seed",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "geqo_selection_bias",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "geqo_threshold",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "gin_fuzzy_search_limit",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "gin_pending_list_limit",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "gss_accept_delegation",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "hash_mem_multiplier",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "hot_standby",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "hot_standby_feedback",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "huge_page_size",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "idle_in_transaction_session_timeout",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "idle_session_timeout",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "ignore_checksum_failure",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "ignore_invalid_pages",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "ignore_system_indexes",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "in_hot_standby",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "integer_datetimes",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "io_combine_limit",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "jit",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "jit_above_cost",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "jit_debugging_support",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "jit_dump_bitcode",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "jit_expressions",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "jit_inline_above_cost",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "jit_optimize_above_cost",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "jit_profiling_support",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "jit_tuple_deforming",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "join_collapse_limit",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "krb_caseins_users",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "lo_compat_privileges",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "lock_timeout",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "log_autovacuum_min_duration",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "log_checkpoints",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "log_connections",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "log_disconnections",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "log_duration",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "log_executor_stats",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "log_file_mode",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "log_hostname",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "log_lock_waits",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "log_min_duration_sample",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "log_min_duration_statement",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "log_parameter_max_length",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "log_parameter_max_length_on_error",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "log_parser_stats",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "log_planner_stats",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "log_recovery_conflict_waits",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "log_replication_commands",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "log_rotation_age",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "log_rotation_size",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "log_startup_progress_interval",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "log_statement_sample_rate",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "log_statement_stats",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "log_temp_files",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "log_transaction_sample_rate",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "log_truncate_on_rotation",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "logging_collector",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "logical_decoding_work_mem",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "maintenance_io_concurrency",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "maintenance_work_mem",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "max_connections",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "max_files_per_process",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "max_function_args",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "max_identifier_length",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "max_index_keys",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "max_locks_per_transaction",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "max_logical_replication_workers",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "max_notify_queue_pages",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "max_parallel_apply_workers_per_subscription",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "max_parallel_maintenance_workers",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "max_parallel_workers",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "max_parallel_workers_per_gather",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "max_pred_locks_per_page",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "max_pred_locks_per_relation",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "max_pred_locks_per_transaction",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "max_prepared_transactions",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "max_replication_slots",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "max_slot_wal_keep_size",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "max_stack_depth",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "max_standby_archive_delay",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "max_standby_streaming_delay",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "max_sync_workers_per_subscription",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "max_wal_senders",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "max_wal_size",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "max_worker_processes",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "min_dynamic_shared_memory",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "min_parallel_index_scan_size",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "min_parallel_table_scan_size",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "min_wal_size",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "multixact_member_buffers",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "multixact_offset_buffers",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "notify_buffers",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "parallel_leader_participation",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "parallel_setup_cost",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "parallel_tuple_cost",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "port",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "post_auth_delay",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "pre_auth_delay",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "quote_all_identifiers",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "random_page_cost",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "recovery_min_apply_delay",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "recovery_target_inclusive",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "recursive_worktable_factor",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "remove_temp_files_after_crash",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "reserved_connections",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "restart_after_crash",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "row_security",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "scram_iterations",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "segment_size",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "send_abort_for_crash",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "send_abort_for_kill",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "seq_page_cost",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "serializable_buffers",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "server_version_num",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "shared_buffers",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "shared_memory_size",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "shared_memory_size_in_huge_pages",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "ssl",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "ssl_passphrase_command_supports_reload",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "ssl_prefer_server_ciphers",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "standard_conforming_strings",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "statement_timeout",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "subtransaction_buffers",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "summarize_wal",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "superuser_reserved_connections",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "sync_replication_slots",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "synchronize_seqscans",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "syslog_sequence_numbers",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "syslog_split_messages",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "tcp_keepalives_count",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "tcp_keepalives_idle",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "tcp_keepalives_interval",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "tcp_user_timeout",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "temp_buffers",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "temp_file_limit",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "trace_connection_negotiation",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "trace_notify",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "trace_sort",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "track_activities",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "track_activity_query_size",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "track_commit_timestamp",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "track_counts",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "track_io_timing",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "track_wal_io_timing",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "transaction_buffers",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "transaction_deferrable",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "transaction_read_only",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "transaction_timeout",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "transform_null_equals",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "unix_socket_permissions",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "update_process_title",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "vacuum_buffer_usage_limit",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "vacuum_cost_delay",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "vacuum_cost_limit",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "vacuum_cost_page_dirty",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "vacuum_cost_page_hit",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "vacuum_cost_page_miss",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "vacuum_failsafe_age",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "vacuum_freeze_min_age",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "vacuum_freeze_table_age",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "vacuum_multixact_failsafe_age",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "vacuum_multixact_freeze_min_age",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "vacuum_multixact_freeze_table_age",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "wal_block_size",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "wal_buffers",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "wal_decode_buffer_size",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "wal_init_zero",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "wal_keep_size",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "wal_log_hints",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "wal_receiver_create_temp_slot",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "wal_receiver_status_interval",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "wal_receiver_timeout",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "wal_recycle",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "wal_retrieve_retry_interval",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "wal_segment_size",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "wal_sender_timeout",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "wal_skip_threshold",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "wal_summary_keep_time",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "wal_writer_delay",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "wal_writer_flush_after",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "work_mem",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_settings_setting",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "name": "zero_damaged_pages",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_archiver_archived_count_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_archiver_archived_count_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_archiver_failed_count_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_archiver_failed_count_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_archiver_last_archived_time",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_archiver_last_archived_time",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_archiver_last_archived_wal_start_lsn",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_archiver_last_archived_wal_start_lsn",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_archiver_last_failed_time",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_archiver_last_failed_time",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_archiver_last_failed_wal_start_lsn",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_archiver_last_failed_wal_start_lsn",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_archiver_seconds_since_last_archival",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_archiver_seconds_since_last_archival",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_archiver_seconds_since_last_failure",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_archiver_seconds_since_last_failure",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_archiver_stats_reset_time",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_archiver_stats_reset_time",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_bgwriter_buffers_alloc_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_bgwriter_buffers_alloc_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_bgwriter_buffers_clean_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_bgwriter_buffers_clean_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_bgwriter_maxwritten_clean_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_bgwriter_maxwritten_clean_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_bgwriter_stats_reset_time",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_bgwriter_stats_reset_time",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_checkpointer_buffers_written_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_checkpointer_buffers_written_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_checkpointer_checkpoints_req_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_checkpointer_checkpoints_req_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_checkpointer_checkpoints_timed_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_checkpointer_checkpoints_timed_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_checkpointer_restartpoints_done_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_checkpointer_restartpoints_done_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_checkpointer_restartpoints_req_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_checkpointer_restartpoints_req_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_checkpointer_restartpoints_timed_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_checkpointer_restartpoints_timed_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_checkpointer_stats_reset_time",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_checkpointer_stats_reset_time",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_checkpointer_sync_time_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_checkpointer_sync_time_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_checkpointer_write_time_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_checkpointer_write_time_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_blk_read_time_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "datname": "postgres",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_blk_read_time_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "datname": "template0",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_blk_read_time_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "datname": "template1",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_blk_read_time_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_blk_read_time_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "datname": "postgres",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_blk_read_time_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "datname": "template0",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_blk_read_time_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "datname": "template1",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_blk_read_time_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_blk_write_time_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "datname": "postgres",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_blk_write_time_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "datname": "template0",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_blk_write_time_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "datname": "template1",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_blk_write_time_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_blk_write_time_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "datname": "postgres",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_blk_write_time_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "datname": "template0",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_blk_write_time_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "datname": "template1",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_blk_write_time_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_blks_hit_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "datname": "postgres",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_blks_hit_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "datname": "template0",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_blks_hit_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "datname": "template1",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_blks_hit_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_blks_hit_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "datname": "postgres",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_blks_hit_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "datname": "template0",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_blks_hit_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "datname": "template1",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_blks_hit_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_blks_read_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "datname": "postgres",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_blks_read_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "datname": "template0",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_blks_read_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "datname": "template1",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_blks_read_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_blks_read_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "datname": "postgres",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_blks_read_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "datname": "template0",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_blks_read_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "datname": "template1",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_blks_read_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_conflicts_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "datname": "postgres",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_conflicts_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "datname": "template0",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_conflicts_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "datname": "template1",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_conflicts_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_conflicts_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "datname": "postgres",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_conflicts_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "datname": "template0",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_conflicts_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "datname": "template1",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_conflicts_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_deadlocks_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "datname": "postgres",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_deadlocks_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "datname": "template0",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_deadlocks_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "datname": "template1",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_deadlocks_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_deadlocks_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "datname": "postgres",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_deadlocks_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "datname": "template0",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_deadlocks_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "datname": "template1",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_deadlocks_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_temp_bytes_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "datname": "postgres",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_temp_bytes_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "datname": "template0",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_temp_bytes_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "datname": "template1",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_temp_bytes_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_temp_bytes_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "datname": "postgres",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_temp_bytes_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "datname": "template0",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_temp_bytes_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "datname": "template1",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_temp_bytes_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_temp_files_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "datname": "postgres",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_temp_files_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "datname": "template0",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_temp_files_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "datname": "template1",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_temp_files_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_temp_files_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "datname": "postgres",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_temp_files_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "datname": "template0",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_temp_files_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "datname": "template1",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_temp_files_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_tup_deleted_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "datname": "postgres",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_tup_deleted_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "datname": "template0",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_tup_deleted_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "datname": "template1",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_tup_deleted_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_tup_deleted_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "datname": "postgres",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_tup_deleted_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "datname": "template0",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_tup_deleted_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "datname": "template1",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_tup_deleted_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_tup_fetched_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "datname": "postgres",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_tup_fetched_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "datname": "template0",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_tup_fetched_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "datname": "template1",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_tup_fetched_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_tup_fetched_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "datname": "postgres",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_tup_fetched_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "datname": "template0",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_tup_fetched_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "datname": "template1",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_tup_fetched_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_tup_inserted_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "datname": "postgres",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_tup_inserted_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "datname": "template0",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_tup_inserted_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "datname": "template1",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_tup_inserted_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_tup_inserted_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "datname": "postgres",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_tup_inserted_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "datname": "template0",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_tup_inserted_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "datname": "template1",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_tup_inserted_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_tup_returned_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "datname": "postgres",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_tup_returned_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "datname": "template0",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_tup_returned_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "datname": "template1",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_tup_returned_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_tup_returned_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "datname": "postgres",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_tup_returned_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "datname": "template0",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_tup_returned_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "datname": "template1",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_tup_returned_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_tup_updated_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "datname": "postgres",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_tup_updated_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "datname": "template0",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_tup_updated_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "datname": "template1",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_tup_updated_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_tup_updated_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "datname": "postgres",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_tup_updated_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "datname": "template0",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_tup_updated_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "datname": "template1",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_tup_updated_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_xact_commit_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "datname": "postgres",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_xact_commit_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "datname": "template0",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_xact_commit_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "datname": "template1",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_xact_commit_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_xact_commit_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "datname": "postgres",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_xact_commit_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "datname": "template0",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_xact_commit_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "datname": "template1",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_xact_commit_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_xact_rollback_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "datname": "postgres",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_xact_rollback_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "datname": "template0",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_xact_rollback_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "datname": "template1",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_xact_rollback_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_xact_rollback_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "datname": "postgres",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_xact_rollback_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "datname": "template0",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_xact_rollback_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "datname": "template1",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "cnpg_pg_stat_database_xact_rollback_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "go_gc_duration_seconds",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "quantile": "0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "go_gc_duration_seconds",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "quantile": "0.25",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "go_gc_duration_seconds",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "quantile": "0.5",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "go_gc_duration_seconds",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "quantile": "0.75",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "go_gc_duration_seconds",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "quantile": "1",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "go_gc_duration_seconds",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "quantile": "0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "go_gc_duration_seconds",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "quantile": "0.25",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "go_gc_duration_seconds",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "quantile": "0.5",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "go_gc_duration_seconds",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "quantile": "0.75",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "go_gc_duration_seconds",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "quantile": "1",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "go_gc_duration_seconds_count",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "go_gc_duration_seconds_count",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "go_gc_duration_seconds_sum",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "go_gc_duration_seconds_sum",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "go_gc_gogc_percent",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "go_gc_gogc_percent",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "go_gc_gomemlimit_bytes",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "go_gc_gomemlimit_bytes",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "go_goroutines",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "go_goroutines",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "go_info",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http",
+        "version": "go1.26.3"
+      }
+    },
+    {
+      "name": "go_info",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http",
+        "version": "go1.26.3"
+      }
+    },
+    {
+      "name": "go_memstats_alloc_bytes",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "go_memstats_alloc_bytes",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "go_memstats_alloc_bytes_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "go_memstats_alloc_bytes_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "go_memstats_buck_hash_sys_bytes",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "go_memstats_buck_hash_sys_bytes",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "go_memstats_frees_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "go_memstats_frees_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "go_memstats_gc_sys_bytes",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "go_memstats_gc_sys_bytes",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "go_memstats_heap_alloc_bytes",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "go_memstats_heap_alloc_bytes",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "go_memstats_heap_idle_bytes",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "go_memstats_heap_idle_bytes",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "go_memstats_heap_inuse_bytes",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "go_memstats_heap_inuse_bytes",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "go_memstats_heap_objects",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "go_memstats_heap_objects",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "go_memstats_heap_released_bytes",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "go_memstats_heap_released_bytes",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "go_memstats_heap_sys_bytes",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "go_memstats_heap_sys_bytes",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "go_memstats_last_gc_time_seconds",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "go_memstats_last_gc_time_seconds",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "go_memstats_mallocs_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "go_memstats_mallocs_total",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "go_memstats_mcache_inuse_bytes",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "go_memstats_mcache_inuse_bytes",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "go_memstats_mcache_sys_bytes",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "go_memstats_mcache_sys_bytes",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "go_memstats_mspan_inuse_bytes",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "go_memstats_mspan_inuse_bytes",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "go_memstats_mspan_sys_bytes",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "go_memstats_mspan_sys_bytes",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "go_memstats_next_gc_bytes",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "go_memstats_next_gc_bytes",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "go_memstats_other_sys_bytes",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "go_memstats_other_sys_bytes",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "go_memstats_stack_inuse_bytes",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "go_memstats_stack_inuse_bytes",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "go_memstats_stack_sys_bytes",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "go_memstats_stack_sys_bytes",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "go_memstats_sys_bytes",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "go_memstats_sys_bytes",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "go_sched_gomaxprocs_threads",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "go_sched_gomaxprocs_threads",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "go_threads",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "go_threads",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "scrape_duration_seconds",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "scrape_duration_seconds",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "scrape_samples_post_metric_relabeling",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "scrape_samples_post_metric_relabeling",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "scrape_samples_scraped",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "scrape_samples_scraped",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "scrape_series_added",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "scrape_series_added",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "target_info",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "server_address": "control0",
+        "server_port": "30987",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "target_info",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "server_address": "db0",
+        "server_port": "30987",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "up",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "control0:30987",
+        "host_name": "control0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "control0",
+        "server_port": "30987",
+        "service_instance_id": "control0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "up",
+      "labels": {
+        "cluster": "test-98ff79e3-9be5-4d8a-9ce1-8aa3d949f869",
+        "job": "postgres",
+        "instance": "db0:30987",
+        "host_name": "db0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "db0",
+        "server_port": "30987",
+        "service_instance_id": "db0:30987",
+        "service_name": "postgres",
+        "url_scheme": "http"
+      }
+    }
+  ]
+}

--- a/src/main/resources/com/rustyrazorblade/easydblab/kits/postgres/nodeport-service.yaml.template
+++ b/src/main/resources/com/rustyrazorblade/easydblab/kits/postgres/nodeport-service.yaml.template
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: __KIT_NAME__-nodeport
+  namespace: default
+spec:
+  type: NodePort
+  selector:
+    cnpg.io/cluster: __KIT_NAME__
+    cnpg.io/instanceRole: primary
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: 5432
+      nodePort: __POSTGRES_PORT__
+    - name: metrics
+      port: 9187
+      targetPort: 9187
+      nodePort: __METRICS_PORT__

--- a/src/main/resources/com/rustyrazorblade/easydblab/kits/postgres/postgres-cluster.yaml.template
+++ b/src/main/resources/com/rustyrazorblade/easydblab/kits/postgres/postgres-cluster.yaml.template
@@ -1,0 +1,63 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: __KIT_NAME__-credentials
+  namespace: default
+type: kubernetes.io/basic-auth
+stringData:
+  username: postgres
+  password: postgres
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: ImageCatalog
+metadata:
+  name: __KIT_NAME__-catalog
+  namespace: default
+spec:
+  images:
+    - major: __PG_MAJOR_VERSION__
+      image: __IMAGE__
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: __KIT_NAME__
+  namespace: default
+spec:
+  instances: __INSTANCES__
+  postgresUID: __POSTGRES_UID__
+  postgresGID: __POSTGRES_GID__
+  imageCatalogRef:
+    apiGroup: postgresql.cnpg.io
+    kind: ImageCatalog
+    name: __KIT_NAME__-catalog
+    major: __PG_MAJOR_VERSION__
+  primaryUpdateStrategy: unsupervised
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: type
+                operator: In
+                values:
+                  - db
+  storage:
+    storageClass: __STORAGE_CLASS_WFC__
+    size: __STORAGE_SIZE__
+  postgresql:
+    shared_preload_libraries: __SHARED_PRELOAD_LIBRARIES__
+    pg_hba:
+      - host all all 10.0.0.0/8 trust
+  bootstrap:
+    initdb:
+      database: postgres
+      owner: postgres
+      secret:
+        name: __KIT_NAME__-credentials
+      postInitSQL: __POST_INIT_SQL__
+  superuserSecret:
+    name: __KIT_NAME__-credentials
+  monitoring:
+    # OTel collector scrapes metrics via NodePort — PodMonitor is not needed
+    enablePodMonitor: false

--- a/src/main/resources/com/rustyrazorblade/easydblab/kits/presto/catalogs/postgres.properties.template
+++ b/src/main/resources/com/rustyrazorblade/easydblab/kits/presto/catalogs/postgres.properties.template
@@ -1,0 +1,4 @@
+connector.name=postgresql
+connection-url=jdbc:postgresql://postgres-rw.default.svc.cluster.local:5432/postgres
+connection-user=postgres
+connection-password=postgres

--- a/src/main/resources/com/rustyrazorblade/easydblab/kits/sysbench/bin/prepare.sh.template
+++ b/src/main/resources/com/rustyrazorblade/easydblab/kits/sysbench/bin/prepare.sh.template
@@ -2,7 +2,8 @@
 set -euo pipefail
 
 SYSBENCH_IMAGE="docker.io/severalnines/sysbench"
-POD_NAME="sysbench-prepare-${KIT_NAME}"
+POD_NAME="sysbench-prepare-${KIT_NAME}-$(date +%s)"
+PREPARE_LABELS="easydblab/kit=${KIT_NAME},easydblab/role=sysbench-prepare"
 
 if [ -n "${TARGET_MYSQL_HOST:-}" ]; then
   DB_ARGS="--db-driver=mysql \
@@ -12,11 +13,12 @@ if [ -n "${TARGET_MYSQL_HOST:-}" ]; then
     --mysql-db=${TARGET_MYSQL_DATABASE}"
 
   # TiDB and MySQL do not ship with the sbtest database — create it before sysbench prepare.
-  CREATE_POD="sysbench-createdb-${KIT_NAME}"
+  CREATE_POD="sysbench-createdb-${KIT_NAME}-$(date +%s)"
   echo "Creating database ${TARGET_MYSQL_DATABASE} on ${TARGET_MYSQL_HOST}:${TARGET_MYSQL_PORT}..."
   kubectl --kubeconfig="${KUBECONFIG}" run "${CREATE_POD}" \
     --image="mysql:8.0" \
     --restart=Never \
+    --labels="easydblab/kit=${KIT_NAME},easydblab/role=sysbench-createdb" \
     --command -- mysql \
       -h "${TARGET_MYSQL_HOST}" \
       -P "${TARGET_MYSQL_PORT}" \
@@ -44,6 +46,7 @@ echo "Preparing sysbench data: ${TABLES} tables, ${SCALE}000 rows each..."
 kubectl --kubeconfig="${KUBECONFIG}" run "${POD_NAME}" \
   --image="${SYSBENCH_IMAGE}" \
   --restart=Never \
+  --labels="${PREPARE_LABELS}" \
   --command -- sysbench \
     ${DB_ARGS} \
     --tables="${TABLES}" \

--- a/src/main/resources/com/rustyrazorblade/easydblab/kits/sysbench/bin/start.sh.template
+++ b/src/main/resources/com/rustyrazorblade/easydblab/kits/sysbench/bin/start.sh.template
@@ -2,7 +2,8 @@
 set -euo pipefail
 
 SYSBENCH_IMAGE="docker.io/severalnines/sysbench"
-POD_NAME="sysbench-${KIT_NAME}"
+POD_NAME="sysbench-${KIT_NAME}-$(date +%s)"
+LABELS="easydblab/kit=${KIT_NAME},easydblab/role=sysbench-run"
 VICTORIA_URL="http://${CONTROL_HOST_PRIVATE}:8428/api/v1/import/prometheus"
 
 if [ -n "${TARGET_MYSQL_HOST:-}" ]; then
@@ -27,6 +28,7 @@ echo "Starting sysbench: workload=${WORKLOAD}, threads=${THREADS}, duration=${DU
 kubectl --kubeconfig="${KUBECONFIG}" run "${POD_NAME}" \
   --image="${SYSBENCH_IMAGE}" \
   --restart=Never \
+  --labels="${LABELS}" \
   --command -- sysbench \
     ${DB_ARGS} \
     --threads="${THREADS}" \

--- a/src/main/resources/com/rustyrazorblade/easydblab/kits/sysbench/bin/stop.sh.template
+++ b/src/main/resources/com/rustyrazorblade/easydblab/kits/sysbench/bin/stop.sh.template
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-POD_NAME="sysbench-${KIT_NAME}"
+LABELS="easydblab/kit=${KIT_NAME},easydblab/role=sysbench-run"
 
 echo "Stopping sysbench run pod..."
-kubectl --kubeconfig="${KUBECONFIG}" delete pod "${POD_NAME}" --ignore-not-found
+kubectl --kubeconfig="${KUBECONFIG}" delete pods -l "${LABELS}" --ignore-not-found
 
 if [ -n "${TARGET_MYSQL_HOST:-}" ]; then
   DB_ARGS="--db-driver=mysql \
@@ -24,10 +24,12 @@ else
 fi
 
 echo "Running sysbench cleanup..."
-CLEANUP_POD="sysbench-cleanup-${KIT_NAME}"
+CLEANUP_POD="sysbench-cleanup-${KIT_NAME}-$(date +%s)"
+CLEANUP_LABELS="easydblab/kit=${KIT_NAME},easydblab/role=sysbench-cleanup"
 kubectl --kubeconfig="${KUBECONFIG}" run "${CLEANUP_POD}" \
   --image="docker.io/severalnines/sysbench" \
   --restart=Never \
+  --labels="${CLEANUP_LABELS}" \
   --command -- sysbench \
     ${DB_ARGS} \
     --tables="${TABLES}" \

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/commands/install/KitExtensionsCommandTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/commands/install/KitExtensionsCommandTest.kt
@@ -1,0 +1,62 @@
+package com.rustyrazorblade.easydblab.commands.install
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.PrintStream
+
+class KitExtensionsCommandTest {
+    @TempDir
+    lateinit var tempDir: File
+
+    private fun captureOutput(block: () -> Unit): String {
+        val baos = ByteArrayOutputStream()
+        val original = System.out
+        System.setOut(PrintStream(baos))
+        try {
+            block()
+        } finally {
+            System.setOut(original)
+        }
+        return baos.toString()
+    }
+
+    @Test
+    fun `output contains all three built-in alias names`() {
+        val extensionsFile = File(tempDir, "extensions.yaml")
+        extensionsFile.writeText(
+            """
+            extensions:
+              duckdb:
+                description: "DuckDB"
+                image: "ghcr.io/duckdb/pg_duckdb:pg__PG_MAJOR__"
+                create_extensions:
+                  - pg_duckdb
+              postgis:
+                description: "PostGIS"
+                image: "ghcr.io/cloudnative-pg/postgis:__PG_MAJOR__"
+                create_extensions:
+                  - postgis
+              timescaledb:
+                description: "TimescaleDB"
+                image: "timescale/timescaledb-ha:pg__PG_MAJOR__-latest"
+                create_extensions:
+                  - timescaledb
+            """.trimIndent(),
+        )
+        val command = KitExtensionsCommand(tempDir)
+        val output = captureOutput { command.call() }
+        assertThat(output).contains("duckdb")
+        assertThat(output).contains("postgis")
+        assertThat(output).contains("timescaledb")
+    }
+
+    @Test
+    fun `output shows no aliases message when extensions yaml missing`() {
+        val command = KitExtensionsCommand(tempDir)
+        val output = captureOutput { command.call() }
+        assertThat(output).contains("No extension aliases found")
+    }
+}

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/commands/install/KitInstallCommandTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/commands/install/KitInstallCommandTest.kt
@@ -1,6 +1,7 @@
 package com.rustyrazorblade.easydblab.commands.install
 
 import com.rustyrazorblade.easydblab.BaseKoinTest
+import com.rustyrazorblade.easydblab.Constants
 import com.rustyrazorblade.easydblab.Context
 import com.rustyrazorblade.easydblab.configuration.ClusterHost
 import com.rustyrazorblade.easydblab.configuration.ClusterState
@@ -162,6 +163,66 @@ class KitInstallCommandTest : BaseKoinTest() {
             .isInstanceOf(IllegalStateException::class.java)
             .hasMessageContaining("sql")
             .hasMessageContaining("presto")
+    }
+
+    private val extensionsYaml =
+        """
+        extensions:
+          duckdb:
+            description: "DuckDB"
+            image: "ghcr.io/duckdb/pg_duckdb:pg__PG_MAJOR__"
+            shared_preload_libraries:
+              - pg_duckdb
+            create_extensions:
+              - pg_duckdb
+        """.trimIndent()
+
+    private val postgresConfig =
+        KitConfig(
+            name = "postgres",
+            type = null,
+            args =
+                listOf(
+                    KitArgSpec(flag = "--version", variable = "POSTGRES_VERSION", type = KitArgSpec.ArgType.STRING, default = "17"),
+                    KitArgSpec(flag = "--extension", variable = "EXTENSION", type = KitArgSpec.ArgType.EXTENSION, default = ""),
+                ),
+        )
+
+    @Test
+    fun `extension arg creates directory named kit-extension`() {
+        File(templateDir, "extensions.yaml").writeText(extensionsYaml)
+        buildAndRun(postgresConfig, mapOf("POSTGRES_VERSION" to "17", "EXTENSION" to "duckdb"))
+        assertThat(File(workingDir, "postgres-duckdb")).isDirectory()
+        assertThat(File(workingDir, "postgres")).doesNotExist()
+    }
+
+    @Test
+    fun `no extension arg creates directory named after kit`() {
+        File(templateDir, "extensions.yaml").writeText(extensionsYaml)
+        buildAndRun(postgresConfig, mapOf("POSTGRES_VERSION" to "17"))
+        assertThat(File(workingDir, "postgres")).isDirectory()
+    }
+
+    @Test
+    fun `extension arg bakes IMAGE into resolved args`() {
+        File(templateDir, "extensions.yaml").writeText(extensionsYaml)
+        buildAndRun(postgresConfig, mapOf("POSTGRES_VERSION" to "17", "EXTENSION" to "duckdb"))
+        val resolvedArgs =
+            File(workingDir, "postgres-duckdb/${Constants.Kit.RESOLVED_ARGS_FILE}")
+                .readLines()
+                .associate { it.substringBefore('=') to it.substringAfter('=') }
+        assertThat(resolvedArgs["IMAGE"]).isEqualTo("ghcr.io/duckdb/pg_duckdb:pg17")
+    }
+
+    @Test
+    fun `no extension bakes default IMAGE into resolved args`() {
+        File(templateDir, "extensions.yaml").writeText(extensionsYaml)
+        buildAndRun(postgresConfig, mapOf("POSTGRES_VERSION" to "17"))
+        val resolvedArgs =
+            File(workingDir, "postgres/${Constants.Kit.RESOLVED_ARGS_FILE}")
+                .readLines()
+                .associate { it.substringBefore('=') to it.substringAfter('=') }
+        assertThat(resolvedArgs["IMAGE"]).isEqualTo("ghcr.io/cloudnative-pg/postgresql:17")
     }
 
     @Test

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/commands/install/KitRunnerCommandFactoryTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/commands/install/KitRunnerCommandFactoryTest.kt
@@ -317,6 +317,28 @@ class KitRunnerCommandFactoryTest : BaseKoinTest() {
     }
 
     @Test
+    fun `sql capability with jdbc endpoint and no driver-class registers sql subcommand`() {
+        writeKitYaml(
+            """
+            name: postgres
+            endpoints:
+              - name: "JDBC"
+                node-type: db
+                port: 30432
+                type: jdbc
+                scheme: postgresql
+                path: /postgres
+            capabilities:
+              - type: sql
+                user: postgres
+            """.trimIndent(),
+        )
+
+        val groupCl = factory.buildKitGroup("postgres", kitDir)
+        assertThat(groupCl.subcommands.keys).contains("sql")
+    }
+
+    @Test
     fun `unknown capability type is ignored and does not throw`() {
         writeKitYaml(
             """

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/configuration/ClusterStateTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/configuration/ClusterStateTest.kt
@@ -212,7 +212,7 @@ class ClusterStateTest {
 
         // Missing values should use defaults
         assertThat(config.stressInstances).isEqualTo(0)
-        assertThat(config.instanceType).isEqualTo("r3.2xlarge")
+        assertThat(config.instanceType).isEqualTo("i4i.xlarge")
         assertThat(config.controlInstances).isEqualTo(1)
         assertThat(config.controlInstanceType).isEqualTo("m5d.xlarge")
     }

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/configuration/otel/OtelManifestBuilderTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/configuration/otel/OtelManifestBuilderTest.kt
@@ -4,6 +4,7 @@ import com.rustyrazorblade.easydblab.BaseKoinTest
 import com.rustyrazorblade.easydblab.configuration.ClusterState
 import com.rustyrazorblade.easydblab.configuration.ClusterStateManager
 import com.rustyrazorblade.easydblab.services.TemplateService
+import io.fabric8.kubernetes.api.model.ConfigMap
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -15,6 +16,11 @@ import org.mockito.kotlin.whenever
 class OtelManifestBuilderTest : BaseKoinTest() {
     private lateinit var builder: OtelManifestBuilder
     private lateinit var mockClusterStateManager: ClusterStateManager
+
+    private fun yamlFrom(configMap: ConfigMap): String =
+        checkNotNull(configMap.data["otel-collector-config.yaml"]) {
+            "ConfigMap missing expected data key 'otel-collector-config.yaml'"
+        }
 
     override fun additionalTestModules(): List<Module> =
         listOf(
@@ -41,7 +47,7 @@ class OtelManifestBuilderTest : BaseKoinTest() {
     @Test
     fun `buildConfigMap with empty list contains all static scrape jobs`() {
         val configMap = builder.buildConfigMap(emptyList())
-        val yaml = configMap.data["otel-collector-config.yaml"]!!
+        val yaml = yamlFrom(configMap)
 
         assertThat(yaml).contains("job_name: 'beyla'")
         assertThat(yaml).contains("job_name: 'ebpf-exporter'")
@@ -53,7 +59,7 @@ class OtelManifestBuilderTest : BaseKoinTest() {
     @Test
     fun `buildConfigMap with empty list does not leave placeholder in output`() {
         val configMap = builder.buildConfigMap(emptyList())
-        val yaml = configMap.data["otel-collector-config.yaml"]!!
+        val yaml = yamlFrom(configMap)
 
         assertThat(yaml).doesNotContain("__WORKLOAD_SCRAPE_JOBS__")
     }
@@ -62,12 +68,12 @@ class OtelManifestBuilderTest : BaseKoinTest() {
     fun `buildConfigMap injects dynamic scrape job for each workload`() {
         val scrapeConfigs =
             listOf(
-                WorkloadScrapeConfig(jobName = "presto", port = 8081, path = "/metrics"),
-                WorkloadScrapeConfig(jobName = "opensearch", port = 9600, path = "/_prometheus/metrics"),
+                WorkloadScrapeConfig(kitName = "presto", jobName = "presto", port = 8081, path = "/metrics"),
+                WorkloadScrapeConfig(kitName = "opensearch", jobName = "opensearch", port = 9600, path = "/_prometheus/metrics"),
             )
 
         val configMap = builder.buildConfigMap(scrapeConfigs)
-        val yaml = configMap.data["otel-collector-config.yaml"]!!
+        val yaml = yamlFrom(configMap)
 
         assertThat(yaml).contains("job_name: \"presto\"")
         assertThat(yaml).contains("localhost:8081")
@@ -78,11 +84,29 @@ class OtelManifestBuilderTest : BaseKoinTest() {
     }
 
     @Test
-    fun `buildConfigMap with dynamic jobs still contains all static scrape jobs`() {
-        val scrapeConfigs = listOf(WorkloadScrapeConfig(jobName = "clickhouse", port = 9363, path = "/metrics"))
+    fun `buildConfigMap uses kitName as OTel job_name and relabels job to jobName`() {
+        val scrapeConfigs =
+            listOf(
+                WorkloadScrapeConfig(kitName = "postgres-duckdb", jobName = "postgres", port = 30987, path = "/metrics"),
+                WorkloadScrapeConfig(kitName = "postgres-postgis", jobName = "postgres", port = 30988, path = "/metrics"),
+            )
 
         val configMap = builder.buildConfigMap(scrapeConfigs)
-        val yaml = configMap.data["otel-collector-config.yaml"]!!
+        val yaml = yamlFrom(configMap)
+
+        // OTel job_name uses kitName to ensure uniqueness across instances
+        assertThat(yaml).contains("job_name: \"postgres-duckdb\"")
+        assertThat(yaml).contains("job_name: \"postgres-postgis\"")
+        // Relabel sets the `job` label in metrics back to the logical jobName
+        assertThat(yaml).contains("target_label: \"job\"").contains("replacement: \"postgres\"")
+    }
+
+    @Test
+    fun `buildConfigMap with dynamic jobs still contains all static scrape jobs`() {
+        val scrapeConfigs = listOf(WorkloadScrapeConfig(kitName = "clickhouse", jobName = "clickhouse", port = 9363, path = "/metrics"))
+
+        val configMap = builder.buildConfigMap(scrapeConfigs)
+        val yaml = yamlFrom(configMap)
 
         assertThat(yaml).contains("job_name: 'beyla'")
         assertThat(yaml).contains("job_name: 'ebpf-exporter'")
@@ -94,10 +118,10 @@ class OtelManifestBuilderTest : BaseKoinTest() {
 
     @Test
     fun `buildConfigMap dynamic jobs use OTel runtime env expansion not placeholder`() {
-        val scrapeConfigs = listOf(WorkloadScrapeConfig(jobName = "mydb", port = 9999, path = "/metrics"))
+        val scrapeConfigs = listOf(WorkloadScrapeConfig(kitName = "mydb", jobName = "mydb", port = 9999, path = "/metrics"))
 
         val configMap = builder.buildConfigMap(scrapeConfigs)
-        val yaml = configMap.data["otel-collector-config.yaml"]!!
+        val yaml = yamlFrom(configMap)
 
         assertThat(yaml).contains("\${env:HOSTNAME}:9999")
         assertThat(yaml).contains("\${env:CLUSTER_NAME}")
@@ -116,11 +140,11 @@ class OtelManifestBuilderTest : BaseKoinTest() {
     fun `buildConfigMap with username generates basic_auth block in scrape job`() {
         val scrapeConfigs =
             listOf(
-                WorkloadScrapeConfig(jobName = "trino", port = 8080, path = "/metrics", username = "trino"),
+                WorkloadScrapeConfig(kitName = "trino", jobName = "trino", port = 8080, path = "/metrics", username = "trino"),
             )
 
         val configMap = builder.buildConfigMap(scrapeConfigs)
-        val yaml = configMap.data["otel-collector-config.yaml"]!!
+        val yaml = yamlFrom(configMap)
 
         assertThat(yaml).contains("basic_auth:")
         assertThat(yaml).contains("username: \"trino\"")
@@ -130,11 +154,11 @@ class OtelManifestBuilderTest : BaseKoinTest() {
     fun `buildConfigMap without username omits basic_auth block`() {
         val scrapeConfigs =
             listOf(
-                WorkloadScrapeConfig(jobName = "clickhouse", port = 9363, path = "/metrics"),
+                WorkloadScrapeConfig(kitName = "clickhouse", jobName = "clickhouse", port = 9363, path = "/metrics"),
             )
 
         val configMap = builder.buildConfigMap(scrapeConfigs)
-        val yaml = configMap.data["otel-collector-config.yaml"]!!
+        val yaml = yamlFrom(configMap)
 
         assertThat(yaml).doesNotContain("basic_auth:")
     }

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/services/ExtensionRegistryTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/services/ExtensionRegistryTest.kt
@@ -1,0 +1,61 @@
+package com.rustyrazorblade.easydblab.services
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class ExtensionRegistryTest {
+    private val registryYaml =
+        """
+        extensions:
+          duckdb:
+            description: "DuckDB via pg_duckdb"
+            image: "ghcr.io/duckdb/pg_duckdb:pg__PG_MAJOR__"
+            shared_preload_libraries:
+              - pg_duckdb
+            create_extensions:
+              - pg_duckdb
+          postgis:
+            description: "Geospatial"
+            image: "ghcr.io/cloudnative-pg/postgis:__PG_MAJOR__"
+            create_extensions:
+              - postgis
+        """.trimIndent()
+
+    private val registry = ExtensionRegistry.fromString(registryYaml)
+
+    @Test
+    fun `loads all aliases`() {
+        assertThat(registry.all()).containsKeys("duckdb", "postgis")
+    }
+
+    @Test
+    fun `lookup returns alias for known name`() {
+        val alias = requireNotNull(registry.lookup("duckdb")) { "Expected 'duckdb' alias to exist" }
+        assertThat(alias.image).isEqualTo("ghcr.io/duckdb/pg_duckdb:pg__PG_MAJOR__")
+        assertThat(alias.sharedPreloadLibraries).containsExactly("pg_duckdb")
+        assertThat(alias.createExtensions).containsExactly("pg_duckdb")
+    }
+
+    @Test
+    fun `lookup returns null for unknown alias`() {
+        assertThat(registry.lookup("nonexistent")).isNull()
+    }
+
+    @Test
+    fun `alias without shared_preload_libraries defaults to empty list`() {
+        val alias = requireNotNull(registry.lookup("postgis")) { "Expected 'postgis' alias to exist" }
+        assertThat(alias.sharedPreloadLibraries).isEmpty()
+    }
+
+    @Test
+    fun `fromClasspath loads built-in postgres extensions`() {
+        val builtin = ExtensionRegistry.fromClasspath("postgres")
+        assertThat(builtin.all()).containsKeys("duckdb", "postgis", "timescaledb")
+    }
+
+    @Test
+    fun `fromClasspath returns empty registry for unknown kit`() {
+        val empty = ExtensionRegistry.fromClasspath("nonexistent-kit")
+        assertThat(empty.all()).isEmpty()
+    }
+}

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/services/ExtensionResolverTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/services/ExtensionResolverTest.kt
@@ -1,0 +1,169 @@
+package com.rustyrazorblade.easydblab.services
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+class ExtensionResolverTest {
+    private val registry =
+        ExtensionRegistry.fromString(
+            """
+            extensions:
+              duckdb:
+                description: "DuckDB"
+                image: "ghcr.io/duckdb/pg_duckdb:pg__PG_MAJOR__"
+                shared_preload_libraries:
+                  - pg_duckdb
+                create_extensions:
+                  - pg_duckdb
+              postgis:
+                description: "PostGIS"
+                image: "ghcr.io/cloudnative-pg/postgis:__PG_MAJOR__"
+                create_extensions:
+                  - postgis
+              timescaledb:
+                description: "TimescaleDB"
+                image: "timescale/timescaledb-ha:pg__PG_MAJOR__-latest"
+                shared_preload_libraries:
+                  - timescaledb
+                create_extensions:
+                  - timescaledb
+            """.trimIndent(),
+        )
+
+    private val resolver = ExtensionResolver(registry, "17")
+
+    @Test
+    fun `no extensions resolves to default image`() {
+        val config = resolver.resolve(emptyList(), null, emptyList(), emptyList())
+        assertThat(config.image).isEqualTo("ghcr.io/cloudnative-pg/postgresql:17")
+        assertThat(config.sharedPreloadLibraries).isEmpty()
+        assertThat(config.createExtensions).isEmpty()
+    }
+
+    @Test
+    fun `single alias resolves image and pg major substitution`() {
+        val config = resolver.resolve(listOf("duckdb"), null, emptyList(), emptyList())
+        assertThat(config.image).isEqualTo("ghcr.io/duckdb/pg_duckdb:pg17")
+        assertThat(config.sharedPreloadLibraries).containsExactly("pg_duckdb")
+        assertThat(config.createExtensions).containsExactly("pg_duckdb")
+    }
+
+    @Test
+    fun `--image override replaces alias image but alias config still applies`() {
+        val config = resolver.resolve(listOf("duckdb"), "my-registry/custom:pg17", emptyList(), emptyList())
+        assertThat(config.image).isEqualTo("my-registry/custom:pg17")
+        assertThat(config.sharedPreloadLibraries).containsExactly("pg_duckdb")
+        assertThat(config.createExtensions).containsExactly("pg_duckdb")
+    }
+
+    @Test
+    fun `multiple aliases with same image succeeds`() {
+        val duckdbWithPostgis =
+            ExtensionRegistry.fromString(
+                """
+                extensions:
+                  ext1:
+                    description: "first"
+                    image: "combined:pg__PG_MAJOR__"
+                    create_extensions:
+                      - ext1
+                  ext2:
+                    description: "second"
+                    image: "combined:pg__PG_MAJOR__"
+                    create_extensions:
+                      - ext2
+                """.trimIndent(),
+            )
+        val sameImageResolver = ExtensionResolver(duckdbWithPostgis, "16")
+        val config = sameImageResolver.resolve(listOf("ext1", "ext2"), null, emptyList(), emptyList())
+        assertThat(config.image).isEqualTo("combined:pg16")
+        assertThat(config.createExtensions).containsExactlyInAnyOrder("ext1", "ext2")
+    }
+
+    @Test
+    fun `multiple aliases with different images throws with actionable message`() {
+        assertThatThrownBy {
+            resolver.resolve(listOf("duckdb", "postgis"), null, emptyList(), emptyList())
+        }.isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("duckdb")
+            .hasMessageContaining("postgis")
+            .hasMessageContaining("--image")
+    }
+
+    @Test
+    fun `--image override resolves conflict between multiple aliases`() {
+        val config = resolver.resolve(listOf("duckdb", "postgis"), "combined:pg17", emptyList(), emptyList())
+        assertThat(config.image).isEqualTo("combined:pg17")
+        assertThat(config.createExtensions).containsExactlyInAnyOrder("pg_duckdb", "postgis")
+    }
+
+    @Test
+    fun `escape-hatch flags augment alias config`() {
+        val config =
+            resolver.resolve(
+                extensions = listOf("duckdb"),
+                imageOverride = null,
+                additionalPreload = listOf("extra_lib"),
+                additionalCreate = listOf("extra_ext"),
+            )
+        assertThat(config.sharedPreloadLibraries).containsExactlyInAnyOrder("pg_duckdb", "extra_lib")
+        assertThat(config.createExtensions).containsExactlyInAnyOrder("pg_duckdb", "extra_ext")
+    }
+
+    @Test
+    fun `pure escape hatch with no alias`() {
+        val config =
+            resolver.resolve(
+                extensions = emptyList(),
+                imageOverride = "my-custom:pg17",
+                additionalPreload = listOf("mylib"),
+                additionalCreate = listOf("myext"),
+            )
+        assertThat(config.image).isEqualTo("my-custom:pg17")
+        assertThat(config.sharedPreloadLibraries).containsExactly("mylib")
+        assertThat(config.createExtensions).containsExactly("myext")
+    }
+
+    @Test
+    fun `unknown alias throws with helpful message`() {
+        assertThatThrownBy {
+            resolver.resolve(listOf("notreal"), null, emptyList(), emptyList())
+        }.isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("notreal")
+    }
+
+    @Test
+    fun `pg major is major version only when version has dot`() {
+        val resolver16 = ExtensionResolver(registry, "16.3")
+        val config = resolver16.resolve(listOf("duckdb"), null, emptyList(), emptyList())
+        assertThat(config.image).isEqualTo("ghcr.io/duckdb/pg_duckdb:pg16")
+    }
+
+    @Test
+    fun `alias with custom UID and GID resolves those values`() {
+        val registryWithUid =
+            ExtensionRegistry.fromString(
+                """
+                extensions:
+                  custom-uid:
+                    description: "Uses Docker postgres base image with UID 999"
+                    image: "example/pgext:pg__PG_MAJOR__"
+                    create_extensions:
+                      - pgext
+                    postgres_uid: 999
+                    postgres_gid: 999
+                """.trimIndent(),
+            )
+        val config = ExtensionResolver(registryWithUid, "17").resolve(listOf("custom-uid"), null, emptyList(), emptyList())
+        assertThat(config.postgresUid).isEqualTo(999)
+        assertThat(config.postgresGid).isEqualTo(999)
+    }
+
+    @Test
+    fun `alias without UID override defaults to CNPG base image UID 26`() {
+        val config = resolver.resolve(listOf("postgis"), null, emptyList(), emptyList())
+        assertThat(config.postgresUid).isEqualTo(26)
+        assertThat(config.postgresGid).isEqualTo(26)
+    }
+}

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/services/MetricsRegistryServiceTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/services/MetricsRegistryServiceTest.kt
@@ -68,9 +68,10 @@ class MetricsRegistryServiceTest : BaseKoinTest() {
         verify(mockK8sService).createConfigMap(
             controlHost = controlHost,
             namespace = "default",
-            name = "easydblab-metrics-clickhouse",
+            name = "easydblab-metrics-clickhouse-clickhouse",
             data =
                 mapOf(
+                    "kit-name" to "clickhouse",
                     "job-name" to "clickhouse",
                     "port" to "9363",
                     "path" to "/metrics",
@@ -84,16 +85,17 @@ class MetricsRegistryServiceTest : BaseKoinTest() {
     }
 
     @Test
-    fun `register uses job field as ConfigMap name when provided`() {
+    fun `register uses kitName-jobName as ConfigMap name when job is provided`() {
         val target = KitMetrics.Scrape(port = 20180, path = "/metrics", job = "tikv")
         service.register(controlHost = controlHost, kitName = "tidb", targets = listOf(target))
 
         verify(mockK8sService).createConfigMap(
             controlHost = controlHost,
             namespace = "default",
-            name = "easydblab-metrics-tikv",
+            name = "easydblab-metrics-tidb-tikv",
             data =
                 mapOf(
+                    "kit-name" to "tidb",
                     "job-name" to "tikv",
                     "port" to "20180",
                     "path" to "/metrics",
@@ -121,29 +123,29 @@ class MetricsRegistryServiceTest : BaseKoinTest() {
         verify(mockK8sService).createConfigMap(
             controlHost = controlHost,
             namespace = "default",
-            name = "easydblab-metrics-tidb-sql",
-            data = mapOf("job-name" to "tidb-sql", "port" to "31080", "path" to "/metrics"),
+            name = "easydblab-metrics-tidb-tidb-sql",
+            data = mapOf("kit-name" to "tidb", "job-name" to "tidb-sql", "port" to "31080", "path" to "/metrics"),
             labels = tidbLabels,
         )
         verify(mockK8sService).createConfigMap(
             controlHost = controlHost,
             namespace = "default",
-            name = "easydblab-metrics-tikv",
-            data = mapOf("job-name" to "tikv", "port" to "32180", "path" to "/metrics"),
+            name = "easydblab-metrics-tidb-tikv",
+            data = mapOf("kit-name" to "tidb", "job-name" to "tikv", "port" to "32180", "path" to "/metrics"),
             labels = tidbLabels,
         )
         verify(mockK8sService).createConfigMap(
             controlHost = controlHost,
             namespace = "default",
-            name = "easydblab-metrics-pd",
-            data = mapOf("job-name" to "pd", "port" to "32379", "path" to "/metrics"),
+            name = "easydblab-metrics-tidb-pd",
+            data = mapOf("kit-name" to "tidb", "job-name" to "pd", "port" to "32379", "path" to "/metrics"),
             labels = tidbLabels,
         )
         verify(mockK8sService).createConfigMap(
             controlHost = controlHost,
             namespace = "default",
-            name = "easydblab-metrics-tiflash",
-            data = mapOf("job-name" to "tiflash", "port" to "32234", "path" to "/metrics"),
+            name = "easydblab-metrics-tidb-tiflash",
+            data = mapOf("kit-name" to "tidb", "job-name" to "tiflash", "port" to "32234", "path" to "/metrics"),
             labels = tidbLabels,
         )
     }

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/services/OtelSyncServiceTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/services/OtelSyncServiceTest.kt
@@ -6,7 +6,6 @@ import com.rustyrazorblade.easydblab.configuration.ClusterHost
 import com.rustyrazorblade.easydblab.configuration.ClusterState
 import com.rustyrazorblade.easydblab.configuration.ClusterStateManager
 import com.rustyrazorblade.easydblab.configuration.otel.OtelManifestBuilder
-import com.rustyrazorblade.easydblab.configuration.otel.WorkloadScrapeConfig
 import io.fabric8.kubernetes.api.model.ConfigMap
 import io.fabric8.kubernetes.api.model.ConfigMapList
 import io.fabric8.kubernetes.client.KubernetesClient
@@ -27,8 +26,9 @@ import org.mockito.kotlin.whenever
 class OtelSyncServiceTest : BaseKoinTest() {
     private lateinit var mockK8sClientProvider: K8sClientProvider
     private lateinit var mockK8sService: K8sService
-    private lateinit var mockOtelManifestBuilder: OtelManifestBuilder
+    private lateinit var otelManifestBuilder: OtelManifestBuilder
     private lateinit var mockK8sClient: KubernetesClient
+    private lateinit var mockFiltered: FilterWatchListDeletable<ConfigMap, ConfigMapList, Resource<ConfigMap>>
     private lateinit var service: OtelSyncService
 
     private val controlHost =
@@ -57,15 +57,14 @@ class OtelSyncServiceTest : BaseKoinTest() {
     fun setup() {
         mockK8sClientProvider = getKoin().get()
         mockK8sService = getKoin().get()
-        mockOtelManifestBuilder = OtelManifestBuilder(getKoin().get())
+        otelManifestBuilder = OtelManifestBuilder(getKoin().get())
         mockK8sClient = mock()
 
         val mockConfigMapOps =
             mock<MixedOperation<ConfigMap, ConfigMapList, Resource<ConfigMap>>>()
         val mockAnyNsOps =
             mock<AnyNamespaceOperation<ConfigMap, ConfigMapList, Resource<ConfigMap>>>()
-        val mockFiltered =
-            mock<FilterWatchListDeletable<ConfigMap, ConfigMapList, Resource<ConfigMap>>>()
+        mockFiltered = mock()
         val emptyConfigMapList = ConfigMapList().also { it.items = mutableListOf() }
 
         whenever(mockK8sClient.configMaps()).thenReturn(mockConfigMapOps)
@@ -77,7 +76,7 @@ class OtelSyncServiceTest : BaseKoinTest() {
         whenever(mockK8sService.applyResource(any(), any())).thenReturn(Result.success(Unit))
         whenever(mockK8sService.rolloutRestartDaemonSet(any(), any(), any())).thenReturn(Result.success(Unit))
 
-        service = DefaultOtelSyncService(mockK8sClientProvider, mockK8sService, mockOtelManifestBuilder)
+        service = DefaultOtelSyncService(mockK8sClientProvider, mockK8sService, otelManifestBuilder)
     }
 
     @Test
@@ -145,14 +144,31 @@ class OtelSyncServiceTest : BaseKoinTest() {
     }
 
     @Test
-    fun `syncConfigMap with workload scrape configs produces ConfigMap with dynamic jobs`() {
-        val scrapeConfigs = listOf(WorkloadScrapeConfig(jobName = "scylladb", port = 9180, path = "/metrics"))
-        val builder = OtelManifestBuilder(getKoin().get())
+    fun `syncConfigMap applies ConfigMap containing dynamic jobs from workload scrape ConfigMaps`() {
+        val metricsConfigMap =
+            ConfigMap().apply {
+                data =
+                    mapOf(
+                        "kit-name" to "scylladb",
+                        "job-name" to "scylladb",
+                        "port" to "9180",
+                        "path" to "/metrics",
+                    )
+            }
+        whenever(mockFiltered.list()).thenReturn(ConfigMapList().also { it.items = mutableListOf(metricsConfigMap) })
 
-        val configMap = builder.buildConfigMap(scrapeConfigs)
-        val yaml = configMap.data["otel-collector-config.yaml"]
+        var appliedConfigMap: ConfigMap? = null
+        whenever(mockK8sService.applyResource(any(), any())).thenAnswer { inv ->
+            appliedConfigMap = inv.getArgument(1) as? ConfigMap
+            Result.success(Unit)
+        }
 
-        assertThat(yaml).isNotNull
+        service.syncConfigMap(controlHost)
+
+        val yaml =
+            checkNotNull(appliedConfigMap?.data?.get("otel-collector-config.yaml")) {
+                "Applied ConfigMap must contain otel-collector-config.yaml"
+            }
         assertThat(yaml).contains("scylladb")
         assertThat(yaml).contains("9180")
     }

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/services/PostgresClusterTemplateTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/services/PostgresClusterTemplateTest.kt
@@ -1,0 +1,94 @@
+package com.rustyrazorblade.easydblab.services
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests that the postgres-cluster.yaml.template renders correctly through install-time
+ * __KEY__ substitution performed by TemplateService.
+ *
+ * All variables — INSTANCES, STORAGE_CLASS_WFC, STORAGE_SIZE, IMAGE,
+ * SHARED_PRELOAD_LIBRARIES, and POST_INIT_SQL — are substituted at install time.
+ */
+class PostgresClusterTemplateTest {
+    private val templateContent: String by lazy {
+        PostgresClusterTemplateTest::class.java.classLoader
+            .getResourceAsStream("com/rustyrazorblade/easydblab/kits/postgres/postgres-cluster.yaml.template")
+            ?.bufferedReader()
+            ?.readText()
+            ?: error("postgres-cluster.yaml.template not found on classpath")
+    }
+
+    private fun simulateInstall(
+        template: String,
+        kitName: String = "postgres-duckdb",
+        image: String = "ghcr.io/cloudnative-pg/postgresql:17",
+        sharedPreloadLibraries: String = "[]",
+        postInitSql: String = "[]",
+        pgMajorVersion: String = "17",
+        postgresUid: String = "26",
+        postgresGid: String = "26",
+    ): String =
+        template
+            .replace("__KIT_NAME__", kitName)
+            .replace("__INSTANCES__", "1")
+            .replace("__STORAGE_CLASS_WFC__", "local-storage-wfc")
+            .replace("__STORAGE_SIZE__", "10Gi")
+            .replace("__IMAGE__", image)
+            .replace("__SHARED_PRELOAD_LIBRARIES__", sharedPreloadLibraries)
+            .replace("__POST_INIT_SQL__", postInitSql)
+            .replace("__PG_MAJOR_VERSION__", pgMajorVersion)
+            .replace("__POSTGRES_UID__", postgresUid)
+            .replace("__POSTGRES_GID__", postgresGid)
+
+    @Test
+    fun `no extensions renders with default image and empty preload and postInitSQL`() {
+        val rendered = simulateInstall(templateContent)
+
+        // Image appears in the ImageCatalog spec.images block (not as imageName)
+        assertThat(rendered).contains("image: ghcr.io/cloudnative-pg/postgresql:17")
+        assertThat(rendered).contains("shared_preload_libraries: []")
+        assertThat(rendered).contains("postInitSQL: []")
+        assertThat(rendered).doesNotContain("__IMAGE__")
+        assertThat(rendered).doesNotContain("__SHARED_PRELOAD_LIBRARIES__")
+        assertThat(rendered).doesNotContain("__POST_INIT_SQL__")
+    }
+
+    @Test
+    fun `single extension renders with alias image and preload and postInitSQL`() {
+        val rendered =
+            simulateInstall(
+                templateContent,
+                image = "timescale/timescaledb-ha:pg17-latest",
+                sharedPreloadLibraries = "[\"timescaledb\"]",
+                postInitSql = "[\"CREATE EXTENSION timescaledb\"]",
+            )
+
+        // Image appears in the ImageCatalog spec.images block (not as imageName)
+        assertThat(rendered).contains("image: timescale/timescaledb-ha:pg17-latest")
+        assertThat(rendered).contains("shared_preload_libraries: [\"timescaledb\"]")
+        assertThat(rendered).contains("postInitSQL: [\"CREATE EXTENSION timescaledb\"]")
+    }
+
+    @Test
+    fun `all install-time vars are substituted`() {
+        val rendered = simulateInstall(templateContent)
+        assertThat(rendered).doesNotContain("__KIT_NAME__")
+        assertThat(rendered).doesNotContain("__INSTANCES__")
+        assertThat(rendered).doesNotContain("__STORAGE_CLASS_WFC__")
+        assertThat(rendered).doesNotContain("__STORAGE_SIZE__")
+        assertThat(rendered).doesNotContain("__IMAGE__")
+        assertThat(rendered).doesNotContain("__SHARED_PRELOAD_LIBRARIES__")
+        assertThat(rendered).doesNotContain("__POST_INIT_SQL__")
+    }
+
+    @Test
+    fun `kit name is used for all K8s resource names`() {
+        val rendered = simulateInstall(templateContent, kitName = "postgres-postgis")
+        assertThat(rendered).contains("name: postgres-postgis-credentials")
+        assertThat(rendered).contains("name: postgres-postgis-catalog")
+        assertThat(rendered).contains("name: postgres-postgis\n")
+        assertThat(rendered).doesNotContain("name: postgres-credentials")
+        assertThat(rendered).doesNotContain("name: postgres-catalog")
+    }
+}

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/services/WorkloadStepExecutorTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/services/WorkloadStepExecutorTest.kt
@@ -169,10 +169,47 @@ class WorkloadStepExecutorTest : BaseKoinTest() {
         @Test
         fun `succeeds when manifest file exists`() {
             val manifestFile = File(tempDir, "deploy.yaml").also { it.writeText("kind: Pod") }
-            whenever(k8sService.applyYaml(any(), any())).thenReturn(Result.success(Unit))
 
             val result = execute(steps = listOf(InstallStep.Manifest(manifestFile.name)), kitDir = tempDir)
             assertThat(result.isSuccess).isTrue()
+        }
+
+        @Test
+        fun `interpolate=true substitutes step vars in manifest content`() {
+            var capturedContent: String? = null
+            val manifestFile = File(tempDir, "cluster.yaml").also { it.writeText("imageName: \${IMAGE}") }
+            org.mockito.kotlin
+                .doAnswer { inv ->
+                    capturedContent = inv.getArgument(1)
+                }.whenever(kubectlService)
+                .applyContent(any(), any())
+
+            execute(
+                steps = listOf(InstallStep.Manifest(manifestFile.name, interpolate = true)),
+                variables = mapOf("IMAGE" to "ghcr.io/example/pg:17"),
+                kitDir = tempDir,
+            )
+
+            assertThat(capturedContent).isEqualTo("imageName: ghcr.io/example/pg:17")
+        }
+
+        @Test
+        fun `interpolate=false leaves step vars in manifest content untouched`() {
+            var capturedContent: String? = null
+            val manifestFile = File(tempDir, "cluster.yaml").also { it.writeText("imageName: \${IMAGE}") }
+            org.mockito.kotlin
+                .doAnswer { inv ->
+                    capturedContent = inv.getArgument(1)
+                }.whenever(kubectlService)
+                .applyContent(any(), any())
+
+            execute(
+                steps = listOf(InstallStep.Manifest(manifestFile.name, interpolate = false)),
+                variables = mapOf("IMAGE" to "ghcr.io/example/pg:17"),
+                kitDir = tempDir,
+            )
+
+            assertThat(capturedContent).isEqualTo("imageName: \${IMAGE}")
         }
     }
 }

--- a/test-plans/postgres-duckdb-dashboard.md
+++ b/test-plans/postgres-duckdb-dashboard.md
@@ -1,0 +1,178 @@
+# Lab Plan: PostgreSQL + DuckDB Dashboard
+
+## Objective
+
+Install PostgreSQL with the DuckDB extension, load data via sysbench, run analytical queries,
+collect the metrics catalog, and author `dashboards/duckdb.json` for the postgres kit.
+
+## Cluster Configuration
+
+| Node type | Count | Role |
+|-----------|-------|------|
+| control   | 1     | K3s control plane, observability stack |
+| db        | 1     | PostgreSQL (CNPG) |
+| app       | 1     | sysbench workload |
+
+## Prerequisites
+
+- AWS credentials configured with `sandbox-admin` profile
+- Tailscale running on the developer machine
+- Project built: `./gradlew installDist`
+
+---
+
+## Steps
+
+### 1. Fix postgres endpoint type (code change)
+
+The postgres kit must expose a `postgresql` wire-protocol endpoint so sysbench can inject
+`TARGET_PG_*` env vars. Update `kit.yaml` in the source tree before building:
+
+Change the PostgreSQL endpoint in
+`src/main/resources/com/rustyrazorblade/easydblab/kits/postgres/kit.yaml` from:
+
+```yaml
+  - name: "PostgreSQL"
+    node-type: db
+    port: 30432
+    type: native
+```
+
+to:
+
+```yaml
+  - name: "PostgreSQL"
+    node-type: db
+    port: 30432
+    type: postgresql
+    database: postgres
+```
+
+Then rebuild:
+
+```bash
+./gradlew installDist
+```
+
+### 2. Set up cluster workspace
+
+```bash
+CLUSTER_DIR="clusters/postgres-duckdb-dashboard-$(date +%Y%m%d-%H%M%S)"
+mkdir -p "$CLUSTER_DIR"
+bin/create-easy-db-lab-wrapper "$CLUSTER_DIR"
+EDB="$CLUSTER_DIR/easy-db-lab"
+```
+
+### 3. Initialize and bring up cluster
+
+```bash
+$EDB init postgres-duckdb -c 1 -s 1 -i i4i.xlarge
+$EDB up
+```
+
+Wait for all nodes to be provisioned and K3s running (~5 min).
+
+### 4. Install and start PostgreSQL with DuckDB
+
+```bash
+$EDB kit install postgres --version 17 --instances 1 --size 100Gi --extension duckdb
+$EDB postgres-duckdb start
+```
+
+The duckdb image will be pulled on first use — expect 3–5 min for pod Ready.
+
+### 5. Verify DuckDB is installed
+
+```bash
+$EDB postgres-duckdb sql "SELECT extname, extversion FROM pg_extension WHERE extname = 'pg_duckdb';"
+$EDB postgres-duckdb sql "SELECT duckdb_version();"
+```
+
+Both queries must return results. If `pg_duckdb` is not in `pg_extension`, stop and investigate
+pod events: `kubectl describe pod -l cnpg.io/cluster=postgres -n default`.
+
+### 6. Install and run sysbench to load data
+
+```bash
+$EDB kit install sysbench --target postgres-duckdb --scale 100 --tables 10 --threads 8 --duration 120
+$EDB sysbench-postgres-duckdb start
+```
+
+This prepares 10 tables × 100k rows then runs `oltp_read_write` for 120s. Wait for the
+sysbench pod to complete (~5 min including prepare).
+
+### 7. Run analytical queries through DuckDB
+
+Demonstrate DuckDB executing analytical queries over the sysbench data:
+
+```bash
+$EDB postgres-duckdb sql "SELECT COUNT(*), AVG(k), MIN(k), MAX(k) FROM sbtest1;"
+$EDB postgres-duckdb sql "SELECT c, COUNT(*) AS n FROM sbtest1 GROUP BY c ORDER BY n DESC LIMIT 10;"
+$EDB postgres-duckdb sql "
+SELECT
+  duckdb_version() AS duckdb_version,
+  (SELECT COUNT(*) FROM sbtest1) AS row_count;
+"
+```
+
+All queries should return results and execute without error.
+
+### 8. Wait for metrics to stabilize
+
+```bash
+CONTROL_IP=$($EDB ip control0 --private)
+DEADLINE=$((SECONDS + 180))
+until [ $SECONDS -ge $DEADLINE ]; do
+    METRIC_COUNT=$(curl -sf "http://${CONTROL_IP}:8428/api/v1/series" \
+        --data-urlencode 'match[]={job="postgres"}' 2>/dev/null \
+        | jq '.data | length' 2>/dev/null || echo 0)
+    echo "$(date +%H:%M:%S)  postgres metric series: ${METRIC_COUNT}"
+    [ "${METRIC_COUNT:-0}" -ge 10 ] && break
+    sleep 15
+done
+[ "${METRIC_COUNT:-0}" -ge 10 ] || { echo "ERROR: expected ≥10 series, got ${METRIC_COUNT:-0}"; exit 1; }
+echo "VictoriaMetrics has ${METRIC_COUNT} postgres metric series ✓"
+```
+
+### 9. Export metrics catalog
+
+```bash
+(cd "$CLUSTER_DIR" && bin/export-workload-metrics postgres)
+cp "$CLUSTER_DIR/postgres/metrics-catalog.json" \
+   src/main/resources/com/rustyrazorblade/easydblab/kits/postgres/metrics-catalog-duckdb.json
+```
+
+### 10. PAUSE — author DuckDB dashboard
+
+**Stop here.** Claude will read `metrics-catalog-duckdb.json`, compare it against the base
+`metrics-catalog.json`, identify any duckdb-specific or analytically-relevant metrics, and
+author `src/main/resources/com/rustyrazorblade/easydblab/kits/postgres/dashboards/duckdb.json`.
+
+Review and approve the dashboard in Grafana before proceeding.
+
+### 11. Stop and uninstall
+
+```bash
+$EDB sysbench-postgres-duckdb stop
+$EDB postgres-duckdb stop
+$EDB postgres-duckdb uninstall
+```
+
+### 12. Tear down cluster
+
+```bash
+$EDB down --auto-approve
+```
+
+---
+
+## Notes
+
+- `kit install postgres --extension duckdb` creates the `postgres-duckdb/` directory and bakes
+  the pg_duckdb image into `postgres-cluster.yaml` at install time.
+- The sysbench kit uses `TARGET_PG_*` vars from the postgres kit's `postgresql` endpoint.
+  Step 1 (endpoint fix) is required for sysbench to connect.
+- Metrics are scraped from the CNPG exporter (NodePort 30987) with `job="postgres"` regardless
+  of extension. The duckdb catalog may have the same series as the base catalog; the dashboard
+  focuses on analytically-relevant panels (seq scans, temp files, buffer hit ratio).
+- AWS profile: `sandbox-admin`

--- a/test-plans/postgres-kit-validation.md
+++ b/test-plans/postgres-kit-validation.md
@@ -1,0 +1,130 @@
+# Lab Plan: postgres kit validation
+
+## Objective
+
+Validate the new `postgres` kit end-to-end: deploy via CNPG, execute SQL via `postgres sql`,
+verify metrics are flowing to VictoriaMetrics, export the metrics catalog, verify Presto sees
+the `postgres` catalog and can query it, and confirm that `stop` preserves data across a restart.
+
+## Environment
+
+1 db node (i4i.xlarge) + 1 app node (i4i.xlarge). PostgreSQL v17, single instance. Presto on the app node.
+
+## Steps
+
+### 1. Create cluster workspace and provision
+
+```bash
+CLUSTER_DIR="clusters/postgres-test-$(date +%Y%m%d-%H%M%S)"
+mkdir -p "$CLUSTER_DIR"
+bin/create-easy-db-lab-wrapper "$CLUSTER_DIR"
+EDB="$CLUSTER_DIR/easy-db-lab"
+$EDB init --db 1 --app 1 --instance i4i.xlarge --stress-instance i4i.xlarge --up
+```
+
+### 2. Configure kubectl access
+
+```bash
+export KUBECONFIG="$CLUSTER_DIR/kubeconfig"
+```
+
+### 3. Install kits
+
+```bash
+$EDB kit install postgres --version 17 --instances 1 --size 100Gi
+$EDB kit install presto
+```
+
+### 4. Start PostgreSQL
+
+```bash
+$EDB postgres start
+```
+
+### 5. Verify SQL works
+
+```bash
+$EDB postgres sql "SELECT version()"
+```
+
+### 6. Create test data
+
+```bash
+$EDB postgres sql "CREATE TABLE test (id serial PRIMARY KEY, msg text)"
+$EDB postgres sql "INSERT INTO test (msg) VALUES ('hello'), ('world')"
+$EDB postgres sql "SELECT count(*) FROM test"
+```
+
+Expected: returns `2`.
+
+### 7. Verify PostgreSQL metrics in VictoriaMetrics
+
+Wait for metrics to flow, then assert ≥10 series are present:
+
+```bash
+EDB="$CLUSTER_DIR/easy-db-lab"
+CONTROL_IP=$($EDB ip control0 --private)
+DEADLINE=$((SECONDS + 180))
+until [ $SECONDS -ge $DEADLINE ]; do
+    METRIC_COUNT=$(curl -sf "http://${CONTROL_IP}:8428/api/v1/series" \
+        --data-urlencode 'match[]={job="postgres"}' 2>/dev/null | jq '.data | length' 2>/dev/null || echo 0)
+    echo "$(date +%H:%M:%S) metric series: ${METRIC_COUNT}"
+    [ "${METRIC_COUNT:-0}" -ge 10 ] && break
+    sleep 15
+done
+[ "${METRIC_COUNT:-0}" -ge 10 ] || { echo "ERROR: expected ≥10 metric series, got ${METRIC_COUNT:-0}"; exit 1; }
+echo "VictoriaMetrics has ${METRIC_COUNT} PostgreSQL metric series ✓"
+```
+
+### 8. Export metrics catalog
+
+Run from the cluster workspace directory so `env.sh` is found:
+
+```bash
+(cd "$CLUSTER_DIR" && bin/export-workload-metrics postgres)
+```
+
+Then copy the output into the source tree and commit:
+
+```bash
+cp "$CLUSTER_DIR/postgres/metrics-catalog.json" \
+   src/main/resources/com/rustyrazorblade/easydblab/kits/postgres/metrics-catalog.json
+```
+
+### 9. Start Presto (triggers postgres catalog injection)
+
+```bash
+$EDB presto start
+```
+
+### 10. Verify Presto sees postgres catalog
+
+```bash
+$EDB presto sql "SHOW CATALOGS"
+$EDB presto sql "SHOW TABLES FROM postgres.public"
+$EDB presto sql "SELECT * FROM postgres.public.test"
+```
+
+### 11. Test stop/start data persistence
+
+```bash
+$EDB postgres stop
+$EDB postgres start
+$EDB postgres sql "SELECT count(*) FROM test"
+```
+
+Expected: returns `2`.
+
+### 12. Tear down
+
+```bash
+$EDB down --auto-approve
+```
+
+## Notes
+
+- CNPG pods may take 2–3 minutes to reach Ready after `postgres start`. The kit waits automatically.
+- The `presto start` hook calls `update-catalogs.sh` which injects the postgres catalog — verify with `SHOW CATALOGS` before querying.
+- If Presto can't reach postgres, check that `postgres-rw.default.svc.cluster.local` resolves inside the cluster (CNPG creates this service automatically).
+- After step 8, author `METRICS.md` and `dashboards/postgres.json` from the exported catalog before committing.
+- AWS profile: `sandbox-admin`

--- a/test-plans/postgres-metrics-dashboards.md
+++ b/test-plans/postgres-metrics-dashboards.md
@@ -1,0 +1,231 @@
+# Lab Plan: postgres metrics and dashboard authoring
+
+## Objective
+
+Collect postgres metrics and author Grafana dashboards for the base postgres kit and each
+extension (duckdb, postgis, timescaledb). Each run uses a clean database (fresh PVs via
+uninstall between runs) to avoid data compatibility issues between images.
+
+Order: base postgres → duckdb (highest priority) → postgis → timescaledb.
+
+## Environment
+
+1 db node (i4i.xlarge). PostgreSQL v17, single instance. No app node needed.
+
+## Steps
+
+### 1. Create cluster workspace and provision
+
+```bash
+CLUSTER_DIR="clusters/postgres-dashboards-$(date +%Y%m%d-%H%M%S)"
+mkdir -p "$CLUSTER_DIR"
+bin/create-easy-db-lab-wrapper "$CLUSTER_DIR"
+EDB="$CLUSTER_DIR/easy-db-lab"
+$EDB init --db 1 --instance i4i.xlarge --up
+```
+
+---
+
+## Run 1: Base postgres (no extensions)
+
+### 2. Install and start
+
+```bash
+$EDB kit install postgres --version 17 --instances 1 --size 100Gi
+$EDB postgres start
+```
+
+### 3. Verify metrics are flowing
+
+```bash
+CONTROL_IP=$($EDB ip control0 --private)
+DEADLINE=$((SECONDS + 180))
+until [ $SECONDS -ge $DEADLINE ]; do
+    METRIC_COUNT=$(curl -sf "http://${CONTROL_IP}:8428/api/v1/series" \
+        --data-urlencode 'match[]={job="postgres"}' 2>/dev/null | jq '.data | length' 2>/dev/null || echo 0)
+    echo "$(date +%H:%M:%S) metric series: ${METRIC_COUNT}"
+    [ "${METRIC_COUNT:-0}" -ge 10 ] && break
+    sleep 15
+done
+[ "${METRIC_COUNT:-0}" -ge 10 ] || { echo "ERROR: expected ≥10 metric series, got ${METRIC_COUNT:-0}"; exit 1; }
+echo "VictoriaMetrics has ${METRIC_COUNT} PostgreSQL metric series ✓"
+```
+
+### 4. Export metrics catalog
+
+```bash
+(cd "$CLUSTER_DIR" && bin/export-workload-metrics postgres)
+cp "$CLUSTER_DIR/postgres/metrics-catalog.json" \
+   src/main/resources/com/rustyrazorblade/easydblab/kits/postgres/metrics-catalog.json
+```
+
+### 5. PAUSE — author base postgres dashboard
+
+**Stop here.** Claude will author `src/main/resources/com/rustyrazorblade/easydblab/kits/postgres/dashboards/postgres.json`
+from the exported catalog. Review and approve the dashboard before continuing.
+
+### 6. Stop and uninstall
+
+```bash
+$EDB postgres stop
+$EDB postgres uninstall
+```
+
+---
+
+## Run 2: DuckDB extension
+
+### 7. Install and start with duckdb
+
+```bash
+$EDB kit install postgres --version 17 --instances 1 --size 100Gi
+$EDB postgres start --extension duckdb
+```
+
+### 8. Verify metrics are flowing
+
+```bash
+CONTROL_IP=$($EDB ip control0 --private)
+DEADLINE=$((SECONDS + 180))
+until [ $SECONDS -ge $DEADLINE ]; do
+    METRIC_COUNT=$(curl -sf "http://${CONTROL_IP}:8428/api/v1/series" \
+        --data-urlencode 'match[]={job="postgres"}' 2>/dev/null | jq '.data | length' 2>/dev/null || echo 0)
+    echo "$(date +%H:%M:%S) metric series: ${METRIC_COUNT}"
+    [ "${METRIC_COUNT:-0}" -ge 10 ] && break
+    sleep 15
+done
+[ "${METRIC_COUNT:-0}" -ge 10 ] || { echo "ERROR: expected ≥10 metric series, got ${METRIC_COUNT:-0}"; exit 1; }
+echo "VictoriaMetrics has ${METRIC_COUNT} PostgreSQL metric series ✓"
+```
+
+### 9. Export metrics catalog
+
+```bash
+(cd "$CLUSTER_DIR" && bin/export-workload-metrics postgres)
+cp "$CLUSTER_DIR/postgres/metrics-catalog.json" \
+   src/main/resources/com/rustyrazorblade/easydblab/kits/postgres/metrics-catalog-duckdb.json
+```
+
+### 10. PAUSE — author duckdb dashboard
+
+**Stop here.** Claude will author `src/main/resources/com/rustyrazorblade/easydblab/kits/postgres/dashboards/duckdb.json`
+from the exported catalog. Review and approve the dashboard before continuing.
+
+### 11. Stop and uninstall
+
+```bash
+$EDB postgres stop
+$EDB postgres uninstall
+```
+
+---
+
+## Run 3: PostGIS extension
+
+### 12. Install and start with postgis
+
+```bash
+$EDB kit install postgres --version 17 --instances 1 --size 100Gi
+$EDB postgres start --extension postgis
+```
+
+### 13. Verify metrics are flowing
+
+```bash
+CONTROL_IP=$($EDB ip control0 --private)
+DEADLINE=$((SECONDS + 180))
+until [ $SECONDS -ge $DEADLINE ]; do
+    METRIC_COUNT=$(curl -sf "http://${CONTROL_IP}:8428/api/v1/series" \
+        --data-urlencode 'match[]={job="postgres"}' 2>/dev/null | jq '.data | length' 2>/dev/null || echo 0)
+    echo "$(date +%H:%M:%S) metric series: ${METRIC_COUNT}"
+    [ "${METRIC_COUNT:-0}" -ge 10 ] && break
+    sleep 15
+done
+[ "${METRIC_COUNT:-0}" -ge 10 ] || { echo "ERROR: expected ≥10 metric series, got ${METRIC_COUNT:-0}"; exit 1; }
+echo "VictoriaMetrics has ${METRIC_COUNT} PostgreSQL metric series ✓"
+```
+
+### 14. Export metrics catalog
+
+```bash
+(cd "$CLUSTER_DIR" && bin/export-workload-metrics postgres)
+cp "$CLUSTER_DIR/postgres/metrics-catalog.json" \
+   src/main/resources/com/rustyrazorblade/easydblab/kits/postgres/metrics-catalog-postgis.json
+```
+
+### 15. PAUSE — author postgis dashboard
+
+**Stop here.** Claude will author `src/main/resources/com/rustyrazorblade/easydblab/kits/postgres/dashboards/postgis.json`
+from the exported catalog. Review and approve the dashboard before continuing.
+
+### 16. Stop and uninstall
+
+```bash
+$EDB postgres stop
+$EDB postgres uninstall
+```
+
+---
+
+## Run 4: TimescaleDB extension
+
+### 17. Install and start with timescaledb
+
+```bash
+$EDB kit install postgres --version 17 --instances 1 --size 100Gi
+$EDB postgres start --extension timescaledb
+```
+
+### 18. Verify metrics are flowing
+
+```bash
+CONTROL_IP=$($EDB ip control0 --private)
+DEADLINE=$((SECONDS + 180))
+until [ $SECONDS -ge $DEADLINE ]; do
+    METRIC_COUNT=$(curl -sf "http://${CONTROL_IP}:8428/api/v1/series" \
+        --data-urlencode 'match[]={job="postgres"}' 2>/dev/null | jq '.data | length' 2>/dev/null || echo 0)
+    echo "$(date +%H:%M:%S) metric series: ${METRIC_COUNT}"
+    [ "${METRIC_COUNT:-0}" -ge 10 ] && break
+    sleep 15
+done
+[ "${METRIC_COUNT:-0}" -ge 10 ] || { echo "ERROR: expected ≥10 metric series, got ${METRIC_COUNT:-0}"; exit 1; }
+echo "VictoriaMetrics has ${METRIC_COUNT} PostgreSQL metric series ✓"
+```
+
+### 19. Export metrics catalog
+
+```bash
+(cd "$CLUSTER_DIR" && bin/export-workload-metrics postgres)
+cp "$CLUSTER_DIR/postgres/metrics-catalog.json" \
+   src/main/resources/com/rustyrazorblade/easydblab/kits/postgres/metrics-catalog-timescaledb.json
+```
+
+### 20. PAUSE — author timescaledb dashboard
+
+**Stop here.** Claude will author `src/main/resources/com/rustyrazorblade/easydblab/kits/postgres/dashboards/timescaledb.json`
+from the exported catalog. Review and approve the dashboard before continuing.
+
+### 21. Stop and uninstall
+
+```bash
+$EDB postgres stop
+$EDB postgres uninstall
+```
+
+---
+
+## Tear down
+
+### 22. Destroy cluster
+
+```bash
+$EDB down --auto-approve
+```
+
+## Notes
+
+- CNPG pods may take 2–3 minutes to reach Ready after `postgres start`. The kit waits automatically.
+- Extension images (duckdb, postgis, timescaledb) are pulled on first use — may add a few minutes to pod startup.
+- Each uninstall removes PVs and the CNPG operator Helm release, giving the next run a clean slate.
+- Dashboard authoring (pause steps) happens after catalog export. Claude reads the catalog and writes the dashboard JSON; user approves before proceeding.
+- AWS profile: `sandbox-admin`


### PR DESCRIPTION
Closes #667

## Summary

- New `postgres` kit deploying PostgreSQL via the CloudNativePG (CNPG) operator on K8s db nodes
- `postgres sql` command for interactive SQL execution via JDBC (PostgreSQL driver auto-registers, no `driver-class` needed)
- Presto integration: `postgres` catalog automatically injected when both kits are running (`connector.name=postgresql` pointing at `postgres-rw.default.svc.cluster.local:5432`)
- `org.postgresql:postgresql` JDBC driver added as a runtime dependency
- Fixes `--version` flag conflict in `KitInstallCommandFactory` — replaced `mixinStandardHelpOptions(true)` with a manual `--help` option so kit args can use `--version` without clashing with PicoCLI's built-in flag
- Renames ClickHouse `--clickhouse-version` arg to `--version` for consistency

## Kit args

| Flag | Default | Description |
|------|---------|-------------|
| `--version` | `17` | PostgreSQL major version |
| `--instances` | `1` | Instance count (>1 enables CNPG replication) |
| `--size` | `10Ti` | Storage per node |

## NodePorts

| Port | Service |
|------|---------|
| 30432 | PostgreSQL |
| 30987 | Metrics (CNPG exporter) |