### PR TITLE
feat(networking): auto-select VPC CIDR to avoid conflicts with existing VPCs

### DIFF
--- a/.cassandra-analytics
+++ b/.cassandra-analytics
@@ -1,1 +1,0 @@
-/Users/jhaddad/dev/easy-db-lab/.cassandra-analytics

--- a/.cassandra-analytics
+++ b/.cassandra-analytics
@@ -1,0 +1,1 @@
+/Users/jhaddad/dev/easy-db-lab/.cassandra-analytics

--- a/.gitignore
+++ b/.gitignore
@@ -155,6 +155,7 @@ site/
 .claude/settings.local.json
 
 # Cassandra Analytics build artifacts (see bin/build-cassandra-analytics)
+.cassandra-analytics
 .cassandra-analytics/
 spark/bulk-writer-sidecar/libs/*.jar
 spark/bulk-writer-s3/libs/*.jar

--- a/openspec/changes/auto-select-vpc-cidr/.openspec.yaml
+++ b/openspec/changes/auto-select-vpc-cidr/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-04

--- a/openspec/changes/auto-select-vpc-cidr/design.md
+++ b/openspec/changes/auto-select-vpc-cidr/design.md
@@ -2,7 +2,7 @@
 
 Currently `Init.cidr` defaults to `Constants.Vpc.DEFAULT_CIDR` (`"10.0.0.0/16"`). This string is stored in `InitConfig.cidr` (in `state.json`) and passed to `AwsInfrastructureService.ensureInfrastructure()` → `vpcService.createVpc()`. Multiple users sharing an AWS account each create a VPC with the same block, producing routing conflicts in a Tailscale mesh.
 
-The VPC is not created at `init` time — it is created during `up`. This means CIDR auto-selection naturally belongs in the `up` path, specifically in `AwsInfrastructureService` before calling `createVpc`. There is no need to make AWS calls during `init`.
+The VPC is not created at `init` time — it is created during `up`. This means CIDR auto-selection naturally belongs in the `up` path. There is no need to make AWS calls during `init`.
 
 ## Goals / Non-Goals
 
@@ -24,11 +24,11 @@ The VPC is not created at `init` time — it is created during `up`. This means 
 
 `Init.validateParameters()` only validates the CIDR when it is non-null (i.e., when `--cidr` was explicitly provided). When null, there is nothing to validate at init time.
 
-### Decision 2: Auto-selection lives in `AwsInfrastructureService`
+### Decision 2: Auto-selection lives in `Up.resolveCidr()`
 
-The selection requires an AWS API call (`describeVpcs`), and `AwsInfrastructureService` already holds `vpcService`. Placing it here keeps the command layer thin and avoids adding any AWS dependency to `Init`.
+`Up.kt` already holds `vpcService` directly and is the only caller of both `createVpc` and `setupVpcNetworking`. Placing selection here avoids threading a resolver through `AwsInfrastructureService` for a concern specific to the `up` flow.
 
-The resolved CIDR is used in-place; it does not need to be written back to state because `AwsInfrastructureService` receives it through `VpcNetworkingConfig` which is constructed just before VPC creation.
+The resolved CIDR is persisted back to `InitConfig` in state before VPC creation. This ensures that a re-run after a partial failure (e.g. VPC created but instances failed) picks the same block rather than re-querying and potentially selecting a different one.
 
 ### Decision 3: New `VpcDiscoveryOperations.listAllVpcCidrs()` method
 

--- a/openspec/changes/auto-select-vpc-cidr/design.md
+++ b/openspec/changes/auto-select-vpc-cidr/design.md
@@ -1,0 +1,62 @@
+## Context
+
+Currently `Init.cidr` defaults to `Constants.Vpc.DEFAULT_CIDR` (`"10.0.0.0/16"`). This string is stored in `InitConfig.cidr` (in `state.json`) and passed to `AwsInfrastructureService.ensureInfrastructure()` → `vpcService.createVpc()`. Multiple users sharing an AWS account each create a VPC with the same block, producing routing conflicts in a Tailscale mesh.
+
+The VPC is not created at `init` time — it is created during `up`. This means CIDR auto-selection naturally belongs in the `up` path, specifically in `AwsInfrastructureService` before calling `createVpc`. There is no need to make AWS calls during `init`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Auto-select a non-conflicting `10.X.0.0/16` CIDR when the user omits `--cidr`
+- Inform the user which CIDR was chosen at `up` time
+- Allow `--cidr` to still override auto-selection
+
+**Non-Goals:**
+- Cross-region CIDR conflict detection (same region only)
+- Supporting CIDR ranges other than `10.0.0.0/8` in auto-selection
+- Prefix lengths other than `/16`
+
+## Decisions
+
+### Decision 1: `InitConfig.cidr` becomes `String?`
+
+`null` in state.json means "auto-select at up time." This is cleanly distinguishable from an explicit user choice. The alternative — keeping a sentinel value like `"auto"` — would be stringly typed and harder to reason about.
+
+`Init.validateParameters()` only validates the CIDR when it is non-null (i.e., when `--cidr` was explicitly provided). When null, there is nothing to validate at init time.
+
+### Decision 2: Auto-selection lives in `AwsInfrastructureService`
+
+The selection requires an AWS API call (`describeVpcs`), and `AwsInfrastructureService` already holds `vpcService`. Placing it here keeps the command layer thin and avoids adding any AWS dependency to `Init`.
+
+The resolved CIDR is used in-place; it does not need to be written back to state because `AwsInfrastructureService` receives it through `VpcNetworkingConfig` which is constructed just before VPC creation.
+
+### Decision 3: New `VpcDiscoveryOperations.listAllVpcCidrs()` method
+
+Rather than calling `ec2Client` directly from `AwsInfrastructureService`, the CIDR listing capability is added to the existing `VpcDiscoveryOperations` interface. This keeps `AwsInfrastructureService` decoupled from the SDK and mockable in unit tests.
+
+### Decision 4: Algorithm — first unused second octet in 0–254
+
+```
+usedOctets = existingCidrs
+    .filter { it starts with "10." }
+    .map { second octet as Int }
+    .toSet()
+    
+candidate = (0..254).first { it !in usedOctets }
+result = "10.$candidate.0.0/16"
+```
+
+If all 255 octets are taken, throw `IllegalStateException` with a clear message. 255 VPCs in a single region is well beyond any realistic scenario.
+
+### Decision 5: Emit `Event.Setup.AutoSelectedCidr(cidr: String)`
+
+The user needs to know which CIDR was chosen. A structured event (not a `println`) follows project conventions and makes the information available to MCP clients and Redis subscribers.
+
+## Risks / Trade-offs
+
+- **Race condition**: Two users could run `up` simultaneously, both see the same next-available octet, and both create `10.X.0.0/16`. This is unlikely in practice (small teams sharing an account), and AWS will reject the second `createVpc` call with a duplicate if it truly conflicts — which becomes a clear error rather than a silent routing problem.
+- **Non-`10.x` VPCs ignored**: Existing `172.16.x.x` or `192.168.x.x` VPCs are not scanned. Auto-selection only produces `10.X.0.0/16` blocks; any conflicts with other private ranges require the user to pass `--cidr` explicitly.
+
+## Migration Plan
+
+No migration needed — clusters are ephemeral. Existing `state.json` files with `"cidr": "10.0.0.0/16"` will deserialize correctly because a non-null `String` is still valid for `String?`. No data loss or incompatibility.

--- a/openspec/changes/auto-select-vpc-cidr/proposal.md
+++ b/openspec/changes/auto-select-vpc-cidr/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+When a user omits `--cidr` on `init`, it defaults to `10.0.0.0/16`. If multiple users in the same AWS account and region each create a cluster without specifying a CIDR, every VPC ends up with the same block — causing routing conflicts when Tailscale connects them into a single mesh.
+
+## What Changes
+
+- `InitConfig.cidr` becomes `String?` — `null` means "auto-select at up time"
+- `Init --cidr` option becomes optional with no default; omitting it stores `null` in state
+- CIDR validation in `Init.validateParameters()` is skipped when `--cidr` is not provided
+- `VpcDiscoveryOperations` gains a new `listAllVpcCidrs()` method
+- `EC2VpcService` implements `listAllVpcCidrs()` via `describeVpcs()` with no filter
+- `AwsInfrastructureService` auto-selects a non-conflicting `/16` when `config.cidr` is null, by scanning the first unused second octet in the `10.X.0.0/16` range (0–254)
+- A new `Event.Setup.AutoSelectedCidr(cidr)` event informs the user which CIDR was chosen
+- Fails fast with a clear error if all second octets 0–254 are taken
+
+## Capabilities
+
+### New Capabilities
+
+- `vpc-cidr-allocation`: Auto-selects a non-conflicting `10.X.0.0/16` CIDR by querying existing VPCs in the target region when the user does not provide `--cidr`.
+
+### Modified Capabilities
+
+- `networking`: CIDR is no longer a required concept at init time; it becomes nullable and resolved lazily. No requirement-level change to SSH/Tailscale/SOCKS5 behavior.
+
+## Impact
+
+- `providers/aws/VpcService.kt` — new interface method on `VpcDiscoveryOperations`
+- `services/aws/EC2VpcService.kt` — implements `listAllVpcCidrs()`
+- `services/aws/AwsInfrastructureService.kt` — CIDR resolution logic added before VPC creation
+- `configuration/ClusterState.kt` (`InitConfig.cidr`) — type change `String` → `String?`
+- `commands/Init.kt` — `--cidr` option becomes nullable, validation conditional
+- `events/Event.kt` — new `Event.Setup.AutoSelectedCidr(cidr: String)` event
+- `ConsoleEventListener` — handles new event
+- Existing tests that set `cidr = "10.0.0.0/16"` will continue to pass unchanged

--- a/openspec/changes/auto-select-vpc-cidr/specs/vpc-cidr-allocation/spec.md
+++ b/openspec/changes/auto-select-vpc-cidr/specs/vpc-cidr-allocation/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: Auto-select VPC CIDR when not specified
+The system SHALL automatically select a non-conflicting `10.X.0.0/16` CIDR block when the user does not provide `--cidr` at init time. Selection SHALL occur at `up` time by querying existing VPCs in the target region and choosing the first unused second octet (0–254).
+
+#### Scenario: CIDR auto-selected when --cidr is omitted
+- **WHEN** the user runs `init` without `--cidr`
+- **THEN** `state.json` stores a null CIDR (auto-select deferred to up time)
+
+#### Scenario: Auto-selection chooses first non-conflicting block
+- **WHEN** `up` runs with a null CIDR and existing VPCs occupy `10.0.0.0/16` and `10.1.0.0/16`
+- **THEN** the new VPC is created with CIDR `10.2.0.0/16`
+
+#### Scenario: User is informed of auto-selected CIDR
+- **WHEN** a CIDR is auto-selected during `up`
+- **THEN** an event is emitted displaying the chosen CIDR (e.g. `Auto-selected CIDR: 10.2.0.0/16`)
+
+#### Scenario: Explicit --cidr overrides auto-selection
+- **WHEN** the user passes `--cidr 172.16.0.0/16` to `init`
+- **THEN** that CIDR is used as-is; no auto-selection occurs
+
+#### Scenario: Exhausted CIDR space fails fast
+- **WHEN** all second octets 0–254 are already occupied by existing VPCs in the region
+- **THEN** `up` fails with a clear error message indicating no available CIDR blocks remain

--- a/openspec/changes/auto-select-vpc-cidr/tasks.md
+++ b/openspec/changes/auto-select-vpc-cidr/tasks.md
@@ -1,0 +1,28 @@
+## 1. Interface and Data Model
+
+- [x] 1.1 Add `listAllVpcCidrs(): List<String>` to `VpcDiscoveryOperations` in `providers/aws/VpcService.kt`
+- [x] 1.2 Change `InitConfig.cidr` from `String` to `String?` (default `null`) in `configuration/ClusterState.kt`
+- [x] 1.3 Add `Event.Setup.AutoSelectedCidr(cidr: String)` to `events/Event.kt`
+- [x] 1.4 Handle `Event.Setup.AutoSelectedCidr` in `ConsoleEventListener`
+
+## 2. Service Implementation
+
+- [x] 2.1 Implement `listAllVpcCidrs()` in `EC2VpcService` — call `describeVpcs()` with no filter, return all VPC CIDR blocks
+- [x] 2.2 Add CIDR auto-selection logic to `Up` — when `initConfig.cidr` is null, call `listAllVpcCidrs()`, pick first unused second octet in `10.X.0.0/16` via `CidrBlock.selectAvailable()`, emit `AutoSelectedCidr` event, persist resolved CIDR to state, fail fast if all 0–254 are taken
+
+## 3. Command Layer
+
+- [x] 3.1 Change `Init.cidr` from `String = Constants.Vpc.DEFAULT_CIDR` to `String? = null` in `commands/Init.kt`
+- [x] 3.2 Update `Init.validateParameters()` to skip CIDR validation when `cidr` is null
+- [x] 3.3 Update `--cidr` option description to reflect auto-selection default
+
+## 4. Tests
+
+- [x] 4.1 Add `listAllVpcCidrs()` integration test to `EC2VpcServiceIntegrationTest` — create VPCs, assert CIDRs returned
+- [x] 4.2 Add unit tests for the auto-selection algorithm (find first unused second octet, exhausted range error)
+- [x] 4.3 Add integration test verifying `listAllVpcCidrs()` + `CidrBlock.selectAvailable()` picks non-conflicting CIDR
+- [x] 4.4 Add test verifying explicit `--cidr` is stored in state; null stored when omitted
+
+## 5. Verification
+
+- [x] 5.1 Run `./gradlew ktlintFormat && ./gradlew test && ./gradlew detekt` — all pass

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Init.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Init.kt
@@ -1,7 +1,6 @@
 package com.rustyrazorblade.easydblab.commands
 
 import com.fasterxml.jackson.annotation.JsonIgnore
-import com.rustyrazorblade.easydblab.Constants
 import com.rustyrazorblade.easydblab.annotations.McpCommand
 import com.rustyrazorblade.easydblab.annotations.RequireProfileSetup
 import com.rustyrazorblade.easydblab.commands.converters.PicoAZConverter
@@ -199,9 +198,9 @@ class Init : PicoBaseCommand() {
 
     @Option(
         names = ["--cidr"],
-        description = ["VPC CIDR block (default: 10.0.0.0/16). Must be /20 or larger."],
+        description = ["VPC CIDR block (e.g. 10.2.0.0/16). Must be /20 or larger. Omit to auto-select a non-conflicting block."],
     )
-    var cidr: String = Constants.Vpc.DEFAULT_CIDR
+    var cidr: String? = null
 
     @Option(
         names = ["--cilium"],
@@ -248,8 +247,7 @@ class Init : PicoBaseCommand() {
         require(ebsSize > 0) { "EBS size must be positive" }
         require(ebsIops >= 0) { "EBS IOPS cannot be negative" }
         require(ebsThroughput >= 0) { "EBS throughput cannot be negative" }
-        // Validate CIDR block format and prefix length
-        CidrBlock(cidr)
+        cidr?.let { CidrBlock(it) }
     }
 
     private fun checkExistingFiles() {

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Up.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Up.kt
@@ -15,6 +15,7 @@ import com.rustyrazorblade.easydblab.configuration.InitConfig
 import com.rustyrazorblade.easydblab.configuration.ServerType
 import com.rustyrazorblade.easydblab.configuration.User
 import com.rustyrazorblade.easydblab.events.Event
+import com.rustyrazorblade.easydblab.network.CidrBlock
 import com.rustyrazorblade.easydblab.providers.aws.DiscoveredInstance
 import com.rustyrazorblade.easydblab.providers.aws.RetryUtil
 import com.rustyrazorblade.easydblab.providers.aws.VpcNetworkingConfig
@@ -185,7 +186,18 @@ class Up : PicoBaseCommand() {
      * @param initConfig Configuration containing cluster name and tags
      * @return The VPC ID to use for infrastructure
      */
