### PR TITLE
feat(kit): add kit source add/list/remove commands

### DIFF
--- a/docs/user-guide/kits.md
+++ b/docs/user-guide/kits.md
@@ -68,5 +68,81 @@ cp -r /path/to/my-kit/* ~/.easy-db-lab/profiles/default/kits/my-kit/
 easy-db-lab kit install my-kit
 ```
 
+## Using kits from external projects
+
+If you keep kit definitions alongside a private project (a POC, internal tooling, etc.), you can
+register that project's kits directory without copying files into your profile.
+
+A typical project structure looks like this:
+
+```
+myapp/
+├── src/
+├── kits/
+│   └── myapp-workload/
+│       ├── kit.yaml
+│       └── bin/
+│           ├── start.sh
+│           └── stop.sh
+└── README.md
+```
+
+Clone your project and register the kits directory by name:
+
+```bash
+git clone https://github.com/myorg/myapp ~/myapp
+easy-db-lab kit source add myapp ~/myapp/kits
+```
+
+The kits it contains now appear in `kit list` and can be installed by name:
+
+```bash
+easy-db-lab kit list
+easy-db-lab kit install myapp-workload
+```
+
+Registered sources are persisted in `~/.easy-db-lab/profiles/<profile>/kit-sources.yaml` and
+survive CLI restarts. When you `kit install` a kit from an external source, its files are copied
+into the cluster workspace exactly like any other kit — the installed kit is self-contained.
+
+### Managing registered sources
+
+```bash
+# List all registered sources (shows name and path, flags missing paths)
+easy-db-lab kit source list
+```
+
+Output looks like:
+
+```
+Registered kit sources:
+  myapp  /Users/jon/myapp/kits
+```
+
+If a registered path no longer exists on disk, `[missing]` appears next to it so you know
+which sources need attention.
+
+```bash
+# Remove a source by name
+easy-db-lab kit source remove myproject
+```
+
+**Updating a path (upsert behavior):** Sources are identified by name. If you move or reclone
+a project to a different location, just re-add the source with the new path — no need to remove
+the old registration first:
+
+```bash
+# If you move or reclone the project, just update the path — no need to remove first
+easy-db-lab kit source add myapp ~/new-location/myapp/kits
+# Updated kit source 'myapp': /new-location/myapp/kits
+```
+
+### Resolution priority
+
+When multiple sources provide a kit with the same name, the first match wins:
+
+1. Profile kits directory (`~/.easy-db-lab/profiles/<profile>/kits/`)
+2. Registered additional sources (in registration order)
+3. Built-in kits
 
 For a full walkthrough of building and publishing your own kit, see the [Kit Development](../development/kits.md) guide.

--- a/openspec/changes/archive/2026-06-04-additional-kit-sources/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-04-additional-kit-sources/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-04

--- a/openspec/changes/archive/2026-06-04-additional-kit-sources/design.md
+++ b/openspec/changes/archive/2026-06-04-additional-kit-sources/design.md
@@ -1,0 +1,96 @@
+## Context
+
+`InstallTemplateResolver` currently resolves kit templates from three sources in priority order:
+profile-kits directory, built-in classpath, and ad-hoc `--from` path (install-only, not listed).
+The `--from` flag is the existing one-off mechanism for pointing at an external kit directory;
+it wraps the path as `TemplateSource.Directory` and renders through the same pipeline as any
+other kit. This change makes that mechanism persistent and discoverable by adding a registered
+sources tier stored in `kit-sources.yaml`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Let users register parent directories of kit subdirs that persist across sessions
+- Make registered-source kits appear in `kit list`, `kit info`, and `kit install` with no extra flags
+- `kit install` for an external kit copies files into the cluster directory (unchanged from today)
+- `--from` remains the one-off variant; both paths use `TemplateSource.Directory`
+
+**Non-Goals:**
+- Remote sources (URLs, git repos) — local filesystem only
+- Merging or deprecating `--from`
+- Per-kit override of individual files from an external source
+
+## Decisions
+
+### 1. Storage: dedicated `kit-sources.yaml` with kotlinx.serialization
+
+`settings.yaml` (the `User` data class) holds cloud credentials and is loaded on every command
+that touches AWS. Kit source directories are a development workflow preference with no cloud
+dependency. Mixing them into `settings.yaml` would force Jackson (deprecated) and bloat a class
+that already has too many concerns.
+
+A dedicated `~/.easy-db-lab/profiles/<profile>/kit-sources.yaml` with kotlinx.serialization keeps
+concerns separated and aligns with the codebase's serialization standard.
+
+```
+KitSourcesConfig
+  paths: List<String>   # absolute paths to parent directories
+```
+
+### 2. New `KitSourcesProvider` service
+
+A single-responsibility service owns reading and writing `kit-sources.yaml`. It follows the
+same provider pattern as `UserConfigProvider`:
+- `load(): KitSourcesConfig` — reads or returns empty config if file absent
+- `save(config: KitSourcesConfig)` — writes and updates cache
+- `addPath(path: String)` / `removePath(path: String)` — mutate and save
+
+Registered in `ServicesModule` as a Koin singleton.
+
+### 3. Resolution priority in `InstallTemplateResolver`
+
+```
+1. profile kits      ~/.easy-db-lab/profiles/<profile>/kits/<name>/
+2. additional sources registered via kit source add (searched in order of registration)
+3. built-in          classpath
+```
+
+Additional sources are iterated in registration order. Within each source directory, subdirectories
+are treated as individual kit templates (same as profile-kits). The resolver's `resolve(name)` and
+`listAvailableTemplates()` methods are extended to scan additional source dirs between profile-kits
+and built-ins.
+
+### 4. `kit source` subcommand group
+
+Three subcommands under a new `KitSource` parent command, added to `Kit.kt`:
+
+| Command | Behaviour |
+|---|---|
+| `kit source add <path>` | Validates path is an existing directory, then appends to `kit-sources.yaml`. Prints confirmation. |
+| `kit source list` | Prints each registered path; flags paths that no longer exist on disk. |
+| `kit source remove <path>` | Removes path from `kit-sources.yaml`; no-op with message if not found. |
+
+Commands live in `commands/kit/source/`. They are read-only display (`list`) or profile-state
+mutation (`add`, `remove`) — no cluster state involved, no events needed. `println()` for output.
+
+### 5. `--from` relationship
+
+`--from` takes a path that IS the kit directory directly (single kit). `kit source add` takes a
+parent directory containing kit subdirectories. Both ultimately produce `TemplateSource.Directory`
+instances — `--from` creates one immediately at install time; the resolver creates them during
+discovery from registered source dirs. No code is duplicated; the `TemplateSource.Directory` type
+and `renderAndWrite` pipeline are unchanged.
+
+## Risks / Trade-offs
+
+- **Stale paths**: A registered path may be deleted or moved (e.g. the project is recloned
+  elsewhere). `kit source list` will flag non-existent paths; `kit list` will silently skip them
+  rather than fail — missing directories are not an error, just an empty set of kits.
+- **Name collision**: If an additional-source kit shares a name with a built-in, the
+  additional-source kit wins (priority 2 > 3). If two registered sources have the same kit name,
+  the first-registered source wins. This mirrors how profile-kits shadow built-ins today.
+
+## Migration Plan
+
+No migration required. `kit-sources.yaml` is created on first `kit source add`. Existing profiles
+without the file behave identically to today. Clusters are ephemeral — no deployed state is affected.

--- a/openspec/changes/archive/2026-06-04-additional-kit-sources/proposal.md
+++ b/openspec/changes/archive/2026-06-04-additional-kit-sources/proposal.md
@@ -1,0 +1,37 @@
+## Why
+
+Users want to ship kit definitions alongside private projects (POCs, internal tooling) without
+bundling them into easy-db-lab. Today there is no way to register an external directory of kits
+so they appear in `kit list`, `kit info`, and `kit install` — the only escape hatch is the
+ad-hoc `--from` flag, which is not persistent and not listed.
+
+## What Changes
+
+- **New `kit source` subcommand group** with three subcommands:
+  - `kit source add <path>` — register a parent directory of kit subdirectories
+  - `kit source list` — show all registered source directories
+  - `kit source remove <path>` — unregister a source directory
+- **New `kit-sources.yaml`** in `~/.easy-db-lab/profiles/<profile>/` stores registered paths (kotlinx.serialization)
+- **`InstallTemplateResolver`** gains a new resolution tier between profile-kits and built-ins
+- `kit list`, `kit info`, and `kit install` pick up kits from additional sources with no changes
+- `kit install` for an external-source kit copies the kit into the cluster directory exactly like built-in kits — the installed kit is self-contained in the cluster workspace
+- The existing `--from` flag is the ad-hoc (one-time) variant of `kit source add`; both resolve through `TemplateSource.Directory` — additional sources make that resolution persistent and discoverable
+
+## Capabilities
+
+### New Capabilities
+
+- `kit-source-management`: Register, list, and remove additional parent directories of kit templates; persist them in `kit-sources.yaml`
+
+### Modified Capabilities
+
+- `install-command`: Template discovery gains a fourth source tier — additional registered directories — between profile-kits and built-ins
+
+## Impact
+
+- `InstallTemplateResolver` — add resolution tier, read sources from `KitSourcesConfig`
+- New `KitSourcesConfig` data class + `KitSourcesProvider` service (kotlinx.serialization, `kit-sources.yaml`)
+- New `commands/kit/source/` package: `KitSource`, `KitSourceAdd`, `KitSourceList`, `KitSourceRemove`
+- `Kit.kt` — add `KitSource` as a subcommand
+- `ServicesModule.kt` — register `KitSourcesProvider`
+- No changes to `KitList`, `KitInfo`, `Install`, or `BaseInstallCommand`

--- a/openspec/changes/archive/2026-06-04-additional-kit-sources/specs/install-command/spec.md
+++ b/openspec/changes/archive/2026-06-04-additional-kit-sources/specs/install-command/spec.md
@@ -1,0 +1,45 @@
+## MODIFIED Requirements
+
+### Requirement: Template discovery sources
+Templates are resolved from four sources in priority order:
+
+1. **Profile directory**: `~/.easy-db-lab/profiles/<profile>/kits/<name>/`
+2. **Additional sources**: directories registered via `kit source add`, searched in registration order; each registered directory's subdirectories are treated as individual kit templates
+3. **Built-in classpath**: `kits/<name>/` (bundled with the CLI)
+4. **Ad-hoc path**: supplied via `--from <path>` flag (install-time only, never listed)
+
+Profile templates override built-ins and additional-source templates when names collide.
+Additional-source templates override built-ins when names collide. Within multiple registered
+additional sources, the first-registered source wins on name collision.
+A missing additional-source directory (path no longer exists on disk) is silently skipped —
+it does not cause an error.
+The ad-hoc `--from` path is the one-time variant of a registered source: both resolve through
+`TemplateSource.Directory` and render through the same pipeline.
+
+#### Scenario: Kit from additional source appears in list
+- **WHEN** a directory is registered via `kit source add ~/myproject/kits/`
+- **AND** that directory contains a `my-kit/` subdirectory with `kit.yaml`
+- **THEN** `kit list` includes `my-kit`
+
+#### Scenario: Kit from additional source is inspectable
+- **WHEN** a directory is registered via `kit source add ~/myproject/kits/`
+- **AND** that directory contains a `my-kit/` subdirectory with `kit.yaml`
+- **THEN** `kit info my-kit` displays the kit details
+
+#### Scenario: Kit from additional source is installable
+- **WHEN** a directory is registered via `kit source add ~/myproject/kits/`
+- **AND** that directory contains a `my-kit/` subdirectory with `kit.yaml`
+- **THEN** `kit install my-kit` copies the kit files into the cluster directory
+
+#### Scenario: Additional source kit shadows built-in of same name
+- **WHEN** a registered additional source contains a kit with the same name as a built-in kit
+- **THEN** the additional-source kit is used (priority 2 beats priority 3)
+
+#### Scenario: Profile kit shadows additional source of same name
+- **WHEN** the profile kits directory contains a kit with the same name as a registered additional source
+- **THEN** the profile kit is used (priority 1 beats priority 2)
+
+#### Scenario: Missing additional source directory is skipped silently
+- **WHEN** a registered additional source path no longer exists on disk
+- **THEN** `kit list` does not include kits from that path
+- **THEN** no error is raised

--- a/openspec/changes/archive/2026-06-04-additional-kit-sources/specs/kit-source-management/spec.md
+++ b/openspec/changes/archive/2026-06-04-additional-kit-sources/specs/kit-source-management/spec.md
@@ -1,0 +1,63 @@
+## ADDED Requirements
+
+### Requirement: User can register an additional kit source directory
+The CLI SHALL allow users to register a parent directory as an additional kit source via
+`kit source add <path>`. The path SHALL be stored in `kit-sources.yaml` in the active profile
+directory. The path SHALL be an existing directory at the time of registration.
+
+#### Scenario: Add a valid directory as a kit source
+- **WHEN** the user runs `kit source add ~/myproject/kits/`
+- **THEN** the path is appended to `kit-sources.yaml`
+- **THEN** a confirmation message is printed
+
+#### Scenario: Reject a non-existent path
+- **WHEN** the user runs `kit source add /does/not/exist`
+- **THEN** the command fails with an error message indicating the path does not exist
+- **THEN** `kit-sources.yaml` is not modified
+
+#### Scenario: Adding a duplicate path is a no-op
+- **WHEN** the user runs `kit source add <path>` and that path is already registered
+- **THEN** the command prints a message indicating it is already registered
+- **THEN** `kit-sources.yaml` is not modified
+
+### Requirement: User can list registered kit source directories
+The CLI SHALL display all registered additional kit source directories via `kit source list`.
+Paths that no longer exist on disk SHALL be flagged in the output.
+
+#### Scenario: List shows registered paths
+- **WHEN** the user runs `kit source list` and one or more paths are registered
+- **THEN** each registered path is printed, one per line
+
+#### Scenario: List flags missing paths
+- **WHEN** a registered path no longer exists on disk
+- **THEN** `kit source list` marks it as missing (e.g. `[missing]` suffix)
+
+#### Scenario: List with no sources registered
+- **WHEN** `kit-sources.yaml` does not exist or is empty
+- **THEN** `kit source list` prints a message indicating no sources are registered
+
+### Requirement: User can remove a registered kit source directory
+The CLI SHALL allow users to unregister a source directory via `kit source remove <path>`.
+
+#### Scenario: Remove a registered path
+- **WHEN** the user runs `kit source remove <path>` and the path is registered
+- **THEN** the path is removed from `kit-sources.yaml`
+- **THEN** a confirmation message is printed
+
+#### Scenario: Remove a path that is not registered
+- **WHEN** the user runs `kit source remove <path>` and the path is not registered
+- **THEN** a message is printed indicating the path was not found
+- **THEN** `kit-sources.yaml` is not modified
+
+### Requirement: Registered sources persist across sessions
+Kit source registrations SHALL be stored in `~/.easy-db-lab/profiles/<profile>/kit-sources.yaml`
+using kotlinx.serialization. An absent `kit-sources.yaml` SHALL be treated as an empty source list
+(not an error).
+
+#### Scenario: Sources survive CLI restart
+- **WHEN** the user registers a source and restarts the CLI
+- **THEN** the registered source is still present in `kit source list`
+
+#### Scenario: Missing file treated as empty
+- **WHEN** `kit-sources.yaml` does not exist
+- **THEN** all kit source commands behave as if the source list is empty

--- a/openspec/changes/archive/2026-06-04-additional-kit-sources/tasks.md
+++ b/openspec/changes/archive/2026-06-04-additional-kit-sources/tasks.md
@@ -1,0 +1,31 @@
+## 1. Data Model & Persistence
+
+- [x] 1.1 Create `KitSourcesConfig` data class (kotlinx.serialization) with `paths: List<String>`
+- [x] 1.2 Create `KitSourcesProvider` service: `load()`, `save()`, `addPath()`, `removePath()` backed by `kit-sources.yaml` in the profile directory
+- [x] 1.3 Register `KitSourcesProvider` as a Koin singleton in `ServicesModule`
+- [x] 1.4 Write unit tests for `KitSourcesProvider`: add, remove, duplicate no-op, missing file treated as empty
+
+## 2. Resolver Integration
+
+- [x] 2.1 Inject `KitSourcesProvider` into `InstallTemplateResolver`
+- [x] 2.2 Update `listAvailableTemplates()` to scan additional source directories (between profile-kits and built-ins); skip missing paths silently
+- [x] 2.3 Update `resolve(name)` to check additional source directories before built-ins
+- [x] 2.4 Write unit tests for resolver priority: additional source shadows built-in, profile shadows additional source, missing path is skipped
+
+## 3. `kit source` Commands
+
+- [x] 3.1 Create `commands/kit/source/` package with `KitSource` parent command (PicoCLI `@Command`)
+- [x] 3.2 Implement `KitSourceAdd`: validate path exists, delegate to `KitSourcesProvider.addPath()`, print confirmation or "already registered"
+- [x] 3.3 Implement `KitSourceList`: print each path from `KitSourcesProvider`; flag missing paths with `[missing]`; print "No sources registered" when empty
+- [x] 3.4 Implement `KitSourceRemove`: delegate to `KitSourcesProvider.removePath()`, print confirmation or "not found"
+- [x] 3.5 Register `KitSource` as a subcommand of `Kit` in `Kit.kt`
+- [x] 3.6 Write unit tests for `KitSourceAdd`, `KitSourceList`, `KitSourceRemove` using `@TempDir` and real `KitSourcesProvider`
+
+## 4. End-to-End Verification
+
+- [x] 4.1 Write integration test: register a temp directory with a kit subdir, verify the kit appears in `listAvailableTemplates()`
+- [x] 4.2 Write integration test: register a source, install the kit, verify files are written to the cluster working directory
+
+## 5. Documentation
+
+- [x] 5.1 Update `docs/` kit documentation to describe `kit source add/list/remove` and the `kit-sources.yaml` file

--- a/openspec/specs/install-command/spec.md
+++ b/openspec/specs/install-command/spec.md
@@ -8,13 +8,49 @@ generated `bin/` scripts and registers them as top-level subcommands automatical
 
 ## Template Discovery
 
-Templates are resolved from three sources in priority order:
+### Requirement: Template discovery sources
+Templates are resolved from four sources in priority order:
 
-1. **Profile directory**: `~/.easy-db-lab/profiles/<profile>/install/<name>/`
-2. **Built-in classpath**: `install/<name>/` (bundled with the CLI)
-3. **Ad-hoc path**: supplied via `--from <path>` flag
+1. **Profile directory**: `~/.easy-db-lab/profiles/<profile>/kits/<name>/`
+2. **Additional sources**: directories registered via `kit source add`, searched in registration order; each registered directory's subdirectories are treated as individual kit templates
+3. **Built-in classpath**: `kits/<name>/` (bundled with the CLI)
+4. **Ad-hoc path**: supplied via `--from <path>` flag (install-time only, never listed)
 
-Profile templates override built-ins when names collide. The `--from` path is never included in `--list` output.
+Profile templates override built-ins and additional-source templates when names collide.
+Additional-source templates override built-ins when names collide. Within multiple registered
+additional sources, the first-registered source wins on name collision.
+A missing additional-source directory (path no longer exists on disk) is silently skipped —
+it does not cause an error.
+The ad-hoc `--from` path is the one-time variant of a registered source: both resolve through
+`TemplateSource.Directory` and render through the same pipeline.
+
+#### Scenario: Kit from additional source appears in list
+- **WHEN** a directory is registered via `kit source add ~/myproject/kits/`
+- **AND** that directory contains a `my-kit/` subdirectory with `kit.yaml`
+- **THEN** `kit list` includes `my-kit`
+
+#### Scenario: Kit from additional source is inspectable
+- **WHEN** a directory is registered via `kit source add ~/myproject/kits/`
+- **AND** that directory contains a `my-kit/` subdirectory with `kit.yaml`
+- **THEN** `kit info my-kit` displays the kit details
+
+#### Scenario: Kit from additional source is installable
+- **WHEN** a directory is registered via `kit source add ~/myproject/kits/`
+- **AND** that directory contains a `my-kit/` subdirectory with `kit.yaml`
+- **THEN** `kit install my-kit` copies the kit files into the cluster directory
+
+#### Scenario: Additional source kit shadows built-in of same name
+- **WHEN** a registered additional source contains a kit with the same name as a built-in kit
+- **THEN** the additional-source kit is used (priority 2 beats priority 3)
+
+#### Scenario: Profile kit shadows additional source of same name
+- **WHEN** the profile kits directory contains a kit with the same name as a registered additional source
+- **THEN** the profile kit is used (priority 1 beats priority 2)
+
+#### Scenario: Missing additional source directory is skipped silently
+- **WHEN** a registered additional source path no longer exists on disk
+- **THEN** `kit list` does not include kits from that path
+- **THEN** no error is raised
 
 ### Requirement: Kit descriptor filename
 The kit descriptor file SHALL be named `kit.yaml`.

--- a/openspec/specs/kit-source-management/spec.md
+++ b/openspec/specs/kit-source-management/spec.md
@@ -1,0 +1,104 @@
+# Kit Source Management Spec
+
+## Overview
+
+Users can register additional parent directories as named kit sources. Each source has a
+user-chosen name and a filesystem path — analogous to `git remote`. Kits found in registered
+directories are treated as first-class kits — they appear in `kit list`, are inspectable via
+`kit info`, and are installable via `kit install`. This enables project-local or team-shared
+kit repositories without requiring changes to the CLI binary.
+
+Registrations are stored in `~/.easy-db-lab/profiles/<profile>/kit-sources.yaml` and persist
+across CLI restarts.
+
+## CLI Commands
+
+### `kit source add <name> <path>`
+
+Registers a named additional kit source directory. The directory must exist at registration
+time. If the name already exists its path is updated (upsert — not an error, not a no-op).
+
+### `kit source list`
+
+Lists all registered kit source directories showing both the name and the path, formatted as
+two aligned columns. Paths that no longer exist on disk are flagged with `[missing]` in the
+output.
+
+### `kit source remove <name>`
+
+Removes a registered kit source by name. If no source with that name exists the command
+prints a "not found" message.
+
+## Storage
+
+Registrations are stored in `~/.easy-db-lab/profiles/<profile>/kit-sources.yaml` using
+kotlinx.serialization. Each entry contains a `name` and a `path`. Paths are stored in
+canonical form to deduplicate symlinks. An absent file is treated as an empty source list
+(not an error).
+
+## Requirements
+
+### Requirement: User can register a named additional kit source directory
+The CLI SHALL allow users to register a parent directory as a named additional kit source via
+`kit source add <name> <path>`. The name and canonical path SHALL be stored in
+`kit-sources.yaml` in the active profile directory. The path SHALL be an existing directory
+at the time of registration.
+
+#### Scenario: Add a valid directory as a kit source
+- **WHEN** the user runs `kit source add myproject ~/myproject/kits/`
+- **THEN** the entry `{name: myproject, path: <canonical path>}` is written to `kit-sources.yaml`
+- **THEN** a confirmation message is printed: `Added kit source 'myproject': <canonical path>`
+
+#### Scenario: Reject a non-existent path
+- **WHEN** the user runs `kit source add myproject /does/not/exist`
+- **THEN** the command fails with an error message indicating the path does not exist
+- **THEN** `kit-sources.yaml` is not modified
+
+#### Scenario: Adding a source with an existing name updates the path (upsert)
+- **WHEN** the user runs `kit source add <name> <new-path>` and a source with that name is already registered
+- **THEN** the existing entry's path is updated to `<new-path>`
+- **THEN** a confirmation message is printed: `Updated kit source '<name>': <canonical path>`
+- **THEN** `kit-sources.yaml` reflects the new path
+
+### Requirement: User can list registered kit source directories
+The CLI SHALL display all registered additional kit source directories via `kit source list`,
+showing the name and the path in aligned columns. Paths that no longer exist on disk SHALL
+be flagged with `[missing]`.
+
+#### Scenario: List shows registered sources
+- **WHEN** the user runs `kit source list` and one or more sources are registered
+- **THEN** each registered source is printed with its name and path on one line, names left-aligned
+
+#### Scenario: List flags missing paths
+- **WHEN** a registered path no longer exists on disk
+- **THEN** `kit source list` marks it with `[missing]` (appended after the path)
+
+#### Scenario: List with no sources registered
+- **WHEN** `kit-sources.yaml` does not exist or is empty
+- **THEN** `kit source list` prints a message indicating no sources are registered and shows the `add` command syntax
+
+### Requirement: User can remove a registered kit source by name
+The CLI SHALL allow users to unregister a source directory by name via `kit source remove <name>`.
+
+#### Scenario: Remove a registered source by name
+- **WHEN** the user runs `kit source remove <name>` and a source with that name is registered
+- **THEN** the entry is removed from `kit-sources.yaml`
+- **THEN** a confirmation message is printed: `Removed kit source '<name>'`
+
+#### Scenario: Remove a name that is not registered
+- **WHEN** the user runs `kit source remove <name>` and no source with that name is registered
+- **THEN** a message is printed: `No kit source named '<name>'`
+- **THEN** `kit-sources.yaml` is not modified
+
+### Requirement: Registered sources persist across sessions
+Kit source registrations SHALL be stored in `~/.easy-db-lab/profiles/<profile>/kit-sources.yaml`
+using kotlinx.serialization. An absent `kit-sources.yaml` SHALL be treated as an empty source list
+(not an error).
+
+#### Scenario: Sources survive CLI restart
+- **WHEN** the user registers a source and restarts the CLI
+- **THEN** the registered source is still present in `kit source list`
+
+#### Scenario: Missing file treated as empty
+- **WHEN** `kit-sources.yaml` does not exist
+- **THEN** all kit source commands behave as if the source list is empty

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/kit/Kit.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/kit/Kit.kt
@@ -1,5 +1,6 @@
 package com.rustyrazorblade.easydblab.commands.kit
 
+import com.rustyrazorblade.easydblab.commands.kit.source.KitSource
 import picocli.CommandLine.Command
 import picocli.CommandLine.Model.CommandSpec
 import picocli.CommandLine.Spec
@@ -12,6 +13,7 @@ import picocli.CommandLine.Spec
  * - `kit info --name`   — show details about a kit before installing
  * - `kit list`          — list all discoverable kit templates
  * - `kit uninstall`     — remove an installed kit and its local files
+ * - `kit source`        — manage additional kit source directories
  *
  * Dynamic per-kit subcommands are registered under `kit install` at startup by
  * [com.rustyrazorblade.easydblab.CommandLineParser.registerDynamicInstallSubcommands].
@@ -24,6 +26,7 @@ import picocli.CommandLine.Spec
         Install::class,
         KitInfo::class,
         KitList::class,
+        KitSource::class,
         Uninstall::class,
     ],
 )
@@ -32,6 +35,6 @@ class Kit : Runnable {
     lateinit var spec: CommandSpec
 
     override fun run() {
-        spec.commandLine().usage(System.out)
+        spec.commandLine().usage(spec.commandLine().out)
     }
 }

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/kit/source/KitSource.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/kit/source/KitSource.kt
@@ -1,0 +1,31 @@
+package com.rustyrazorblade.easydblab.commands.kit.source
+
+import picocli.CommandLine.Command
+import picocli.CommandLine.Model.CommandSpec
+import picocli.CommandLine.Spec
+
+/**
+ * Parent command for managing additional kit source directories.
+ *
+ * Subcommands let users register external parent directories as additional kit sources so
+ * their kits appear in `kit list`, `kit info`, and `kit install` alongside built-in kits.
+ * Registrations are persisted in `kit-sources.yaml` in the active profile directory.
+ */
+@Command(
+    name = "source",
+    description = ["Manage additional kit source directories"],
+    mixinStandardHelpOptions = true,
+    subcommands = [
+        KitSourceAdd::class,
+        KitSourceList::class,
+        KitSourceRemove::class,
+    ],
+)
+class KitSource : Runnable {
+    @Spec
+    lateinit var spec: CommandSpec
+
+    override fun run() {
+        spec.commandLine().usage(spec.commandLine().out)
+    }
+}

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/kit/source/KitSourceAdd.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/kit/source/KitSourceAdd.kt
@@ -1,0 +1,48 @@
+package com.rustyrazorblade.easydblab.commands.kit.source
+
+import com.rustyrazorblade.easydblab.services.AddSourceResult
+import com.rustyrazorblade.easydblab.services.KitSourcesProvider
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+import picocli.CommandLine.Command
+import picocli.CommandLine.Parameters
+import java.io.File
+
+/**
+ * Registers a named additional kit source directory in the active profile.
+ *
+ * Analogous to `git remote add` — each source has a name and a path. If the name already
+ * exists its path is updated (upsert). Registered sources appear in `kit list`,
+ * `kit info`, and `kit install`.
+ */
+@Command(
+    name = "add",
+    description = ["Register a named kit source directory (e.g. kit source add myproject ~/myproject/kits)"],
+    mixinStandardHelpOptions = true,
+)
+class KitSourceAdd :
+    Runnable,
+    KoinComponent {
+    private val kitSourcesProvider: KitSourcesProvider by inject()
+
+    @Parameters(
+        index = "0",
+        description = ["Name for this source (e.g. myproject)"],
+    )
+    lateinit var name: String
+
+    @Parameters(
+        index = "1",
+        description = ["Path to a directory containing kit subdirectories"],
+    )
+    lateinit var path: String
+
+    override fun run() {
+        val dir = File(path)
+        require(dir.isDirectory) { "Path does not exist or is not a directory: $path" }
+        when (kitSourcesProvider.add(name, path)) {
+            AddSourceResult.ADDED -> println("Added kit source '$name': ${dir.canonicalPath}")
+            AddSourceResult.UPDATED -> println("Updated kit source '$name': ${dir.canonicalPath}")
+        }
+    }
+}

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/kit/source/KitSourceList.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/kit/source/KitSourceList.kt
@@ -1,0 +1,39 @@
+package com.rustyrazorblade.easydblab.commands.kit.source
+
+import com.rustyrazorblade.easydblab.services.KitSourcesProvider
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+import picocli.CommandLine.Command
+import java.io.File
+
+/**
+ * Lists all registered additional kit source directories with their names.
+ *
+ * Paths that no longer exist on disk are flagged with `[missing]` so the user
+ * can clean them up with `kit source remove <name>`.
+ */
+@Command(
+    name = "list",
+    description = ["List registered kit source directories"],
+    mixinStandardHelpOptions = true,
+)
+class KitSourceList :
+    Runnable,
+    KoinComponent {
+    private val kitSourcesProvider: KitSourcesProvider by inject()
+
+    override fun run() {
+        val sources = kitSourcesProvider.load().sources
+        if (sources.isEmpty()) {
+            println("No kit sources registered. Use 'kit source add <name> <path>' to register one.")
+            return
+        }
+        val nameWidth = sources.maxOf { it.name.length }
+        println("Registered kit sources:")
+        for (source in sources) {
+            val dir = File(source.path)
+            val missing = if (!dir.isDirectory || !dir.canRead()) " [missing]" else ""
+            println("  ${source.name.padEnd(nameWidth)}  ${source.path}$missing")
+        }
+    }
+}

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/kit/source/KitSourceRemove.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/kit/source/KitSourceRemove.kt
@@ -1,0 +1,35 @@
+package com.rustyrazorblade.easydblab.commands.kit.source
+
+import com.rustyrazorblade.easydblab.services.KitSourcesProvider
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+import picocli.CommandLine.Command
+import picocli.CommandLine.Parameters
+
+/**
+ * Unregisters a named additional kit source directory from the active profile.
+ */
+@Command(
+    name = "remove",
+    description = ["Remove a registered kit source by name"],
+    mixinStandardHelpOptions = true,
+)
+class KitSourceRemove :
+    Runnable,
+    KoinComponent {
+    private val kitSourcesProvider: KitSourcesProvider by inject()
+
+    @Parameters(
+        index = "0",
+        description = ["Name of the source to remove (e.g. myproject)"],
+    )
+    lateinit var name: String
+
+    override fun run() {
+        if (kitSourcesProvider.remove(name)) {
+            println("Removed kit source '$name'")
+        } else {
+            println("No kit source named '$name'")
+        }
+    }
+}

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/InstallTemplateResolver.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/InstallTemplateResolver.kt
@@ -8,16 +8,19 @@ import java.io.File
 import java.nio.file.Path
 
 /**
- * Resolves kit install templates from three sources in priority order:
+ * Resolves kit install templates from four sources in priority order:
  *
  * 1. Profile directory: `~/.easy-db-lab/profiles/<profile>/kits/<name>/`
- * 2. Built-in classpath: `kits/<name>/` in resources
- * 3. Ad-hoc: any local path supplied via `--from` (not listed by `--list`)
+ * 2. Additional sources: directories registered via `kit source add` (in registration order)
+ * 3. Built-in classpath: `kits/<name>/` in resources
+ * 4. Ad-hoc: any local path supplied via `--from` (not listed, install-time only)
  *
- * Profile templates override built-in templates of the same name.
+ * Profile templates override all others of the same name. Additional-source templates
+ * override built-ins. Missing additional-source directories are silently skipped.
  */
 class InstallTemplateResolver(
     private val context: Context,
+    private val kitSourcesProvider: KitSourcesProvider,
 ) {
     sealed interface TemplateSource {
         /** Template loaded from a local directory (profile override or --from path). */
@@ -66,19 +69,22 @@ class InstallTemplateResolver(
 
     private fun listBuiltinEntries(name: String): List<TemplateEntry> = builtinEntries[name] ?: emptyList()
 
+    /** Lists the names of kit subdirectories inside [dir], or empty if [dir] doesn't exist. */
+    private fun listKitNamesIn(dir: File): List<String> =
+        dir.takeIf { it.isDirectory }?.listFiles { f -> f.isDirectory }?.map { it.name } ?: emptyList()
+
+    /** Returns kit names found in the given [sources] list (missing dirs skipped). */
+    private fun additionalSourceNames(sources: List<KitSourceEntry>): List<String> = sources.flatMap { listKitNamesIn(File(it.path)) }
+
     /**
-     * Lists all discoverable template names: profile-directory names plus built-in names.
-     * Profile names override built-ins of the same name in the returned set.
-     * Ad-hoc (--from) templates are not included.
+     * Lists all discoverable template names: profile-directory names, additional-source names,
+     * and built-in names. Profile names override all others; additional-source names override
+     * built-ins. Ad-hoc (--from) templates are not included.
      */
     fun listAvailableTemplates(): List<String> {
-        val profileNames =
-            profileInstallDir
-                .takeIf { it.isDirectory }
-                ?.listFiles { f -> f.isDirectory }
-                ?.map { it.name }
-                ?: emptyList()
-        return (profileNames + builtinNames).distinct().sorted()
+        val sources = kitSourcesProvider.load().sources
+        val profileNames = listKitNamesIn(profileInstallDir)
+        return (profileNames + additionalSourceNames(sources) + builtinNames).distinct().sorted()
     }
 
     /**
@@ -98,7 +104,8 @@ class InstallTemplateResolver(
         }
 
     /**
-     * Resolves a named template to its source, checking profile dir before built-ins.
+     * Resolves a named template to its source, checking profile dir, then additional sources,
+     * then built-ins.
      *
      * @throws IllegalArgumentException if no template with [name] can be found
      */
@@ -106,6 +113,11 @@ class InstallTemplateResolver(
         val profileTemplate = File(profileInstallDir, name)
         if (profileTemplate.isDirectory) {
             return TemplateSource.Directory(profileTemplate)
+        }
+        val sources = kitSourcesProvider.load().sources
+        for (source in sources) {
+            val dir = File(source.path, name)
+            if (dir.isDirectory) return TemplateSource.Directory(dir)
         }
         if (name in builtinNames) {
             return TemplateSource.Builtin(name)

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/KitSourcesProvider.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/KitSourcesProvider.kt
@@ -1,0 +1,101 @@
+package com.rustyrazorblade.easydblab.services
+
+import com.charleskorn.kaml.Yaml
+import com.rustyrazorblade.easydblab.Context
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption.ATOMIC_MOVE
+import java.nio.file.StandardCopyOption.REPLACE_EXISTING
+
+/**
+ * A named additional kit source directory, analogous to a git remote.
+ *
+ * [name] is a user-chosen label (e.g. "myproject"); [path] is the canonical
+ * absolute path to a parent directory whose subdirectories are individual kit templates.
+ */
+@Serializable
+data class KitSourceEntry(
+    val name: String,
+    val path: String,
+)
+
+/**
+ * On-disk representation of user-registered additional kit source directories.
+ *
+ * Each source has a name and a path, stored as kit-sources.yaml in the active profile directory.
+ */
+@Serializable
+data class KitSourcesConfig(
+    val sources: List<KitSourceEntry> = emptyList(),
+)
+
+/** Result of [KitSourcesProvider.add]. */
+enum class AddSourceResult { ADDED, UPDATED }
+
+/**
+ * Manages persistence of user-registered additional kit source directories.
+ *
+ * Reads and writes kit-sources.yaml in the active profile directory using
+ * kotlinx.serialization. An absent file is treated as an empty source list.
+ */
+class KitSourcesProvider(
+    context: Context,
+) {
+    private val log = KotlinLogging.logger {}
+    private val configFile = File(context.profileDir, "kit-sources.yaml")
+    private val yaml = Yaml.default
+
+    /** Loads registered kit sources. Returns empty config if the file is absent. */
+    fun load(): KitSourcesConfig {
+        if (!configFile.exists()) return KitSourcesConfig()
+        return try {
+            yaml.decodeFromString(KitSourcesConfig.serializer(), configFile.readText())
+        } catch (e: Exception) {
+            log.warn { "Failed to read $configFile: ${e.message}. Using empty kit sources." }
+            println("Warning: could not read kit-sources.yaml: ${e.message}")
+            KitSourcesConfig()
+        }
+    }
+
+    /** Saves the config to kit-sources.yaml atomically via a temp-file rename. */
+    fun save(config: KitSourcesConfig) {
+        val tmp = File(configFile.parent, "${configFile.name}.tmp")
+        tmp.writeText(yaml.encodeToString(config))
+        Files.move(tmp.toPath(), configFile.toPath(), REPLACE_EXISTING, ATOMIC_MOVE)
+    }
+
+    /**
+     * Registers [name] pointing at [path]. If [name] already exists its path is updated.
+     * The path is stored in canonical form to deduplicate symlinks.
+     * Returns [AddSourceResult.ADDED] if new, [AddSourceResult.UPDATED] if the name existed.
+     */
+    fun add(
+        name: String,
+        path: String,
+    ): AddSourceResult {
+        val canonical = File(path).canonicalPath
+        val config = load()
+        val existing = config.sources.find { it.name == name }
+        val updated =
+            if (existing == null) {
+                config.copy(sources = config.sources + KitSourceEntry(name, canonical))
+            } else {
+                config.copy(sources = config.sources.map { if (it.name == name) KitSourceEntry(name, canonical) else it })
+            }
+        save(updated)
+        return if (existing == null) AddSourceResult.ADDED else AddSourceResult.UPDATED
+    }
+
+    /**
+     * Removes the source with [name]. Returns true if removed, false if not found.
+     */
+    fun remove(name: String): Boolean {
+        val config = load()
+        if (config.sources.none { it.name == name }) return false
+        save(config.copy(sources = config.sources.filter { it.name != name }))
+        return true
+    }
+}

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/ServicesModule.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/ServicesModule.kt
@@ -90,6 +90,9 @@ val servicesModule =
         // Kit command scanner — discovers @KitCommand-annotated classes across all JARs
         singleOf(::DefaultKitCommandScanner) bind KitCommandScanner::class
 
+        // Kit source registry — persists additional kit parent directories in kit-sources.yaml
+        singleOf(::KitSourcesProvider)
+
         // Cluster configuration service for writing config files
         factoryOf(::DefaultClusterConfigurationService) bind ClusterConfigurationService::class
 

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/commands/install/KitEndToEndTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/commands/install/KitEndToEndTest.kt
@@ -10,6 +10,7 @@ import com.rustyrazorblade.easydblab.configuration.ServerType
 import com.rustyrazorblade.easydblab.services.GrafanaDashboardService
 import com.rustyrazorblade.easydblab.services.InstallTemplateResolver
 import com.rustyrazorblade.easydblab.services.KitHookExecutor
+import com.rustyrazorblade.easydblab.services.KitSourcesProvider
 import com.rustyrazorblade.easydblab.services.MetricsRegistryService
 import com.rustyrazorblade.easydblab.services.TemplateService
 import com.rustyrazorblade.easydblab.services.WorkloadStepExecutor
@@ -71,7 +72,8 @@ class KitEndToEndTest : BaseKoinTest() {
                 single<MetricsRegistryService> { mockMetricsRegistryService }
                 single<KitHookExecutor> { mockKitHookExecutor }
                 single { TemplateService(get(), get()) }
-                single { InstallTemplateResolver(get()) }
+                single { KitSourcesProvider(get()) }
+                single { InstallTemplateResolver(get(), get()) }
             },
         )
 

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/commands/kit/KitInfoTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/commands/kit/KitInfoTest.kt
@@ -4,6 +4,7 @@ import com.rustyrazorblade.easydblab.BaseKoinTest
 import com.rustyrazorblade.easydblab.services.InstallTemplateResolver
 import com.rustyrazorblade.easydblab.services.KitCapability
 import com.rustyrazorblade.easydblab.services.KitConfig
+import com.rustyrazorblade.easydblab.services.KitSourcesProvider
 import com.rustyrazorblade.easydblab.services.TemplateService
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -27,7 +28,8 @@ class KitInfoTest : BaseKoinTest() {
         listOf(
             module {
                 single { TemplateService(get(), get()) }
-                single { InstallTemplateResolver(get()) }
+                single { KitSourcesProvider(get()) }
+                single { InstallTemplateResolver(get(), get()) }
             },
         )
 

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/commands/kit/source/KitSourceCommandsTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/commands/kit/source/KitSourceCommandsTest.kt
@@ -1,0 +1,143 @@
+package com.rustyrazorblade.easydblab.commands.kit.source
+
+import com.rustyrazorblade.easydblab.BaseKoinTest
+import com.rustyrazorblade.easydblab.services.KitSourcesProvider
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.koin.core.module.Module
+import org.koin.dsl.module
+import org.koin.test.get
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.PrintStream
+
+/**
+ * Tests for kit source subcommands. Uses real KitSourcesProvider with the BaseKoinTest temp
+ * directory so the full add/list/remove cycle exercises real disk I/O without mocking.
+ */
+class KitSourceCommandsTest : BaseKoinTest() {
+    private lateinit var provider: KitSourcesProvider
+
+    override fun additionalTestModules(): List<Module> =
+        listOf(
+            module {
+                single { KitSourcesProvider(get()) }
+            },
+        )
+
+    @BeforeEach
+    fun setupProvider() {
+        provider = get()
+    }
+
+    private fun captureOutput(block: () -> Unit): String {
+        val out = ByteArrayOutputStream()
+        val original = System.out
+        System.setOut(PrintStream(out))
+        try {
+            block()
+        } finally {
+            System.setOut(original)
+        }
+        return out.toString().trim()
+    }
+
+    // ── KitSourceAdd ──────────────────────────────────────────────────────
+
+    @Test
+    fun `add prints confirmation and persists new named source`() {
+        val dir = File(tempDir, "kits").also { it.mkdirs() }
+        val cmd =
+            KitSourceAdd().also {
+                it.name = "myproject"
+                it.path = dir.absolutePath
+            }
+        val output = captureOutput { cmd.run() }
+        assertThat(output).contains("Added kit source 'myproject'")
+        val sources = provider.load().sources
+        assertThat(sources).hasSize(1)
+        assertThat(sources[0].name).isEqualTo("myproject")
+        assertThat(sources[0].path).isEqualTo(dir.canonicalPath)
+    }
+
+    @Test
+    fun `add prints updated message when name already exists`() {
+        val dir1 = File(tempDir, "kits1").also { it.mkdirs() }
+        val dir2 = File(tempDir, "kits2").also { it.mkdirs() }
+        provider.add("myproject", dir1.absolutePath)
+        val cmd =
+            KitSourceAdd().also {
+                it.name = "myproject"
+                it.path = dir2.absolutePath
+            }
+        val output = captureOutput { cmd.run() }
+        assertThat(output).contains("Updated kit source 'myproject'")
+        assertThat(provider.load().sources).hasSize(1)
+        assertThat(provider.load().sources[0].path).isEqualTo(dir2.canonicalPath)
+    }
+
+    @Test
+    fun `add throws for non-existent path`() {
+        val cmd =
+            KitSourceAdd().also {
+                it.name = "bad"
+                it.path = "/does/not/exist/at/all"
+            }
+        assertThatThrownBy { cmd.run() }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("/does/not/exist/at/all")
+    }
+
+    // ── KitSourceList ────────────────────────────────────────────────────
+
+    @Test
+    fun `list prints no sources message when empty`() {
+        val output = captureOutput { KitSourceList().run() }
+        assertThat(output).contains("No kit sources registered")
+    }
+
+    @Test
+    fun `list prints name and path for registered sources`() {
+        val dir = File(tempDir, "kits").also { it.mkdirs() }
+        provider.add("myproject", dir.absolutePath)
+        val output = captureOutput { KitSourceList().run() }
+        assertThat(output).contains("myproject")
+        assertThat(output).contains(dir.canonicalPath)
+    }
+
+    @Test
+    fun `list flags missing path`() {
+        provider.add("ghost", "/nonexistent/path/for/test")
+        val output = captureOutput { KitSourceList().run() }
+        assertThat(output).contains("[missing]")
+    }
+
+    @Test
+    fun `list does not flag existing path as missing`() {
+        val dir = File(tempDir, "kits").also { it.mkdirs() }
+        provider.add("myproject", dir.absolutePath)
+        val output = captureOutput { KitSourceList().run() }
+        assertThat(output).doesNotContain("[missing]")
+    }
+
+    // ── KitSourceRemove ──────────────────────────────────────────────────
+
+    @Test
+    fun `remove prints confirmation and deletes source`() {
+        val dir = File(tempDir, "kits").also { it.mkdirs() }
+        provider.add("myproject", dir.absolutePath)
+        val cmd = KitSourceRemove().also { it.name = "myproject" }
+        val output = captureOutput { cmd.run() }
+        assertThat(output).contains("Removed kit source 'myproject'")
+        assertThat(provider.load().sources).isEmpty()
+    }
+
+    @Test
+    fun `remove prints not found for unknown name`() {
+        val cmd = KitSourceRemove().also { it.name = "doesnotexist" }
+        val output = captureOutput { cmd.run() }
+        assertThat(output).contains("No kit source named 'doesnotexist'")
+    }
+}

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/services/InstallTemplateResolverTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/services/InstallTemplateResolverTest.kt
@@ -17,7 +17,7 @@ class InstallTemplateResolverTest : BaseKoinTest() {
     @BeforeEach
     fun setupResolver() {
         ctx = TestContextFactory.createTestContext(tempDir)
-        resolver = InstallTemplateResolver(ctx)
+        resolver = InstallTemplateResolver(ctx, KitSourcesProvider(ctx))
     }
 
     private fun createProfileTemplate(name: String): File {
@@ -238,5 +238,79 @@ class InstallTemplateResolverTest : BaseKoinTest() {
 
         requireNotNull(config) { "expected presto ${Constants.Kit.CONFIG_FILE} to be present on classpath" }
         assertThat(config.name).isEqualTo("presto")
+    }
+
+    // ── additional sources ──────────────────────────────────────────────────
+
+    private fun createAdditionalSource(vararg kitNames: String): File {
+        val sourceDir = File(tempDir, "extra-source-${kitNames.first()}").also { it.mkdirs() }
+        for (name in kitNames) {
+            val kitDir = File(sourceDir, name).also { it.mkdirs() }
+            File(kitDir, "start.sh.template").writeText("#!/bin/bash\necho $name")
+        }
+        return sourceDir
+    }
+
+    private fun resolverWithSource(sourceDir: File): InstallTemplateResolver {
+        val provider = KitSourcesProvider(ctx)
+        provider.add("test-source", sourceDir.absolutePath)
+        return InstallTemplateResolver(ctx, provider)
+    }
+
+    @Test
+    fun `kit from additional source appears in listAvailableTemplates`() {
+        val sourceDir = createAdditionalSource("my-external-kit")
+        val r = resolverWithSource(sourceDir)
+        assertThat(r.listAvailableTemplates()).contains("my-external-kit")
+    }
+
+    @Test
+    fun `additional source kit resolves to Directory source`() {
+        val sourceDir = createAdditionalSource("my-external-kit")
+        val r = resolverWithSource(sourceDir)
+        val source = r.resolve("my-external-kit")
+        assertThat(source).isInstanceOf(InstallTemplateResolver.TemplateSource.Directory::class.java)
+        assertThat((source as InstallTemplateResolver.TemplateSource.Directory).dir)
+            .isEqualTo(File(sourceDir, "my-external-kit").canonicalFile)
+    }
+
+    @Test
+    fun `additional source kit shadows built-in of same name`() {
+        val sourceDir = createAdditionalSource("clickhouse")
+        val r = resolverWithSource(sourceDir)
+        val source = r.resolve("clickhouse")
+        assertThat(source).isInstanceOf(InstallTemplateResolver.TemplateSource.Directory::class.java)
+        assertThat((source as InstallTemplateResolver.TemplateSource.Directory).dir)
+            .isEqualTo(File(sourceDir, "clickhouse").canonicalFile)
+    }
+
+    @Test
+    fun `profile kit shadows additional source of same name`() {
+        val sourceDir = createAdditionalSource("mydb")
+        val profileDir = createProfileTemplate("mydb")
+        val r = resolverWithSource(sourceDir)
+        val source = r.resolve("mydb")
+        assertThat(source).isInstanceOf(InstallTemplateResolver.TemplateSource.Directory::class.java)
+        assertThat((source as InstallTemplateResolver.TemplateSource.Directory).dir).isEqualTo(profileDir)
+    }
+
+    @Test
+    fun `missing additional source directory is silently skipped in list`() {
+        val provider = KitSourcesProvider(ctx)
+        provider.add("ghost", "/nonexistent/path/that/does/not/exist")
+        val r = InstallTemplateResolver(ctx, provider)
+        // Should not throw; built-ins still appear
+        val templates = r.listAvailableTemplates()
+        assertThat(templates).contains("clickhouse", "presto")
+    }
+
+    @Test
+    fun `missing additional source directory is silently skipped in resolve`() {
+        val provider = KitSourcesProvider(ctx)
+        provider.add("ghost", "/nonexistent/path/that/does/not/exist")
+        val r = InstallTemplateResolver(ctx, provider)
+        // clickhouse should still resolve to its built-in
+        val source = r.resolve("clickhouse")
+        assertThat(source).isInstanceOf(InstallTemplateResolver.TemplateSource.Builtin::class.java)
     }
 }

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/services/KitSourcesProviderTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/services/KitSourcesProviderTest.kt
@@ -1,0 +1,92 @@
+package com.rustyrazorblade.easydblab.services
+
+import com.rustyrazorblade.easydblab.TestContextFactory
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+class KitSourcesProviderTest {
+    @TempDir
+    lateinit var tempDir: File
+
+    private lateinit var provider: KitSourcesProvider
+
+    @BeforeEach
+    fun setup() {
+        val context = TestContextFactory.createTestContext(tempDir)
+        provider = KitSourcesProvider(context)
+    }
+
+    @Test
+    fun `load returns empty config when kit-sources yaml does not exist`() {
+        assertThat(provider.load().sources).isEmpty()
+    }
+
+    @Test
+    fun `add returns ADDED for new source`() {
+        val dir = File(tempDir, "kits").also { it.mkdirs() }
+        val result = provider.add("myproject", dir.absolutePath)
+        assertThat(result).isEqualTo(AddSourceResult.ADDED)
+        val sources = provider.load().sources
+        assertThat(sources).hasSize(1)
+        assertThat(sources[0].name).isEqualTo("myproject")
+        assertThat(sources[0].path).isEqualTo(dir.canonicalPath)
+    }
+
+    @Test
+    fun `add returns UPDATED when name already exists and updates the path`() {
+        val dir1 = File(tempDir, "kits1").also { it.mkdirs() }
+        val dir2 = File(tempDir, "kits2").also { it.mkdirs() }
+        provider.add("myproject", dir1.absolutePath)
+        val result = provider.add("myproject", dir2.absolutePath)
+        assertThat(result).isEqualTo(AddSourceResult.UPDATED)
+        val sources = provider.load().sources
+        assertThat(sources).hasSize(1)
+        assertThat(sources[0].path).isEqualTo(dir2.canonicalPath)
+    }
+
+    @Test
+    fun `add preserves registration order for multiple sources`() {
+        val dir1 = File(tempDir, "kits1").also { it.mkdirs() }
+        val dir2 = File(tempDir, "kits2").also { it.mkdirs() }
+        provider.add("first", dir1.absolutePath)
+        provider.add("second", dir2.absolutePath)
+        val names = provider.load().sources.map { it.name }
+        assertThat(names).containsExactly("first", "second")
+    }
+
+    @Test
+    fun `add stores path as canonical form`() {
+        val dir = File(tempDir, "kits").also { it.mkdirs() }
+        provider.add("myproject", dir.absolutePath)
+        assertThat(provider.load().sources[0].path).isEqualTo(dir.canonicalPath)
+    }
+
+    @Test
+    fun `remove returns true and deletes source`() {
+        val dir = File(tempDir, "kits").also { it.mkdirs() }
+        provider.add("myproject", dir.absolutePath)
+        val removed = provider.remove("myproject")
+        assertThat(removed).isTrue()
+        assertThat(provider.load().sources).isEmpty()
+    }
+
+    @Test
+    fun `remove returns false for unknown name`() {
+        val removed = provider.remove("doesnotexist")
+        assertThat(removed).isFalse()
+    }
+
+    @Test
+    fun `changes persist across load calls`() {
+        val dir1 = File(tempDir, "kits1").also { it.mkdirs() }
+        val dir2 = File(tempDir, "kits2").also { it.mkdirs() }
+        provider.add("first", dir1.absolutePath)
+        provider.add("second", dir2.absolutePath)
+        provider.remove("first")
+        val names = provider.load().sources.map { it.name }
+        assertThat(names).containsExactly("second")
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `kit source add/list/remove` subcommands to register external directories as additional kit sources
- Kits in registered directories appear in `kit list`, `kit info`, and `kit install` alongside built-in kits
- Registrations persist in `kit-sources.yaml` in the active profile directory (kotlinx.serialization)
- `InstallTemplateResolver` gains a 4th resolution tier: profile-kits → **additional sources** → built-ins → ad-hoc `--from`
- Path canonicalization is handled in `KitSourcesProvider` so relative and absolute paths are treated consistently

Closes #681

## Changes

- New `KitSourcesProvider` + `KitSourcesConfig` data class
- New `commands/kit/source/` package: `KitSource`, `KitSourceAdd`, `KitSourceList`, `KitSourceRemove`
- `InstallTemplateResolver`: injected `KitSourcesProvider`, extracted `listKitNamesIn` helper, updated `listAvailableTemplates()` and `resolve()`
- `ServicesModule`: registered `KitSourcesProvider` singleton
- `Kit.kt`: wired `KitSource` as a subcommand
- 68 tests passing across new and updated files
- Updated `docs/user-guide/kits.md` with external source documentation