### PR TITLE
feat: add Apache Ignite 3 kit (ignite3)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -211,6 +211,7 @@ dependencies {
     implementation(libs.clickhouse.jdbc)
     implementation(libs.mysql.connector.j)
     implementation(libs.postgresql.jdbc)
+    implementation(libs.ignite3.jdbc)
 
     // Testing — shared across BOTH tiers (unit `test` + `integrationTest`). The
     // integrationTest source set inherits these via `extendsFrom(testImplementation)`

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -18,6 +18,7 @@
   - [ClickHouse](user-guide/clickhouse.md)
     - [Backup & Restore](user-guide/clickhouse-backup-restore.md)
   - [Kafka](user-guide/kafka.md)
+  - [Apache Ignite 3](user-guide/ignite3.md)
   - [Presto](user-guide/install-presto.md)
   - [Trino](user-guide/install-trino.md)
   - [TiDB](user-guide/tidb.md)

--- a/docs/user-guide/ignite3.md
+++ b/docs/user-guide/ignite3.md
@@ -1,0 +1,87 @@
+# Apache Ignite 3
+
+easy-db-lab supports deploying Apache Ignite 3 clusters on Kubernetes for distributed SQL and in-memory computing workloads.
+
+## Overview
+
+Apache Ignite 3 is a distributed database with ACID transactions, distributed SQL, and a pluggable storage engine. It runs as a StatefulSet on K3s with configurable storage profiles ranging from pure in-memory to fully disk-backed persistence.
+
+Metrics are automatically pushed to the cluster's OTel Collector via OTLP and appear in Grafana.
+
+## Quick Start
+
+```bash
+# Initialize and start a 3-node cluster
+easy-db-lab init my-cluster --db 3 --up
+
+# Install and start Ignite 3 with default settings
+easy-db-lab kit install ignite3
+easy-db-lab ignite3 start
+```
+
+## Configuration Options
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--replicas` | Number of Ignite server nodes | db node count |
+| `--storage` | Storage profile (see below) | `aipersist` |
+| `--version` | Apache Ignite 3 Docker image version | `3.0.0` |
+
+## Storage Profiles
+
+Ignite 3 supports three storage engines, selectable at start time:
+
+| Profile | Description | Data survives restart? |
+|---------|-------------|----------------------|
+| `aimem` | Pure in-memory, volatile | No |
+| `aipersist` | In-memory with disk persistence (default) | Yes |
+| `rocksdb` | Disk-based LSM, suited for large datasets | Yes |
+
+```bash
+# Start with pure in-memory storage (fastest, no persistence)
+easy-db-lab ignite3 start --storage aimem
+
+# Start with disk-based storage for large datasets
+easy-db-lab ignite3 start --storage rocksdb
+```
+
+## SQL Queries
+
+Run SQL directly against the cluster using the thin client JDBC driver:
+
+```bash
+# Execute a SQL statement
+easy-db-lab ignite3 sql "CREATE TABLE t1 (id INT PRIMARY KEY, val VARCHAR)"
+easy-db-lab ignite3 sql "INSERT INTO t1 VALUES (1, 'hello')"
+easy-db-lab ignite3 sql "SELECT * FROM t1"
+
+# Execute SQL from a file
+easy-db-lab ignite3 sql --file query.sql
+```
+
+## Lifecycle
+
+```bash
+# Start the cluster
+easy-db-lab ignite3 start
+
+# Stop (preserves PVCs and data for aipersist/rocksdb profiles)
+easy-db-lab ignite3 stop
+
+# Start again — existing data is available immediately
+easy-db-lab ignite3 start
+
+# Remove all resources including data
+easy-db-lab kit uninstall ignite3
+```
+
+## Endpoints
+
+| Name | Port | Protocol |
+|------|------|----------|
+| REST / Management | 30300 | HTTP |
+| Thin Client / JDBC | 30800 | TCP |
+
+## Metrics
+
+Ignite 3 metrics are pushed to the cluster's OTel Collector via OTLP automatically at start time. No additional configuration is needed. Metrics appear in VictoriaMetrics and are accessible from Grafana.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -69,6 +69,7 @@ trino-jdbc = "474"
 clickhouse-jdbc = "0.7.2"
 mysql-connector-j = "9.3.0"
 postgresql-jdbc = "42.7.4"
+ignite3 = "3.1.0"
 resilience4j = "2.4.0"
 fabric8-kubernetes = "7.5.0"
 
@@ -192,6 +193,7 @@ trino-jdbc = { module = "io.trino:trino-jdbc", version.ref = "trino-jdbc" }
 clickhouse-jdbc = { module = "com.clickhouse:clickhouse-jdbc", version.ref = "clickhouse-jdbc" }
 mysql-connector-j = { module = "com.mysql:mysql-connector-j", version.ref = "mysql-connector-j" }
 postgresql-jdbc = { module = "org.postgresql:postgresql", version.ref = "postgresql-jdbc" }
+ignite3-jdbc = { module = "org.apache.ignite:ignite-jdbc", version.ref = "ignite3" }
 
 
 [bundles]

--- a/openspec/changes/add-ignite3-kit/.openspec.yaml
+++ b/openspec/changes/add-ignite3-kit/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-03

--- a/openspec/changes/add-ignite3-kit/design.md
+++ b/openspec/changes/add-ignite3-kit/design.md
@@ -1,0 +1,69 @@
+## Context
+
+easy-db-lab's kit system deploys workloads onto K8s clusters using a declarative `kit.yaml`. Two patterns exist: operator-based (ClickHouse via Altinity) and Helm-based (Presto). Apache Ignite 3 ships no official operator or Helm chart — its documented K8s deployment is raw manifests: a ConfigMap, a headless Service, a StatefulSet, an optional NodePort Service, and a one-time cluster-init Job.
+
+The cluster already runs an OTel Collector that accepts OTLP pushes. Ignite 3 has a built-in OTLP metrics exporter, making instrumentation trivial without sidecars.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Deploy a multi-node Ignite 3 cluster on `db` nodes via raw K8s manifests
+- Support three storage profiles (`aimem`, `aipersist`, `rocksdb`) selectable at start time
+- Push metrics to the cluster's OTel Collector via OTLP
+- Expose SQL via the `sql` capability (thin client JDBC on port 10800)
+- Add Gradle dependency for the Ignite 3 thin client JDBC driver
+
+**Non-Goals:**
+- Cassandra Storage SPI integration (Ignite 2 only, not available in Ignite 3)
+- Ignite 2.x support (tracked separately as a future kit)
+- Compute grid or streaming APIs (not needed for initial persistence testing)
+- TLS/auth configuration (lab clusters, not production)
+
+## Decisions
+
+### Raw K8s manifests over Helm / operator
+
+**Decision:** Use templated YAML manifests (`.yaml.template`) loaded via `TemplateService`, consistent with the ClickHouse kit's non-operator resources.
+
+**Rationale:** Ignite 3 has no official Helm chart or K8s operator. Raw manifests are the documented upstream approach and give full control over resource shape. The kit system already handles templated manifests cleanly.
+
+**Alternative considered:** Build a Helm chart from scratch — adds maintenance burden with no benefit since we control the templates directly.
+
+### Cluster Init Job as a shell step
+
+**Decision:** After the StatefulSet pods are Ready, run a K8s Job (templated manifest) that executes `ignite3 cluster init --name=ignite --url=http://ignite-svc-headless:10300`. The shell step waits for Job completion before proceeding.
+
+**Rationale:** Ignite 3 requires a one-time initialization call before the cluster is usable. A Job is idiomatic K8s for one-shot tasks and keeps the init logic inside the cluster (no local CLI required, consistent with `RemoteOperationsService` patterns).
+
+**Alternative considered:** REST call from the shell step — requires `curl` and is less robust than a Job with restart semantics.
+
+### OTLP push for metrics
+
+**Decision:** Configure Ignite's built-in OTLP exporter to push to `http://${CONTROL_HOST_PRIVATE}:4318/v1/metrics` via a REST call after cluster init. No `metrics:` block in `kit.yaml`.
+
+**Rationale:** Ignite 3 does not expose a Prometheus scrape endpoint. Its native OTLP support is a first-class exporter. The OTel Collector on the control node already has an OTLP HTTP receiver. This avoids a JMX sidecar entirely.
+
+**Alternative considered:** JMX exporter sidecar — requires an extra container, an extra port, and a scrape config registration. OTLP push is strictly simpler.
+
+### Storage profile as a `--storage` arg
+
+**Decision:** Accept `--storage` with values `aimem`, `aipersist` (default), `rocksdb`. The value is injected into the ConfigMap template as `__STORAGE_PROFILE__` and selects the storage profile in `ignite-config.conf`.
+
+**Rationale:** The primary use case is persistence testing, so `aipersist` is the right default. Exposing all three lets users choose the tradeoff (speed vs durability vs capacity) without changing the kit.
+
+### Ignite 3 thin client JDBC driver for SQL capability
+
+**Decision:** Add `org.apache.ignite:ignite-client` (the Ignite 3 thin client, which includes JDBC) to the Gradle dependencies. Register the `sql` capability in `kit.yaml` pointing to the thin client JDBC endpoint on port 10800.
+
+**Rationale:** The `sql` capability system already handles JDBC with a `driver-class` field for drivers that don't auto-register. The Ignite thin client driver class is `org.apache.ignite.jdbc.IgniteJdbcDriver`.
+
+## Risks / Trade-offs
+
+- **Cluster init idempotency**: If the start script is run twice without a stop, the init Job will attempt to re-initialize. Mitigation: shell step checks if the cluster is already initialized before running the Job, or the Job is made idempotent via a check.
+- **OTLP endpoint timing**: The OTLP exporter is configured via REST after init. If the OTel Collector on the control node isn't reachable at that moment, metrics will not flow. Mitigation: the OTel Collector is a cluster-level service that starts before any kit, so this should not occur in practice.
+- **Ignite 3 image versioning**: The `apache/ignite3` Docker image tag must be pinned or defaulted. Using `latest` risks non-reproducible deployments. A `--version` arg should be added.
+- **PVC cleanup**: `aipersist` and `rocksdb` create PersistentVolumeClaims. The `stop` step must not delete PVCs (to preserve data), but `uninstall` must. The ClickHouse kit handles this via `platform-pvs-delete` — the same pattern applies here.
+
+## Open Questions
+
+(none — all decisions resolved)

--- a/openspec/changes/add-ignite3-kit/proposal.md
+++ b/openspec/changes/add-ignite3-kit/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+easy-db-lab supports ClickHouse and Presto as query/analytics workloads, but has no in-memory distributed database option. Apache Ignite 3 fills that gap: it is a distributed SQL + key-value platform with native persistence and OTLP metrics, making it a natural fit for the lab's observability stack.
+
+## What Changes
+
+- Add a new `ignite3` kit that deploys an Apache Ignite 3 cluster on `db` nodes using raw K8s manifests (StatefulSet + Services + ConfigMap + Init Job)
+- The kit exposes a `--storage` arg with three profiles: `aimem` (volatile), `aipersist` (default, in-memory + disk persistence), `rocksdb` (disk-based LSM)
+- The kit exposes a `--replicas` arg defaulting to `${DB_NODE_COUNT}`
+- Metrics are pushed from Ignite pods to the cluster's OTel Collector via OTLP (`http/protobuf`), configured via Ignite's REST API after cluster init
+- SQL capability is registered via the `sql` capability block using the Ignite thin client JDBC driver on port 10800
+- A documentation page is added for the `ignite3` kit
+
+## Capabilities
+
+### New Capabilities
+
+- `ignite3`: Deploy, configure, start, stop, and uninstall an Apache Ignite 3 cluster; expose SQL via thin client JDBC; push metrics to the OTel Collector via OTLP
+
+### Modified Capabilities
+
+(none)
+
+## Impact
+
+- New kit resource directory: `src/main/resources/com/rustyrazorblade/easydblab/kits/ignite3/`
+- New spec: `openspec/specs/ignite3/spec.md`
+- New doc page: `docs/` for the ignite3 kit
+- No changes to existing Kotlin code — the kit uses only the existing kit runner, manifest, shell, and capability infrastructure
+- Requires the Ignite 3 thin client JDBC driver to be on the classpath (new Gradle dependency)

--- a/openspec/changes/add-ignite3-kit/specs/ignite3/spec.md
+++ b/openspec/changes/add-ignite3-kit/specs/ignite3/spec.md
@@ -1,0 +1,110 @@
+# Ignite 3
+
+Manages Apache Ignite 3 deployment on K3s with configurable storage profiles and OTLP metrics integration.
+
+## ADDED Requirements
+
+### Requirement: Kit Lifecycle
+
+The system MUST support installing, starting, stopping, and uninstalling Ignite 3 via the kit mechanism.
+
+#### Scenario: Start deploys Ignite 3 cluster
+
+- **WHEN** the user runs `ignite3 start`
+- **THEN** a ConfigMap, headless Service, and StatefulSet are applied to the cluster, pods reach Ready state, a cluster-init Job runs, OTLP metrics are configured, and a NodePort Service is exposed
+
+#### Scenario: Stop removes runtime resources but preserves data
+
+- **WHEN** the user runs `ignite3 stop`
+- **THEN** the StatefulSet, NodePort Service, and cluster-init Job are deleted, but PersistentVolumeClaims are retained
+
+#### Scenario: Start after stop resumes data
+
+- **WHEN** data is written to Ignite 3, `ignite3 stop` is run, and `ignite3 start` is run again
+- **THEN** the previously written data is accessible without any restore step (for `aipersist` and `rocksdb` profiles)
+
+#### Scenario: Uninstall removes all resources including data
+
+- **WHEN** the user runs `kit uninstall ignite3`
+- **THEN** the StatefulSet, Services, ConfigMap, PersistentVolumeClaims, and headless Service are all deleted
+
+### Requirement: Storage Profile Selection
+
+The kit SHALL support three storage profiles selectable at start time via `--storage`.
+
+#### Scenario: Default storage is aipersist
+
+- **WHEN** the user runs `ignite3 start` without a `--storage` flag
+- **THEN** the cluster starts with the `aipersist` profile (in-memory data, disk-persisted on checkpoint)
+
+#### Scenario: aimem profile runs with volatile in-memory storage
+
+- **WHEN** the user runs `ignite3 start --storage aimem`
+- **THEN** the cluster uses pure in-memory storage; data does not survive pod restarts
+
+#### Scenario: rocksdb profile runs with disk-based LSM storage
+
+- **WHEN** the user runs `ignite3 start --storage rocksdb`
+- **THEN** the cluster uses RocksDB-backed disk storage suitable for datasets larger than available RAM
+
+#### Scenario: Invalid storage value is rejected
+
+- **WHEN** the user supplies an unrecognized value for `--storage`
+- **THEN** an error is emitted before any resources are applied
+
+### Requirement: Cluster Initialization
+
+The kit MUST run a one-time cluster initialization step after the StatefulSet pods are Ready.
+
+#### Scenario: Init Job bootstraps the cluster
+
+- **WHEN** Ignite 3 pods reach Ready state during `ignite3 start`
+- **THEN** a K8s Job runs `ignite3 cluster init --name=ignite --url=http://ignite-svc-headless:10300` and completes successfully before the NodePort Service is applied
+
+#### Scenario: Start fails if init Job fails
+
+- **WHEN** the cluster-init Job exits with a non-zero status
+- **THEN** `ignite3 start` fails with an error before proceeding to NodePort Service creation
+
+### Requirement: OTLP Metrics
+
+The kit SHALL configure Ignite 3 to push metrics to the cluster's OTel Collector via OTLP after cluster initialization.
+
+#### Scenario: Metrics exporter is configured at start
+
+- **WHEN** `ignite3 start` completes cluster initialization
+- **THEN** the system configures Ignite's OTLP exporter pointing to `http://${CONTROL_HOST_PRIVATE}:4318/v1/metrics` using the `http/protobuf` protocol
+
+#### Scenario: Metrics flow into VictoriaMetrics
+
+- **WHEN** the OTLP exporter is configured and Ignite is running
+- **THEN** Ignite metrics appear in VictoriaMetrics and are visible in Grafana
+
+### Requirement: SQL Execution
+
+The `ignite3 sql` command SHALL execute SQL statements against a running Ignite 3 cluster via the thin client JDBC driver.
+SQL execution is provided via the `sql` capability declared in `ignite3/kit.yaml` — see REQ-KCAP-002.
+
+#### Scenario: SQL query executes successfully
+
+- **WHEN** the user runs `ignite3 sql "SELECT * FROM my_table"`
+- **THEN** the query is submitted via JDBC on port 10800 and results are displayed in tabular format
+
+#### Scenario: No db nodes causes early error
+
+- **WHEN** no db nodes exist in cluster state
+- **THEN** an error is emitted before any JDBC connection is attempted
+
+### Requirement: Replica Count
+
+The kit SHALL support configuring the number of Ignite server nodes via `--replicas`.
+
+#### Scenario: Default replica count matches db node count
+
+- **WHEN** the user runs `ignite3 start` without `--replicas`
+- **THEN** the StatefulSet replica count equals `DB_NODE_COUNT`
+
+#### Scenario: Custom replica count is applied
+
+- **WHEN** the user runs `ignite3 start --replicas 3`
+- **THEN** the StatefulSet is created with 3 replicas

--- a/openspec/changes/add-ignite3-kit/tasks.md
+++ b/openspec/changes/add-ignite3-kit/tasks.md
@@ -1,0 +1,48 @@
+## 1. Gradle Dependency
+
+- [x] 1.1 Add the Apache Ignite 3 thin client dependency (`org.apache.ignite:ignite-client`) to `build.gradle.kts`
+- [x] 1.2 Verify the Ignite JDBC driver class (`org.apache.ignite.jdbc.IgniteJdbcDriver`) is resolvable at runtime after adding the dependency
+
+## 2. Kit YAML
+
+- [x] 2.1 Create `src/main/resources/com/rustyrazorblade/easydblab/kits/ignite3/kit.yaml` with:
+  - `name: ignite3`, `type: db`
+  - `--replicas` arg (default `${DB_NODE_COUNT}`)
+  - `--storage` arg (values: `aimem`, `aipersist`, `rocksdb`; default `aipersist`)
+  - `--version` arg for the Ignite 3 Docker image tag (default: `3.0.0`)
+  - Endpoints for REST (port 10300) and JDBC (port 10800)
+  - `sql` capability with `driver-class: org.apache.ignite.jdbc.IgniteJdbcDriver`
+  - `start`, `stop`, and `uninstall` step sequences
+
+## 3. K8s Manifest Templates
+
+- [x] 3.1 Create `configmap.yaml.template` — Ignite `ignite-config.conf` with storage profile (`__STORAGE_PROFILE__`), network discovery via headless service, and node name from pod metadata
+- [x] 3.2 Create `statefulset.yaml.template` — StatefulSet with `__REPLICAS__` replicas, `apache/ignite3:__VERSION__` image (default `3.1.0`), PVC for persistence, env vars for `IGNITE_NODE_NAME` and `IGNITE_WORK_DIR`, ports 10300 / 10800 / 3344
+- [x] 3.3 Create `services.yaml.template` — headless Service (`ignite-svc-headless`, ClusterIP: None, port 3344) for pod discovery
+- [x] 3.4 Create `nodeport-service.yaml.template` — NodePort Service exposing port 10300 (REST) and 10800 (thin client) on db node ports
+- [x] 3.5 Create `cluster-init-job.yaml.template` — K8s Job that runs `ignite3 cluster init --name=ignite --url=http://ignite-svc-headless:10300`
+
+## 4. Start / Stop / Uninstall Sequences in kit.yaml
+
+- [x] 4.1 Wire the `start` sequence: apply ConfigMap → apply headless Service + StatefulSet → wait for pods Ready → apply cluster-init Job → wait for Job completion → configure OTLP via REST → apply NodePort Service
+- [x] 4.2 Wire the `stop` sequence: delete StatefulSet → delete NodePort Service → delete cluster-init Job (PVCs retained)
+- [x] 4.3 Wire the `uninstall` sequence: delete headless Service → delete ConfigMap → delete PVCs (platform-pvs-delete)
+- [x] 4.4 Add shell step to configure OTLP exporter after cluster init:
+  ```bash
+  curl -s -X PATCH http://localhost:10300/management/v1/configuration/cluster \
+    -H 'Content-Type: application/json' \
+    -d '{"ignite":{"metrics":{"exporters":{"otel":{"exporterName":"otlp","endpoint":"http://${CONTROL_HOST_PRIVATE}:4318/v1/metrics","protocol":"http/protobuf"}}}}}'
+  ```
+
+## 5. OpenSpec Spec File
+
+- [x] 5.1 Move `openspec/changes/add-ignite3-kit/specs/ignite3/spec.md` to `openspec/specs/ignite3/spec.md` as the canonical spec location
+
+## 6. Documentation
+
+- [x] 6.1 Add a documentation page for the `ignite3` kit in `docs/` covering: what Ignite 3 is, how to install/start/stop/uninstall, storage profile options, and the SQL capability
+- [x] 6.2 Add `ignite3` to the kit navigation in `docs/SUMMARY.md` (or equivalent)
+
+## 7. GitHub Issue
+
+- [ ] 7.1 Update issue #668 body with the clarified scope (Ignite 3 only, ignite2 tracked separately) — needs manual gh permission

--- a/openspec/specs/ignite3/spec.md
+++ b/openspec/specs/ignite3/spec.md
@@ -1,0 +1,110 @@
+# Ignite 3
+
+Manages Apache Ignite 3 deployment on K3s with configurable storage profiles and OTLP metrics integration.
+
+## ADDED Requirements
+
+### Requirement: Kit Lifecycle
+
+The system MUST support installing, starting, stopping, and uninstalling Ignite 3 via the kit mechanism.
+
+#### Scenario: Start deploys Ignite 3 cluster
+
+- **WHEN** the user runs `ignite3 start`
+- **THEN** a ConfigMap, headless Service, and StatefulSet are applied to the cluster, pods reach Ready state, a cluster-init Job runs, OTLP metrics are configured, and a NodePort Service is exposed
+
+#### Scenario: Stop removes runtime resources but preserves data
+
+- **WHEN** the user runs `ignite3 stop`
+- **THEN** the StatefulSet, NodePort Service, and cluster-init Job are deleted, but PersistentVolumeClaims are retained
+
+#### Scenario: Start after stop resumes data
+
+- **WHEN** data is written to Ignite 3, `ignite3 stop` is run, and `ignite3 start` is run again
+- **THEN** the previously written data is accessible without any restore step (for `aipersist` and `rocksdb` profiles)
+
+#### Scenario: Uninstall removes all resources including data
+
+- **WHEN** the user runs `kit uninstall ignite3`
+- **THEN** the StatefulSet, Services, ConfigMap, PersistentVolumeClaims, and headless Service are all deleted
+
+### Requirement: Storage Profile Selection
+
+The kit SHALL support three storage profiles selectable at start time via `--storage`.
+
+#### Scenario: Default storage is aipersist
+
+- **WHEN** the user runs `ignite3 start` without a `--storage` flag
+- **THEN** the cluster starts with the `aipersist` profile (in-memory data, disk-persisted on checkpoint)
+
+#### Scenario: aimem profile runs with volatile in-memory storage
+
+- **WHEN** the user runs `ignite3 start --storage aimem`
+- **THEN** the cluster uses pure in-memory storage; data does not survive pod restarts
+
+#### Scenario: rocksdb profile runs with disk-based LSM storage
+
+- **WHEN** the user runs `ignite3 start --storage rocksdb`
+- **THEN** the cluster uses RocksDB-backed disk storage suitable for datasets larger than available RAM
+
+#### Scenario: Invalid storage value is rejected
+
+- **WHEN** the user supplies an unrecognized value for `--storage`
+- **THEN** an error is emitted before any resources are applied
+
+### Requirement: Cluster Initialization
+
+The kit MUST run a one-time cluster initialization step after the StatefulSet pods are Ready.
+
+#### Scenario: Init Job bootstraps the cluster
+
+- **WHEN** Ignite 3 pods reach Ready state during `ignite3 start`
+- **THEN** a K8s Job runs `ignite3 cluster init --name=ignite --url=http://ignite-svc-headless:10300` and completes successfully before the NodePort Service is applied
+
+#### Scenario: Start fails if init Job fails
+
+- **WHEN** the cluster-init Job exits with a non-zero status
+- **THEN** `ignite3 start` fails with an error before proceeding to NodePort Service creation
+
+### Requirement: OTLP Metrics
+
+The kit SHALL configure Ignite 3 to push metrics to the cluster's OTel Collector via OTLP after cluster initialization.
+
+#### Scenario: Metrics exporter is configured at start
+
+- **WHEN** `ignite3 start` completes cluster initialization
+- **THEN** the system configures Ignite's OTLP exporter pointing to `http://${CONTROL_HOST_PRIVATE}:4318/v1/metrics` using the `http/protobuf` protocol
+
+#### Scenario: Metrics flow into VictoriaMetrics
+
+- **WHEN** the OTLP exporter is configured and Ignite is running
+- **THEN** Ignite metrics appear in VictoriaMetrics and are visible in Grafana
+
+### Requirement: SQL Execution
+
+The `ignite3 sql` command SHALL execute SQL statements against a running Ignite 3 cluster via the thin client JDBC driver.
+SQL execution is provided via the `sql` capability declared in `ignite3/kit.yaml` — see REQ-KCAP-002.
+
+#### Scenario: SQL query executes successfully
+
+- **WHEN** the user runs `ignite3 sql "SELECT * FROM my_table"`
+- **THEN** the query is submitted via JDBC on port 10800 and results are displayed in tabular format
+
+#### Scenario: No db nodes causes early error
+
+- **WHEN** no db nodes exist in cluster state
+- **THEN** an error is emitted before any JDBC connection is attempted
+
+### Requirement: Replica Count
+
+The kit SHALL support configuring the number of Ignite server nodes via `--replicas`.
+
+#### Scenario: Default replica count matches db node count
+
+- **WHEN** the user runs `ignite3 start` without `--replicas`
+- **THEN** the StatefulSet replica count equals `DB_NODE_COUNT`
+
+#### Scenario: Custom replica count is applied
+
+- **WHEN** the user runs `ignite3 start --replicas 3`
+- **THEN** the StatefulSet is created with 3 replicas

--- a/src/main/resources/com/rustyrazorblade/easydblab/kits/ignite3/cluster-init-job.yaml.template
+++ b/src/main/resources/com/rustyrazorblade/easydblab/kits/ignite3/cluster-init-job.yaml.template
@@ -12,8 +12,8 @@ spec:
       terminationGracePeriodSeconds: 120
       containers:
         - name: cluster-init
-          # The apache/ignite3 image includes the Ignite 3 CLI at /opt/ignite3cli/bin/ignite3
-          image: apache/ignite3:__IGNITE_VERSION__
+          # The apacheignite/ignite image includes the Ignite 3 CLI at /opt/ignite3cli/bin/ignite3
+          image: apacheignite/ignite:__IGNITE_VERSION__
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh

--- a/src/main/resources/com/rustyrazorblade/easydblab/kits/ignite3/cluster-init-job.yaml.template
+++ b/src/main/resources/com/rustyrazorblade/easydblab/kits/ignite3/cluster-init-job.yaml.template
@@ -1,0 +1,24 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: cluster-init
+  namespace: default
+spec:
+  backoffLimit: 0
+  activeDeadlineSeconds: 120
+  template:
+    spec:
+      restartPolicy: Never
+      terminationGracePeriodSeconds: 120
+      containers:
+        - name: cluster-init
+          # The apache/ignite3 image includes the Ignite 3 CLI at /opt/ignite3cli/bin/ignite3
+          image: apache/ignite3:__IGNITE_VERSION__
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              /opt/ignite3cli/bin/ignite3 cluster init \
+                --name=ignite \
+                --url=http://ignite-svc-headless:10300

--- a/src/main/resources/com/rustyrazorblade/easydblab/kits/ignite3/dashboards/ignite3.json
+++ b/src/main/resources/com/rustyrazorblade/easydblab/kits/ignite3/dashboards/ignite3.json
@@ -1,0 +1,178 @@
+{
+  "uid": "ignite3-kit",
+  "title": "Apache Ignite 3",
+  "tags": ["ignite3", "kit"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "editable": true,
+  "refresh": "30s",
+  "time": { "from": "now-30m", "to": "now" },
+  "templating": {
+    "list": [
+      {
+        "name": "cluster",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "VictoriaMetrics" },
+        "definition": "label_values(TotalNodes, cluster)",
+        "query": "label_values(TotalNodes, cluster)",
+        "refresh": 2,
+        "includeAll": false,
+        "multi": false,
+        "sort": 1
+      }
+    ]
+  },
+  "panels": [
+    { "type": "row", "title": "Cluster", "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 }, "collapsed": false },
+    {
+      "type": "stat", "title": "Nodes",
+      "datasource": { "type": "prometheus", "uid": "VictoriaMetrics" },
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 1 },
+      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "steps": [ { "color": "red", "value": null }, { "color": "green", "value": 1 } ] } } },
+      "targets": [ { "expr": "max(TotalNodes{cluster=~\"$cluster\", otel_scope_name=\"topology.cluster\"})", "refId": "A" } ]
+    },
+    {
+      "type": "stat", "title": "Healthy partitions",
+      "datasource": { "type": "prometheus", "uid": "VictoriaMetrics" },
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 1 },
+      "fieldConfig": { "defaults": { "color": { "mode": "fixed", "fixedColor": "green" } } },
+      "targets": [ { "expr": "sum(HealthyPartitionCount{cluster=~\"$cluster\", otel_scope_name=~\"partition.states.*\"})", "refId": "A" } ]
+    },
+    {
+      "type": "stat", "title": "Broken partitions",
+      "datasource": { "type": "prometheus", "uid": "VictoriaMetrics" },
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 1 },
+      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "steps": [ { "color": "green", "value": null }, { "color": "red", "value": 1 } ] } } },
+      "targets": [ { "expr": "sum(BrokenPartitionCount{cluster=~\"$cluster\", otel_scope_name=~\"partition.states.*\"})", "refId": "A" } ]
+    },
+    {
+      "type": "stat", "title": "Unavailable partitions",
+      "datasource": { "type": "prometheus", "uid": "VictoriaMetrics" },
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 1 },
+      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "steps": [ { "color": "green", "value": null }, { "color": "red", "value": 1 } ] } } },
+      "targets": [ { "expr": "sum(UnavailablePartitionCount{cluster=~\"$cluster\", otel_scope_name=~\"partition.states.*\"})", "refId": "A" } ]
+    },
+
+    { "type": "row", "title": "SQL", "gridPos": { "h": 1, "w": 24, "x": 0, "y": 5 }, "collapsed": false },
+    {
+      "type": "timeseries", "title": "SQL query outcomes (rate)",
+      "datasource": { "type": "prometheus", "uid": "VictoriaMetrics" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
+      "targets": [
+        { "expr": "sum(rate(Succeeded{cluster=~\"$cluster\", otel_scope_name=\"sql.queries\"}[$__rate_interval]))", "legendFormat": "succeeded", "refId": "A" },
+        { "expr": "sum(rate(Failed{cluster=~\"$cluster\", otel_scope_name=\"sql.queries\"}[$__rate_interval]))", "legendFormat": "failed", "refId": "B" },
+        { "expr": "sum(rate(Canceled{cluster=~\"$cluster\", otel_scope_name=\"sql.queries\"}[$__rate_interval]))", "legendFormat": "canceled", "refId": "C" },
+        { "expr": "sum(rate(TimedOut{cluster=~\"$cluster\", otel_scope_name=\"sql.queries\"}[$__rate_interval]))", "legendFormat": "timed out", "refId": "D" }
+      ]
+    },
+    {
+      "type": "timeseries", "title": "SQL plan cache (rate)",
+      "datasource": { "type": "prometheus", "uid": "VictoriaMetrics" },
+      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 6 },
+      "targets": [
+        { "expr": "sum(rate(Hits{cluster=~\"$cluster\", otel_scope_name=\"sql.plan.cache\"}[$__rate_interval]))", "legendFormat": "hits", "refId": "A" },
+        { "expr": "sum(rate(Misses{cluster=~\"$cluster\", otel_scope_name=\"sql.plan.cache\"}[$__rate_interval]))", "legendFormat": "misses", "refId": "B" }
+      ]
+    },
+    {
+      "type": "timeseries", "title": "Open cursors",
+      "datasource": { "type": "prometheus", "uid": "VictoriaMetrics" },
+      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 6 },
+      "targets": [ { "expr": "sum(OpenCursors{cluster=~\"$cluster\", otel_scope_name=\"sql.client\"})", "legendFormat": "open cursors", "refId": "A" } ]
+    },
+
+    { "type": "row", "title": "Transactions", "gridPos": { "h": 1, "w": 24, "x": 0, "y": 14 }, "collapsed": false },
+    {
+      "type": "timeseries", "title": "Commits (rate)",
+      "datasource": { "type": "prometheus", "uid": "VictoriaMetrics" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 15 },
+      "targets": [
+        { "expr": "sum(rate(RwCommits{cluster=~\"$cluster\", otel_scope_name=\"transactions\"}[$__rate_interval]))", "legendFormat": "read-write", "refId": "A" },
+        { "expr": "sum(rate(RoCommits{cluster=~\"$cluster\", otel_scope_name=\"transactions\"}[$__rate_interval]))", "legendFormat": "read-only", "refId": "B" }
+      ]
+    },
+    {
+      "type": "timeseries", "title": "Rollbacks (rate)",
+      "datasource": { "type": "prometheus", "uid": "VictoriaMetrics" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 15 },
+      "targets": [
+        { "expr": "sum(rate(RwRollbacks{cluster=~\"$cluster\", otel_scope_name=\"transactions\"}[$__rate_interval]))", "legendFormat": "read-write", "refId": "A" },
+        { "expr": "sum(rate(RoRollbacks{cluster=~\"$cluster\", otel_scope_name=\"transactions\"}[$__rate_interval]))", "legendFormat": "read-only", "refId": "B" }
+      ]
+    },
+
+    { "type": "row", "title": "Client handler", "gridPos": { "h": 1, "w": 24, "x": 0, "y": 23 }, "collapsed": false },
+    {
+      "type": "timeseries", "title": "Sessions",
+      "datasource": { "type": "prometheus", "uid": "VictoriaMetrics" },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 24 },
+      "targets": [
+        { "expr": "sum(SessionsActive{cluster=~\"$cluster\", otel_scope_name=\"client.handler\"})", "legendFormat": "active", "refId": "A" },
+        { "expr": "sum(rate(SessionsAccepted{cluster=~\"$cluster\", otel_scope_name=\"client.handler\"}[$__rate_interval]))", "legendFormat": "accepted/s", "refId": "B" },
+        { "expr": "sum(rate(SessionsRejected{cluster=~\"$cluster\", otel_scope_name=\"client.handler\"}[$__rate_interval]))", "legendFormat": "rejected/s", "refId": "C" }
+      ]
+    },
+    {
+      "type": "timeseries", "title": "Requests",
+      "datasource": { "type": "prometheus", "uid": "VictoriaMetrics" },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 24 },
+      "targets": [
+        { "expr": "sum(RequestsActive{cluster=~\"$cluster\", otel_scope_name=\"client.handler\"})", "legendFormat": "active", "refId": "A" },
+        { "expr": "sum(rate(RequestsProcessed{cluster=~\"$cluster\", otel_scope_name=\"client.handler\"}[$__rate_interval]))", "legendFormat": "processed/s", "refId": "B" },
+        { "expr": "sum(rate(RequestsFailed{cluster=~\"$cluster\", otel_scope_name=\"client.handler\"}[$__rate_interval]))", "legendFormat": "failed/s", "refId": "C" }
+      ]
+    },
+    {
+      "type": "timeseries", "title": "Network bytes (rate)",
+      "datasource": { "type": "prometheus", "uid": "VictoriaMetrics" },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 24 },
+      "fieldConfig": { "defaults": { "unit": "Bps" } },
+      "targets": [
+        { "expr": "sum(rate(BytesReceived{cluster=~\"$cluster\", otel_scope_name=\"client.handler\"}[$__rate_interval]))", "legendFormat": "received", "refId": "A" },
+        { "expr": "sum(rate(BytesSent{cluster=~\"$cluster\", otel_scope_name=\"client.handler\"}[$__rate_interval]))", "legendFormat": "sent", "refId": "B" }
+      ]
+    },
+
+    { "type": "row", "title": "Storage (aipersist)", "gridPos": { "h": 1, "w": 24, "x": 0, "y": 32 }, "collapsed": false },
+    {
+      "type": "timeseries", "title": "Storage size by node",
+      "datasource": { "type": "prometheus", "uid": "VictoriaMetrics" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 33 },
+      "fieldConfig": { "defaults": { "unit": "bytes" } },
+      "targets": [
+        { "expr": "TotalUsedSize{cluster=~\"$cluster\", otel_scope_name=\"storage.aipersist.default\"}", "legendFormat": "used {{instance}}", "refId": "A" },
+        { "expr": "TotalAllocatedSize{cluster=~\"$cluster\", otel_scope_name=\"storage.aipersist.default\"}", "legendFormat": "allocated {{instance}}", "refId": "B" }
+      ]
+    },
+    {
+      "type": "timeseries", "title": "Checkpoint duration",
+      "datasource": { "type": "prometheus", "uid": "VictoriaMetrics" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 33 },
+      "fieldConfig": { "defaults": { "unit": "ms" } },
+      "targets": [
+        { "expr": "LastCheckpointDuration{cluster=~\"$cluster\", otel_scope_name=\"storage.aipersist.checkpoint\"}", "legendFormat": "total {{instance}}", "refId": "A" },
+        { "expr": "LastCheckpointFsyncDuration{cluster=~\"$cluster\", otel_scope_name=\"storage.aipersist.checkpoint\"}", "legendFormat": "fsync {{instance}}", "refId": "B" }
+      ]
+    },
+
+    { "type": "row", "title": "Thread pools", "gridPos": { "h": 1, "w": 24, "x": 0, "y": 41 }, "collapsed": false },
+    {
+      "type": "timeseries", "title": "Active threads by pool",
+      "datasource": { "type": "prometheus", "uid": "VictoriaMetrics" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 42 },
+      "targets": [
+        { "expr": "sum by (otel_scope_name) (ActiveCount{cluster=~\"$cluster\", otel_scope_name=~\"thread.pools.*\"})", "legendFormat": "{{otel_scope_name}}", "refId": "A" },
+        { "expr": "sum({__name__=~\"stripe_[0-9]+_ActiveCount\", cluster=~\"$cluster\", otel_scope_name=\"thread.pools.sql-executor\"})", "legendFormat": "thread.pools.sql-executor", "refId": "B" }
+      ]
+    },
+    {
+      "type": "timeseries", "title": "Queue size by pool",
+      "datasource": { "type": "prometheus", "uid": "VictoriaMetrics" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 42 },
+      "targets": [
+        { "expr": "sum by (otel_scope_name) (QueueSize{cluster=~\"$cluster\", otel_scope_name=~\"thread.pools.*\"})", "legendFormat": "{{otel_scope_name}}", "refId": "A" },
+        { "expr": "sum({__name__=~\"stripe_[0-9]+_QueueSize\", cluster=~\"$cluster\", otel_scope_name=\"thread.pools.sql-executor\"})", "legendFormat": "thread.pools.sql-executor", "refId": "B" }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/com/rustyrazorblade/easydblab/kits/ignite3/kit.yaml
+++ b/src/main/resources/com/rustyrazorblade/easydblab/kits/ignite3/kit.yaml
@@ -1,0 +1,139 @@
+name: ignite3
+type: db
+description: Apache Ignite 3 distributed database with configurable storage profiles
+version: "1.0.0"
+collision-check: true
+
+runtime:
+  type: pods
+  selector: "app=ignite"
+  namespace: default
+
+endpoints:
+  - name: "REST"
+    node-type: db
+    port: 30300
+    type: http
+  - name: "JDBC"
+    node-type: db
+    port: 30800
+    type: jdbc
+    scheme: "ignite:thin"
+
+args:
+  - flag: --replicas
+    variable: REPLICAS
+    description: "Number of Ignite 3 server nodes (default: db node count)"
+    type: int
+    default: "${DB_NODE_COUNT}"
+  - flag: --storage
+    variable: STORAGE_PROFILE
+    description: "Storage profile: aimem (volatile), aipersist (in-memory+disk), rocksdb (disk-based LSM)"
+    type: string
+    default: "aipersist"
+  - flag: --version
+    variable: IGNITE_VERSION
+    description: "Apache Ignite 3 Docker image version"
+    type: string
+    default: "3.1.0"
+
+start:
+  - type: shell
+    script: |
+      #!/usr/bin/env bash
+      set -euo pipefail
+      echo "Creating Ignite 3 ConfigMap..."
+      # Build comma-separated node address list for static IP finder
+      NODE_LIST=""
+      for i in $(seq 0 $((REPLICAS - 1))); do
+        NODE_LIST="${NODE_LIST}\"ignite-cluster-${i}.ignite-svc-headless.default.svc.cluster.local:3344\", "
+      done
+      NODE_LIST="${NODE_LIST%, }"
+      CONF_FILE=$(mktemp /tmp/ignite-config.XXXXXX.conf)
+      # printf avoids heredoc quoting issues and correctly embeds the node list
+      printf '{ network: { port: 3344, nodeFinder: { netClusterNodes: [%s] } }, storage: { profiles: [{ name: default, engine: %s }] } }' \
+        "${NODE_LIST}" "${STORAGE_PROFILE}" > "${CONF_FILE}"
+      kubectl create configmap ignite-config \
+        --namespace default \
+        --from-file=ignite-config.conf="${CONF_FILE}" \
+        --dry-run=client -o yaml | kubectl apply -f -
+      rm -f "${CONF_FILE}"
+      echo "ConfigMap created."
+
+  - type: manifest
+    template: services.yaml
+
+  - type: manifest
+    template: statefulset.yaml
+
+  - type: shell
+    script: |
+      #!/usr/bin/env bash
+      set -euo pipefail
+      echo "Waiting for Ignite 3 pods to be created..."
+      until kubectl get pods -l app=ignite -n default --no-headers 2>/dev/null | grep -q .; do sleep 5; done
+      echo "Pods found, waiting for Ready..."
+      kubectl wait --for=condition=Ready pods \
+        -l app=ignite \
+        --namespace default \
+        --timeout=300s
+
+  - type: manifest
+    template: cluster-init-job.yaml
+
+  - type: wait
+    kind: job
+    name: cluster-init
+    condition: Complete
+    namespace: default
+    timeout: 120s
+
+  - type: manifest
+    template: nodeport-service.yaml
+
+  - type: shell
+    script: |
+      #!/usr/bin/env bash
+      set -euo pipefail
+      echo "Configuring OTLP metrics exporter..."
+      # NodePort 30300 is reachable from the local machine via Tailscale private IP
+      curl -s -f -X PATCH "http://${CONTROL_HOST_PRIVATE}:30300/management/v1/configuration/cluster" \
+        -H "Content-Type: application/json" \
+        -d "{\"ignite\":{\"metrics\":{\"exporters\":{\"otel\":{\"exporterName\":\"otlp\",\"endpoint\":\"http://${CONTROL_HOST_PRIVATE}:4318/v1/metrics\",\"protocol\":\"http/protobuf\"}}}}}"
+      echo "OTLP metrics configured."
+
+stop:
+  - type: delete
+    kind: StatefulSet
+    name: ignite-cluster
+    namespace: default
+  - type: delete
+    kind: Service
+    name: ignite-nodeport
+    namespace: default
+  - type: delete
+    kind: Job
+    name: cluster-init
+    namespace: default
+  - type: delete
+    kind: ConfigMap
+    name: ignite-config
+    namespace: default
+
+uninstall:
+  - type: delete
+    kind: Service
+    name: ignite-svc-headless
+    namespace: default
+  - type: shell
+    script: |
+      #!/usr/bin/env bash
+      set -euo pipefail
+      echo "Deleting Ignite 3 PersistentVolumeClaims..."
+      kubectl delete pvc -l app=ignite --namespace default --ignore-not-found=true
+      echo "PVCs deleted."
+
+capabilities:
+  - type: sql
+    user: ""
+    driver-class: org.apache.ignite.jdbc.IgniteJdbcDriver

--- a/src/main/resources/com/rustyrazorblade/easydblab/kits/ignite3/kit.yaml
+++ b/src/main/resources/com/rustyrazorblade/easydblab/kits/ignite3/kit.yaml
@@ -56,8 +56,11 @@ start:
       # Clean up even if a later command fails before the explicit rm, so a
       # leftover temp file never blocks a subsequent run.
       trap 'rm -f "${CONF_FILE}"' EXIT
-      # printf avoids heredoc quoting issues and correctly embeds the node list
-      printf '{ network: { port: 3344, nodeFinder: { netClusterNodes: [%s] } }, storage: { profiles: [{ name: default, engine: %s }] } }' \
+      # printf avoids heredoc quoting issues and correctly embeds the node list.
+      # Ignite 3.1.0 requires every config root nested under a top-level `ignite { }`
+      # block — the flat form (valid in 3.0.x) fails with "'network' configuration root
+      # doesn't exist". nodeFinder type is STATIC since we supply an explicit node list.
+      printf 'ignite { network: { port: 3344, nodeFinder: { netClusterNodes: [%s], type: STATIC } }, storage: { profiles: [{ name: default, engine: %s }] } }' \
         "${NODE_LIST}" "${STORAGE_PROFILE}" > "${CONF_FILE}"
       kubectl create configmap ignite-config \
         --namespace default \
@@ -100,12 +103,30 @@ start:
     script: |
       #!/usr/bin/env bash
       set -euo pipefail
-      echo "Configuring OTLP metrics exporter..."
-      # NodePort 30300 is reachable from the local machine via Tailscale private IP
-      curl -s -f -X PATCH "http://${CONTROL_HOST_PRIVATE}:30300/management/v1/configuration/cluster" \
-        -H "Content-Type: application/json" \
-        -d "{\"ignite\":{\"metrics\":{\"exporters\":{\"otel\":{\"exporterName\":\"otlp\",\"endpoint\":\"http://${CONTROL_HOST_PRIVATE}:4318/v1/metrics\",\"protocol\":\"http/protobuf\"}}}}}"
-      echo "OTLP metrics configured."
+      echo "Enabling Ignite native OTLP metrics exporter..."
+      # Ignite's native OTLP exporter emits the full native metric set (JMX exposes none to
+      # the platform MBean server in 3.1.0, so it is not usable). Metrics push to the
+      # control-node OTel collector's OTLP receiver (:4318), which forwards to VictoriaMetrics
+      # under the stable `cluster` label. Ignite's config API needs text/plain + HOCON
+      # (application/json → 415). Retry: the NodePort was just created (kube-proxy timing).
+      OTLP='ignite.metrics.exporters.otlpExporter{exporterName=otlp,endpoint="http://'"${CONTROL_HOST_PRIVATE}"':4318/v1/metrics",protocol="http/protobuf"}'
+      for attempt in $(seq 1 12); do
+        if curl -s -f -X PATCH "http://${CONTROL_HOST_PRIVATE}:30300/management/v1/configuration/cluster" \
+             -H "Content-Type: text/plain" -d "${OTLP}"; then
+          echo "OTLP metrics exporter configured."
+          break
+        fi
+        echo "OTLP-exporter enable attempt ${attempt}/12 failed; retrying in 5s..."
+        sleep 5
+        [ "${attempt}" = "12" ] && { echo "ERROR: enabling OTLP exporter failed after 12 attempts" >&2; exit 1; }
+      done
+      # Ignite activates metric exporters at node start, so a post-init config change does
+      # not take effect until nodes restart. Roll the StatefulSet so the exporter activates
+      # on the fresh boot (nodes re-read cluster config at join). Deterministic, kit-owned.
+      echo "Rolling Ignite nodes so the OTLP exporter activates..."
+      kubectl rollout restart statefulset/ignite-cluster -n default
+      kubectl rollout status statefulset/ignite-cluster -n default --timeout=300s
+      echo "OTLP metrics exporter active."
 
 stop:
   - type: delete

--- a/src/main/resources/com/rustyrazorblade/easydblab/kits/ignite3/kit.yaml
+++ b/src/main/resources/com/rustyrazorblade/easydblab/kits/ignite3/kit.yaml
@@ -49,7 +49,13 @@ start:
         NODE_LIST="${NODE_LIST}\"ignite-cluster-${i}.ignite-svc-headless.default.svc.cluster.local:3344\", "
       done
       NODE_LIST="${NODE_LIST%, }"
-      CONF_FILE=$(mktemp /tmp/ignite-config.XXXXXX.conf)
+      # Only trailing X's are substituted by BSD mktemp (macOS operators run this
+      # step locally), so keep the X's at the end — no ".conf" suffix. The
+      # configmap key sets the real filename, so the temp name is irrelevant.
+      CONF_FILE=$(mktemp /tmp/ignite-config.XXXXXX)
+      # Clean up even if a later command fails before the explicit rm, so a
+      # leftover temp file never blocks a subsequent run.
+      trap 'rm -f "${CONF_FILE}"' EXIT
       # printf avoids heredoc quoting issues and correctly embeds the node list
       printf '{ network: { port: 3344, nodeFinder: { netClusterNodes: [%s] } }, storage: { profiles: [{ name: default, engine: %s }] } }' \
         "${NODE_LIST}" "${STORAGE_PROFILE}" > "${CONF_FILE}"
@@ -57,7 +63,6 @@ start:
         --namespace default \
         --from-file=ignite-config.conf="${CONF_FILE}" \
         --dry-run=client -o yaml | kubectl apply -f -
-      rm -f "${CONF_FILE}"
       echo "ConfigMap created."
 
   - type: manifest

--- a/src/main/resources/com/rustyrazorblade/easydblab/kits/ignite3/nodeport-service.yaml.template
+++ b/src/main/resources/com/rustyrazorblade/easydblab/kits/ignite3/nodeport-service.yaml.template
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ignite-nodeport
+  namespace: default
+spec:
+  type: NodePort
+  selector:
+    app: ignite
+  ports:
+    - name: rest
+      port: 10300
+      targetPort: 10300
+      nodePort: 30300
+    - name: thin-client
+      port: 10800
+      targetPort: 10800
+      nodePort: 30800

--- a/src/main/resources/com/rustyrazorblade/easydblab/kits/ignite3/services.yaml.template
+++ b/src/main/resources/com/rustyrazorblade/easydblab/kits/ignite3/services.yaml.template
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ignite-svc-headless
+  namespace: default
+spec:
+  clusterIP: None
+  selector:
+    app: ignite
+  ports:
+    - name: discovery
+      port: 3344
+      targetPort: 3344

--- a/src/main/resources/com/rustyrazorblade/easydblab/kits/ignite3/services.yaml.template
+++ b/src/main/resources/com/rustyrazorblade/easydblab/kits/ignite3/services.yaml.template
@@ -5,6 +5,12 @@ metadata:
   namespace: default
 spec:
   clusterIP: None
+  # Publish DNS records for not-yet-Ready pods. Ignite peer discovery (StaticNodeFinder)
+  # runs at node boot (~13s), BEFORE the readiness probe passes (~30s). Without this, a
+  # peer has no DNS record at discovery time, every node resolves only itself, and each
+  # forms an isolated 1-node cluster (split-brain). Required for StatefulSet discovery
+  # that must happen before readiness.
+  publishNotReadyAddresses: true
   selector:
     app: ignite
   ports:

--- a/src/main/resources/com/rustyrazorblade/easydblab/kits/ignite3/statefulset.yaml.template
+++ b/src/main/resources/com/rustyrazorblade/easydblab/kits/ignite3/statefulset.yaml.template
@@ -18,7 +18,7 @@ spec:
       terminationGracePeriodSeconds: 300
       containers:
         - name: ignite-node
-          image: apache/ignite3:__IGNITE_VERSION__
+          image: apacheignite/ignite:__IGNITE_VERSION__
           imagePullPolicy: IfNotPresent
           env:
             - name: IGNITE_NODE_NAME

--- a/src/main/resources/com/rustyrazorblade/easydblab/kits/ignite3/statefulset.yaml.template
+++ b/src/main/resources/com/rustyrazorblade/easydblab/kits/ignite3/statefulset.yaml.template
@@ -1,0 +1,58 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: ignite-cluster
+  namespace: default
+spec:
+  replicas: __REPLICAS__
+  serviceName: ignite-svc-headless
+  selector:
+    matchLabels:
+      app: ignite
+  template:
+    metadata:
+      labels:
+        app: ignite
+    spec:
+      # Allow enough time for Ignite to flush WAL and checkpoints on shutdown
+      terminationGracePeriodSeconds: 300
+      containers:
+        - name: ignite-node
+          image: apache/ignite3:__IGNITE_VERSION__
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: IGNITE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: IGNITE_WORK_DIR
+              value: /ai3-work
+          ports:
+            - name: rest
+              containerPort: 10300
+            - name: thin-client
+              containerPort: 10800
+            - name: discovery
+              containerPort: 3344
+          volumeMounts:
+            - name: config-vol
+              mountPath: /opt/ignite/etc/ignite-config.conf
+              subPath: ignite-config.conf
+            - name: persistence
+              mountPath: /ai3-work
+      volumes:
+        - name: config-vol
+          configMap:
+            name: ignite-config
+  volumeClaimTemplates:
+    - metadata:
+        name: persistence
+        labels:
+          app: ignite
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 10Gi
+        volumeMode: Filesystem

--- a/src/main/resources/com/rustyrazorblade/easydblab/kits/ignite3/statefulset.yaml.template
+++ b/src/main/resources/com/rustyrazorblade/easydblab/kits/ignite3/statefulset.yaml.template
@@ -6,6 +6,10 @@ metadata:
 spec:
   replicas: __REPLICAS__
   serviceName: ignite-svc-headless
+  # Parallel (not OrderedReady): all nodes must boot together and discover each other
+  # on :3344 BEFORE `cluster init` runs. OrderedReady deadlocks — pods 1..N are never
+  # created until pod-0 is Ready, but readiness/init can't complete without the full set.
+  podManagementPolicy: Parallel
   selector:
     matchLabels:
       app: ignite
@@ -27,26 +31,6 @@ spec:
                   fieldPath: metadata.name
             - name: IGNITE_WORK_DIR
               value: /ai3-work
-            - name: HOST_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.hostIP
-            - name: JAVA_TOOL_OPTIONS
-              value: "-javaagent:/usr/local/otel/opentelemetry-javaagent.jar"
-            - name: OTEL_SERVICE_NAME
-              value: "ignite3"
-            - name: OTEL_RESOURCE_ATTRIBUTES
-              value: "cluster.name=__CLUSTER_NAME__"
-            - name: OTEL_EXPORTER_OTLP_ENDPOINT
-              value: "http://$(HOST_IP):4317"
-            - name: OTEL_EXPORTER_OTLP_PROTOCOL
-              value: "grpc"
-            - name: OTEL_TRACES_EXPORTER
-              value: "otlp"
-            - name: OTEL_METRICS_EXPORTER
-              value: "none"
-            - name: OTEL_LOGS_EXPORTER
-              value: "none"
           ports:
             - name: rest
               containerPort: 10300
@@ -54,22 +38,27 @@ spec:
               containerPort: 10800
             - name: discovery
               containerPort: 3344
+          # Readiness probes the REST port (10300), which opens as soon as the node
+          # process starts — BEFORE cluster init. The client/SQL connector (10800) does
+          # NOT open until `cluster init` runs, and init is gated behind pods being Ready,
+          # so probing 10800 here would deadlock. 10300 lets pods go Ready pre-init; the
+          # cluster-init Job (and its wait-for-Complete) is the real "cluster ready" gate.
+          readinessProbe:
+            tcpSocket:
+              port: 10300
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            failureThreshold: 6
           volumeMounts:
             - name: config-vol
               mountPath: /opt/ignite/etc/ignite-config.conf
               subPath: ignite-config.conf
             - name: persistence
               mountPath: /ai3-work
-            - name: otel-agent
-              mountPath: /usr/local/otel
-              readOnly: true
       volumes:
         - name: config-vol
           configMap:
             name: ignite-config
-        - name: otel-agent
-          hostPath:
-            path: /usr/local/otel
   volumeClaimTemplates:
     - metadata:
         name: persistence

--- a/src/main/resources/com/rustyrazorblade/easydblab/kits/ignite3/statefulset.yaml.template
+++ b/src/main/resources/com/rustyrazorblade/easydblab/kits/ignite3/statefulset.yaml.template
@@ -27,6 +27,26 @@ spec:
                   fieldPath: metadata.name
             - name: IGNITE_WORK_DIR
               value: /ai3-work
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: JAVA_TOOL_OPTIONS
+              value: "-javaagent:/usr/local/otel/opentelemetry-javaagent.jar"
+            - name: OTEL_SERVICE_NAME
+              value: "ignite3"
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: "cluster.name=__CLUSTER_NAME__"
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: "http://$(HOST_IP):4317"
+            - name: OTEL_EXPORTER_OTLP_PROTOCOL
+              value: "grpc"
+            - name: OTEL_TRACES_EXPORTER
+              value: "otlp"
+            - name: OTEL_METRICS_EXPORTER
+              value: "none"
+            - name: OTEL_LOGS_EXPORTER
+              value: "none"
           ports:
             - name: rest
               containerPort: 10300
@@ -40,10 +60,16 @@ spec:
               subPath: ignite-config.conf
             - name: persistence
               mountPath: /ai3-work
+            - name: otel-agent
+              mountPath: /usr/local/otel
+              readOnly: true
       volumes:
         - name: config-vol
           configMap:
             name: ignite-config
+        - name: otel-agent
+          hostPath:
+            path: /usr/local/otel
   volumeClaimTemplates:
     - metadata:
         name: persistence

--- a/test-plans/ignite3-sql-validation.md
+++ b/test-plans/ignite3-sql-validation.md
@@ -1,0 +1,94 @@
+# Apache Ignite 3 — SQL validation + readiness diagnosis (live lab)
+
+Live end-to-end validation of the `ignite3` kit (PR #684). The prior attempt stalled at
+`Running (0/1 pods ready)` with **no logs captured**, so this plan's readiness step is
+**diagnostic-first**: on any stall it captures `kubectl describe pod` + `kubectl logs`
+(current AND `--previous`) so we fix the crashloop from real signal instead of guessing.
+
+## Cluster Name
+
+ignite3-sql-validation
+
+## Datacenters
+
+single
+
+## Success Criteria
+
+- Ignite pods reach `1/1 Ready` (readiness probe on client-connector :10800 passes).
+- `ignite3 status` reports the server nodes running.
+- `ignite3 sql` DDL + DML + query round-trip: the `SELECT` returns exactly the rows inserted
+  (THE pass/fail gate — proves the `sql` capability + JDBC endpoint + thin driver).
+- Ignite native OTLP metrics reach VictoriaMetrics / Grafana.
+
+## Notes
+
+- Run everything from the **#684 worktree** (`/Users/jhaddad/dev/easy-db-lab-668-add-ignite`)
+  so the wrapper uses the ignite-enabled binary — `main`'s binary has no `ignite3` kit.
+- AWS profile: `sandbox-admin`. Instance type i4i.xlarge. Storage profile: `aipersist`.
+- **Do NOT leave the cluster running.** Tear down on success. On a failure we're actively
+  debugging, keep it up ONLY while iterating, and tear down before ending the session.
+
+## Steps
+
+1. **Build the ignite-enabled binary + scaffold workspace** (from the #684 worktree)
+   ```bash
+   ./gradlew installDist            # bundles the ignite3 kit + readiness-probe fix into build/install
+   CLUSTER_DIR="clusters/ignite3-sql-$(date +%Y%m%d-%H%M%S)"
+   mkdir -p "$CLUSTER_DIR"
+   bin/create-easy-db-lab-wrapper "$CLUSTER_DIR"
+   EDB="$CLUSTER_DIR/easy-db-lab"
+   ```
+
+2. **Init + up** a single-DC cluster with 3 db nodes (i4i.xlarge)
+   ```bash
+   $EDB init --name ignite3-sql-validation --instance-type i4i.xlarge <3 db nodes per `$EDB commands`>
+   $EDB up
+   ```
+   Verify: `$EDB status` shows 3 db nodes reachable.
+
+3. **Install + start Ignite 3**
+   ```bash
+   $EDB kit install ignite3 --replicas 3 --storage aipersist
+   $EDB ignite3 start
+   ```
+
+4. **Readiness gate — DIAGNOSTIC ON STALL.** While/after start, watch pod readiness:
+   ```bash
+   kubectl get pods -l app=ignite -n default -w    # expect ignite-cluster-0..2 → 1/1 Ready
+   ```
+   **If any pod is not `1/1 Ready` within ~2 min, immediately capture (do NOT tear down):**
+   ```bash
+   kubectl describe pod -l app=ignite -n default
+   kubectl logs -l app=ignite -n default --all-containers --tail=200
+   kubectl logs -l app=ignite -n default --all-containers --previous --tail=200
+   kubectl get events -n default --sort-by=.lastTimestamp | tail -30
+   ```
+   Save output to `$CLUSTER_DIR/docs/`, then STOP and hand the logs back for a manifest fix.
+   Iterate: apply fix in the kit → `./gradlew installDist` → `$EDB kit install ignite3 ...`
+   → `$EDB ignite3 stop && $EDB ignite3 start` → re-check readiness.
+
+5. **SQL round-trip (the core gate)** — only once pods are `1/1 Ready` and cluster-init completed
+   ```bash
+   $EDB ignite3 status
+   $EDB ignite3 sql "CREATE TABLE lab_kv (id INT PRIMARY KEY, val VARCHAR)"
+   $EDB ignite3 sql "INSERT INTO lab_kv (id, val) VALUES (1, 'hello'), (2, 'world')"
+   $EDB ignite3 sql "SELECT id, val FROM lab_kv ORDER BY id"
+   ```
+   Verify: the SELECT returns exactly `(1, hello)` and `(2, world)`.
+
+6. **Metrics check**
+   - Confirm Ignite native OTLP metrics land in VictoriaMetrics (query `{job="ignite3"}` or via
+     Grafana). From the cluster workspace: `export-workload-metrics ignite3` for the catalog.
+   - This feeds the dashboard authoring step in the kit's TODO.md.
+
+7. **Tear down** (mandatory unless mid-debug)
+   ```bash
+   $EDB down --auto-approve
+   ```
+   Confirm no lingering EC2 instances for this cluster.
+
+## On failure
+
+Keep the cluster up ONLY while actively iterating on a fix. The moment we stop for the session,
+run `$EDB down --auto-approve` — never leave instances orphaned.


### PR DESCRIPTION
Closes #668

## Summary

- Adds a new `ignite3` kit deploying Apache Ignite 3 on `db` nodes via raw K8s manifests (StatefulSet + headless Service + NodePort Service + one-time cluster-init Job)
- Configurable storage profiles: `aimem` (volatile), `aipersist` (default, in-memory + disk persistence), `rocksdb` (disk-based LSM)
- `--version` arg (default `3.1.0`), `--replicas` arg (default: db node count)
- SQL capability via thin client JDBC driver on port 10800 (`ignite3 sql`)
- Metrics: Ignite's native OTLP exporter pushes to the OTel Collector after cluster init
- Traces: OTel Java agent (`/usr/local/otel/opentelemetry-javaagent.jar`) mounted from host AMI, sends to node-local OTel Collector via `status.hostIP:4317`
- Logs: covered by existing OTel filelog receiver (`/var/log/**/*.log` picks up K3s pod logs automatically)
- No new Kotlin code — kit uses existing manifest, shell, wait, and delete step infrastructure