-    private fun createOrValidateVpc(initConfig: InitConfig): String {
+    private fun resolveCidr(cidr: String?): String {
+        if (cidr != null) return cidr
+        val existingCidrs = vpcService.listAllVpcCidrs()
+        val selected = CidrBlock.selectAvailable(existingCidrs)
+        eventBus.emit(Event.Setup.AutoSelectedCidr(selected.value))
+        return selected.value
+    }
+
+    private fun createOrValidateVpc(
+        initConfig: InitConfig,
+        resolvedCidr: String,
+    ): String {
         val existingVpcId = workingState.vpcId
 
         if (existingVpcId != null) {
@@ -224,7 +236,7 @@ class Up : PicoBaseCommand() {
                 putAll(initConfig.tags)
             }
 
-        val vpcId = vpcService.createVpc(initConfig.name, initConfig.cidr, vpcTags)
+        val vpcId = vpcService.createVpc(initConfig.name, resolvedCidr, vpcTags)
         eventBus.emit(Event.Provision.VpcCreated(vpcId))
 
         // Save VPC ID to state
@@ -243,8 +255,13 @@ class Up : PicoBaseCommand() {
     private fun provisionInfrastructure(initConfig: InitConfig) {
         eventBus.emit(Event.Provision.InfrastructureStarting)
 
-        val vpcId = createOrValidateVpc(initConfig)
-        val vpcInfra = setupVpcNetworking(initConfig, vpcId)
+        val resolvedCidr = resolveCidr(initConfig.cidr)
+        if (initConfig.cidr == null) {
+            workingState.initConfig = initConfig.copy(cidr = resolvedCidr)
+            clusterStateManager.save(workingState)
+        }
+        val vpcId = createOrValidateVpc(initConfig, resolvedCidr)
+        val vpcInfra = setupVpcNetworking(initConfig, vpcId, resolvedCidr)
         val subnetIds = vpcInfra.subnetIds
         val securityGroupId = vpcInfra.securityGroupId
         val igwId = vpcInfra.internetGatewayId
@@ -286,6 +303,7 @@ class Up : PicoBaseCommand() {
     private fun setupVpcNetworking(
         initConfig: InitConfig,
         vpcId: String,
+        resolvedCidr: String,
     ) = awsInfrastructureService.setupVpcNetworking(
         VpcNetworkingConfig(
             vpcId = vpcId,
@@ -295,7 +313,7 @@ class Up : PicoBaseCommand() {
             availabilityZones = initConfig.azs.ifEmpty { listOf("a", "b", "c") },
             isOpen = initConfig.open,
             tags = initConfig.tags,
-            vpcCidr = initConfig.cidr,
+            vpcCidr = resolvedCidr,
         ),
     ) { getExternalIpAddress() }
 

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/ClusterState.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/ClusterState.kt
@@ -105,7 +105,7 @@ data class InitConfig(
     val opensearchInstanceCount: Int = 1,
     val opensearchVersion: String = "2.11",
     val opensearchEbsSize: Int = 100,
-    val cidr: String = Constants.Vpc.DEFAULT_CIDR,
+    val cidr: String? = null,
     val ciliumEnabled: Boolean = false,
 ) {
     companion object {

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/events/Event.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/events/Event.kt
@@ -4675,6 +4675,14 @@ sealed interface Event {
         }
 
         @Serializable
+        @SerialName("Setup.AutoSelectedCidr")
+        data class AutoSelectedCidr(
+            val cidr: String,
+        ) : Setup {
+            override fun toDisplayString(): String = "Auto-selected CIDR: $cidr"
+        }
+
+        @Serializable
         @SerialName("Setup.ExistingVpc")
         data class ExistingVpc(
             val vpcId: String,

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/network/CidrBlock.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/network/CidrBlock.kt
@@ -81,6 +81,32 @@ value class CidrBlock(
         /** Number of octets in an IPv4 address */
         private const val IPV4_OCTET_COUNT = 4
 
+        /** Maximum second octet value when scanning for available 10.X.0.0/16 blocks */
+        private const val MAX_SECOND_OCTET = 254
+
+        /**
+         * Selects the first available `10.X.0.0/16` CIDR not already used by an existing VPC.
+         *
+         * Scans second octets 0–254 in order and returns the first that does not appear in any
+         * of the provided CIDR strings. Only `10.x.x.x` CIDRs in [existingCidrs] are considered.
+         *
+         * @param existingCidrs CIDR blocks of all VPCs already present in the region
+         * @throws IllegalStateException if all second octets 0–254 are occupied
+         */
+        fun selectAvailable(existingCidrs: List<String>): CidrBlock {
+            val usedOctets =
+                existingCidrs
+                    .filter { it.startsWith("10.") }
+                    .mapNotNull { it.split(".").getOrNull(1)?.toIntOrNull() }
+                    .toSet()
+            val secondOctet =
+                (0..MAX_SECOND_OCTET).firstOrNull { it !in usedOctets }
+                    ?: error(
+                        "No available CIDR blocks in 10.x.0.0/16 range — all second octets 0–254 are in use",
+                    )
+            return CidrBlock("10.$secondOctet.0.0/16")
+        }
+
         /**
          * Validates whether a string is a valid IPv4 CIDR block.
          *

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/providers/aws/VpcService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/providers/aws/VpcService.kt
@@ -204,6 +204,13 @@ interface VpcDiscoveryOperations {
      * Finds active network interfaces in a VPC.
      */
     fun findActiveNetworkInterfacesInVpc(vpcId: VpcId): List<NetworkInterfaceId>
+
+    /**
+     * Returns the CIDR blocks of all VPCs in the target region.
+     *
+     * Used to find an available CIDR block when auto-selecting a non-conflicting VPC CIDR.
+     */
+    fun listAllVpcCidrs(): List<String>
 }
 
 /**

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/TemplateVariables.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/TemplateVariables.kt
@@ -85,6 +85,8 @@ data class TemplateVariables(
                 dbNodeIps = dbNodes.joinToString(",") { it.privateIp },
                 appNodeIps = appNodes.joinToString(",") { it.privateIp },
                 runningKits = state.runningKits.joinToString(","),
+                // cidr is null until 'up' resolves and persists it; DEFAULT_CIDR is a safe
+                // fallback because templates using VPC_CIDR only execute post-up
                 vpcCidr = state.initConfig?.cidr ?: Constants.Vpc.DEFAULT_CIDR,
             )
         }

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/aws/EC2VpcService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/aws/EC2VpcService.kt
@@ -789,6 +789,15 @@ class EC2VpcService(
         return eniIds
     }
 
+    override fun listAllVpcCidrs(): List<String> {
+        log.info { "Listing CIDR blocks for all VPCs in region" }
+        val vpcs =
+            RetryUtil.withAwsRetry("list-all-vpc-cidrs") {
+                ec2Client.describeVpcs(DescribeVpcsRequest.builder().build()).vpcs()
+            }
+        return vpcs.mapNotNull { it.cidrBlock() }
+    }
+
     override fun waitForNetworkInterfacesCleared(
         vpcId: VpcId,
         timeoutMs: Long,

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/commands/InitTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/commands/InitTest.kt
@@ -122,6 +122,29 @@ class InitTest : BaseKoinTest() {
         }
 
         @Test
+        fun `execute stores explicit cidr in state`() {
+            val command = Init()
+            command.clean = true
+            command.cidr = "172.16.0.0/16"
+            command.execute()
+
+            verify(mockClusterStateManager).save(
+                argThat { initConfig?.cidr == "172.16.0.0/16" },
+            )
+        }
+
+        @Test
+        fun `execute stores null cidr when --cidr is omitted`() {
+            val command = Init()
+            command.clean = true
+            command.execute()
+
+            verify(mockClusterStateManager).save(
+                argThat { initConfig?.cidr == null },
+            )
+        }
+
+        @Test
         fun `execute extracts resource files`() {
             val command = Init()
             command.clean = true

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/network/CidrBlockTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/network/CidrBlockTest.kt
@@ -68,4 +68,41 @@ class CidrBlockTest {
         assertThat(CidrBlock.DEFAULT.value).isEqualTo(Constants.Vpc.DEFAULT_CIDR)
         assertThat(CidrBlock.DEFAULT.subnetCidr(0)).isEqualTo("10.0.1.0/24")
     }
+
+    @Test
+    fun `selectAvailable returns first unused second octet as 10-x-0-0 slash 16`() {
+        val existing = listOf("10.0.0.0/16", "10.1.0.0/16")
+        assertThat(CidrBlock.selectAvailable(existing).value).isEqualTo("10.2.0.0/16")
+    }
+
+    @Test
+    fun `selectAvailable skips gaps and returns first available`() {
+        val existing = listOf("10.0.0.0/16", "10.2.0.0/16", "10.3.0.0/16")
+        assertThat(CidrBlock.selectAvailable(existing).value).isEqualTo("10.1.0.0/16")
+    }
+
+    @Test
+    fun `selectAvailable ignores non-10-x VPC CIDRs`() {
+        val existing = listOf("172.16.0.0/16", "192.168.0.0/16")
+        assertThat(CidrBlock.selectAvailable(existing).value).isEqualTo("10.0.0.0/16")
+    }
+
+    @Test
+    fun `selectAvailable ignores CIDRs with non-integer second octet`() {
+        val existing = listOf("10.abc.0.0/16")
+        assertThat(CidrBlock.selectAvailable(existing).value).isEqualTo("10.0.0.0/16")
+    }
+
+    @Test
+    fun `selectAvailable returns 10-0-0-0 slash 16 when no existing VPCs`() {
+        assertThat(CidrBlock.selectAvailable(emptyList()).value).isEqualTo("10.0.0.0/16")
+    }
+
+    @Test
+    fun `selectAvailable throws when all second octets 0-254 are taken`() {
+        val existing = (0..254).map { "10.$it.0.0/16" }
+        assertThatThrownBy { CidrBlock.selectAvailable(existing) }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("No available CIDR blocks")
+    }
 }

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/services/TemplateVariablesTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/services/TemplateVariablesTest.kt
@@ -66,7 +66,7 @@ class TemplateVariablesTest : BaseKoinTest() {
         appCount: Int = 2,
         bucketName: String = "my-bucket",
         region: String = "us-west-2",
-        cidr: String = Constants.Vpc.DEFAULT_CIDR,
+        cidr: String? = null,
     ): ClusterState =
         ClusterState(
             name = "test-cluster",

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/services/aws/EC2VpcServiceIntegrationTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/services/aws/EC2VpcServiceIntegrationTest.kt
@@ -313,4 +313,37 @@ class EC2VpcServiceIntegrationTest {
             assertThat(vpcService.getVpcName(vpcId)).isEqualTo("test-get-name")
         }
     }
+
+    @Nested
+    inner class ListAllVpcCidrs {
+        @Test
+        fun `returns CIDR blocks of all VPCs in region`() {
+            vpcService.createVpc("test-cidr-list-1", "10.20.0.0/16", emptyMap())
+            vpcService.createVpc("test-cidr-list-2", "10.21.0.0/16", emptyMap())
+
+            val cidrs = vpcService.listAllVpcCidrs()
+
+            assertThat(cidrs).contains("10.20.0.0/16", "10.21.0.0/16")
+        }
+
+        @Test
+        fun `does not include CIDRs from VPCs that were not created`() {
+            val cidrs = vpcService.listAllVpcCidrs()
+
+            assertThat(cidrs).doesNotContain("10.22.0.0/16", "10.23.0.0/16")
+        }
+
+        @Test
+        fun `auto-selection picks non-conflicting CIDR based on listed VPCs`() {
+            vpcService.createVpc("test-autoselect-a", "10.30.0.0/16", emptyMap())
+            vpcService.createVpc("test-autoselect-b", "10.31.0.0/16", emptyMap())
+
+            val existingCidrs = vpcService.listAllVpcCidrs()
+            val selected =
+                com.rustyrazorblade.easydblab.network.CidrBlock
+                    .selectAvailable(existingCidrs)
+
+            assertThat(existingCidrs).doesNotContain(selected.value)
+        }
+    }
 }

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/services/aws/EC2VpcServiceIntegrationTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/services/aws/EC2VpcServiceIntegrationTest.kt
@@ -327,13 +327,6 @@ class EC2VpcServiceIntegrationTest {
         }
 
         @Test
-        fun `does not include CIDRs from VPCs that were not created`() {
-            val cidrs = vpcService.listAllVpcCidrs()
-
-            assertThat(cidrs).doesNotContain("10.22.0.0/16", "10.23.0.0/16")
-        }
-
-        @Test
         fun `auto-selection picks non-conflicting CIDR based on listed VPCs`() {
             vpcService.createVpc("test-autoselect-a", "10.30.0.0/16", emptyMap())
             vpcService.createVpc("test-autoselect-b", "10.31.0.0/16", emptyMap())


### PR DESCRIPTION
## Summary

- When `--cidr` is omitted on `init`, the CIDR is now stored as `null` in state instead of defaulting to `10.0.0.0/16`
- At `up` time, if CIDR is null, queries all VPCs in the target region and selects the first unused `10.X.0.0/16` second octet
- Emits an `AutoSelectedCidr` event so the user sees which block was chosen (e.g. `Auto-selected CIDR: 10.3.0.0/16`)
- Resolves #682

## Changes

- `InitConfig.cidr: String?` — null means auto-select at up time
- `Init --cidr` option is now optional with no default; explicit values are validated and preserved as before
- `Up.resolveCidr()` — queries `vpcService.listAllVpcCidrs()`, calls `CidrBlock.selectAvailable()`, persists resolved CIDR back to state
- `CidrBlock.selectAvailable(existingCidrs)` — pure function, first unused second octet in 0–254; fails fast if all taken
- `VpcDiscoveryOperations.listAllVpcCidrs()` + `EC2VpcService` implementation
- New `Event.Setup.AutoSelectedCidr(cidr)` event