### PR TITLE
feat(kits): SQL benchmarking framework with cross-kit targeting

### DIFF
--- a/docs/development/kits.md
+++ b/docs/development/kits.md
@@ -45,15 +45,17 @@ endpoints:
   - name: "HTTP UI"
     node-type: app       # "app" or "db"
     port: 8080
-    type: http           # http | https | jdbc | native | cql
-    scheme: ""           # optional: used for JDBC URLs
-    path: ""             # optional: appended to URL
+    type: http           # http | https | jdbc | native | cql | postgresql | mysql
+    scheme: ""           # optional: used for JDBC URLs (jdbc type only)
+    path: ""             # optional: appended to URL (http/https/jdbc only)
+    database: ""         # optional: logical database name (postgresql and mysql types)
 
 args:
   - flag: --workers
     variable: WORKERS
     description: "Number of workers"
-    type: int            # string | int | float | boolean
+    type: int            # string | int | float | boolean | kit-ref
+    capability: sql      # optional: for kit-ref, declares required capability
     required: false
     default: "${APP_NODE_COUNT}"
 
@@ -392,6 +394,140 @@ datasource under `service_name=<kit>`.
 
 See `docs/user-guide/profiling.md` for how to access profiles in Grafana, profile types, and
 the full observability data flow.
+
+## Bench Kits — cross-kit targeting
+
+A bench kit benchmarks a running database kit. It declares a `kit-ref` arg that the user
+populates with `--target <kit-name>` at install time. The framework then reads the target
+kit's declared endpoints and injects them as `TARGET_*` environment variables into every phase
+script.
+
+### Declaring a kit-ref arg
+
+```yaml
+args:
+  - flag: --target
+    variable: TARGET
+    type: kit-ref
+    capability: sql      # advisory: documents required capability
+    description: "Name of the running database kit to benchmark"
+    required: true
+```
+
+`type: kit-ref` tells easy-db-lab two things:
+1. The installed kit directory is named `<kit>-<target>` instead of `<kit>`, allowing
+   multiple simultaneous instances (e.g. `sysbench-clickhouse` and `sysbench-tidb`).
+2. At start time, `KitEndpointResolver` reads the target kit's `kit.yaml` endpoints and
+   injects them as `TARGET_*` environment variables.
+
+### TARGET_* injection rules
+
+The variables injected depend on what endpoints the target kit declares:
+
+| Endpoint type | Variables injected |
+|---------------|-------------------|
+| `jdbc` | `TARGET_JDBC_URL`, `TARGET_JDBC_USER`, `TARGET_JDBC_DRIVER` |
+| `postgresql` | `TARGET_PG_HOST`, `TARGET_PG_PORT`, `TARGET_PG_USER`, `TARGET_PG_DATABASE` |
+| `mysql` | `TARGET_MYSQL_HOST`, `TARGET_MYSQL_PORT`, `TARGET_MYSQL_USER`, `TARGET_MYSQL_DATABASE` |
+| `http` | `TARGET_HTTP_URL` |
+
+If the target kit directory does not exist or its `kit.yaml` is unreadable, no `TARGET_*`
+variables are injected and no error is raised (fail-safe).
+
+### Wire protocol endpoint types
+
+To expose a PostgreSQL or MySQL wire protocol port, use the corresponding endpoint type:
+
+```yaml
+endpoints:
+  - name: "PostgreSQL wire"
+    node-type: db
+    port: 5432
+    type: postgresql
+    database: "mydb"      # logical database name
+
+  - name: "MySQL wire"
+    node-type: db
+    port: 4000
+    type: mysql
+    database: "test"      # logical database name
+```
+
+The `database` field is also available on `jdbc` endpoints to store the logical database name
+separately from the JDBC URL path.
+
+### SQL capability
+
+Database kits that expose a SQL interface should declare the `sql` capability:
+
+```yaml
+capabilities:
+  - type: sql
+    user: default                            # default username
+    driver-class: com.clickhouse.jdbc.ClickHouseDriver  # JDBC driver (optional)
+```
+
+The `user` and `driver-class` fields are used when constructing `TARGET_JDBC_USER` and
+`TARGET_JDBC_DRIVER` for bench kits targeting this database.
+
+### Making an external kit targetable by bench kits
+
+If you are writing an external kit that exposes a SQL interface and want bench kits like
+sysbench to be able to target it, add three things to your `kit.yaml`:
+
+**1. A `sql` capability** — declares the default username and (for JDBC) the driver class:
+
+```yaml
+capabilities:
+  - type: sql
+    user: root
+    driver-class: com.mysql.cj.jdbc.Driver   # omit if you don't expose JDBC
+```
+
+**2. One or more wire protocol endpoints** — the endpoint type determines which `TARGET_*`
+variables the bench kit receives. Declare one per protocol your database supports:
+
+```yaml
+endpoints:
+  - name: "MySQL wire"
+    node-type: app        # or "db" — must match the node pool your kit runs on
+    port: 3306
+    type: mysql
+    database: "mydb"      # the logical database name bench kits should connect to
+
+  - name: "PostgreSQL wire"
+    node-type: app
+    port: 5432
+    type: postgresql
+    database: "mydb"
+
+  - name: "JDBC"
+    node-type: app
+    port: 3306
+    type: jdbc
+    scheme: mysql
+    path: "/mydb?useSSL=false"
+```
+
+You only need to declare the protocols your database actually supports. A MySQL-compatible
+database only needs the `mysql` endpoint; it does not need to also declare `jdbc` unless
+you want JDBC bench tools to target it.
+
+**3. NodePort service on the declared port** — the bench kit pod runs inside the same
+Kubernetes cluster and connects via the app or db node's private IP. Make sure your kit's
+`start` phase creates a NodePort service exposing the port you declared in the endpoint.
+
+Once these three pieces are in place, a user can install sysbench (or any other bench kit
+that declares `capability: sql`) against your kit:
+
+```bash
+easy-db-lab kit install sysbench --target <your-kit-name>
+easy-db-lab sysbench-<your-kit-name> prepare
+easy-db-lab sysbench-<your-kit-name> start
+```
+
+The capability check at install time will verify your kit exposes `sql` before writing
+any files, so misconfigured targets fail immediately with a clear error.
 
 ## Adding a New Kit
 

--- a/docs/user-guide/kits.md
+++ b/docs/user-guide/kits.md
@@ -36,6 +36,56 @@ easy-db-lab kit install clickhouse --help
 After install, the kit's files are written into a subdirectory of the cluster workspace.
 The kit's lifecycle commands are registered automatically.
 
+## Bench kits — benchmarking a database
+
+Bench kits are a special class of kit that run against an already-running database kit. They
+require a `--target` flag pointing at the installed database kit you want to benchmark.
+
+```bash
+# Install sysbench targeting your running ClickHouse instance
+easy-db-lab kit install sysbench --target clickhouse
+
+# Run the prepare, start, and stop lifecycle as usual
+easy-db-lab sysbench-clickhouse prepare
+easy-db-lab sysbench-clickhouse start
+easy-db-lab sysbench-clickhouse stop
+```
+
+The kit is installed into a directory named `<bench-kit>-<target>` (e.g. `sysbench-clickhouse`).
+This lets you run the same bench kit against multiple databases simultaneously and compare results:
+
+```bash
+easy-db-lab kit install sysbench --target clickhouse
+easy-db-lab kit install sysbench --target tidb
+
+# Both run at the same time — compare results in Grafana
+easy-db-lab sysbench-clickhouse start
+easy-db-lab sysbench-tidb start
+```
+
+### TARGET_* environment variables
+
+When a bench kit starts, easy-db-lab reads the target database's endpoint configuration and
+injects it as environment variables into every phase script:
+
+| Variable | Description |
+|----------|-------------|
+| `TARGET_JDBC_URL` | Full JDBC connection URL (e.g. `jdbc:clickhouse://10.0.1.5:8123/default`) |
+| `TARGET_JDBC_USER` | Database username for JDBC connections |
+| `TARGET_JDBC_DRIVER` | Fully-qualified JDBC driver class name |
+| `TARGET_PG_HOST` | Host for PostgreSQL wire protocol connections |
+| `TARGET_PG_PORT` | Port for PostgreSQL wire protocol connections |
+| `TARGET_PG_USER` | Username for PostgreSQL wire protocol connections |
+| `TARGET_PG_DATABASE` | Database name for PostgreSQL wire protocol connections |
+| `TARGET_MYSQL_HOST` | Host for MySQL wire protocol connections |
+| `TARGET_MYSQL_PORT` | Port for MySQL wire protocol connections |
+| `TARGET_MYSQL_USER` | Username for MySQL wire protocol connections |
+| `TARGET_MYSQL_DATABASE` | Database name for MySQL wire protocol connections |
+| `TARGET_HTTP_URL` | Full URL for HTTP endpoint connections |
+
+Which variables are populated depends on what endpoints the target kit declares. A kit that
+supports both JDBC and PostgreSQL wire protocol will populate both sets.
+
 ## Running kit commands
 
 Every installed kit gains a set of subcommands:

--- a/openspec/changes/sql-benchmarking-framework/.openspec.yaml
+++ b/openspec/changes/sql-benchmarking-framework/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-09

--- a/openspec/changes/sql-benchmarking-framework/design.md
+++ b/openspec/changes/sql-benchmarking-framework/design.md
@@ -1,0 +1,127 @@
+## Context
+
+The kit system lets users install and run database workloads (clickhouse, presto, etc.)
+in a cluster. Each kit lives in its own directory (`<workspace>/<kit-name>/`), is
+tracked by name in `ClusterState.runningKits: Set<String>`, and exposes CLI subcommands
+generated from its directory name by `CommandLineParser`.
+
+Benchmark kits (sysbench, YCSB, pgbench, HammerDB, TPC-H) need to connect to a running
+database kit. There are two gaps in the current architecture:
+
+1. **No cross-kit endpoint discovery.** `TemplateVariables` provides cluster-level env
+   vars (node IPs, counts, region) but nothing kit-specific. A bench kit script has no
+   way to know the JDBC URL or host/port of a running database kit.
+
+2. **No multi-instance support.** `runningKits` is `Set<String>` keyed by kit name.
+   Running `sysbench` against both clickhouse and mysql simultaneously would require two
+   instances of the same kit — impossible today since `sysbench/` can only exist once.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Allow bench kits to declare a `--target <kit>` arg that resolves to `TARGET_*`
+  endpoint env vars at start time.
+- Support `postgresql` and `mysql` wire-protocol endpoints in `kit.yaml` alongside
+  existing `jdbc`, `http`, `native`, `cql`.
+- Enable simultaneous multi-database benchmarking by naming bench kit instances
+  `<bench>-<target>` (e.g., `sysbench-clickhouse`, `sysbench-mysql`).
+- Keep the framework changes minimal — new bench kits should need only `kit.yaml` and
+  shell scripts, no Kotlin.
+
+**Non-Goals:**
+- Shipping specific bench kits (sysbench, YCSB, etc.) — this framework makes them
+  possible; authoring them is separate work.
+- Changing how non-bench kits (db kits, app kits) are named or installed.
+- Automatic wiring or hook-based auto-discovery — targeting is always explicit.
+- Multi-target within a single bench instance (one instance = one target).
+
+## Decisions
+
+### 1. New `kit-ref` arg type drives both naming and env injection
+
+A `kit-ref` arg is declared in `kit.yaml` just like `string` or `int`. The framework
+gives it special treatment in two phases:
+
+- **At install time**: `KitInstallCommand` detects a `kit-ref` arg, reads its value
+  (the target kit name), and passes `instanceName = "${config.name}-${targetKitName}"`
+  to `renderAndWrite()` instead of `config.name`. The `TARGET` variable is written to
+  `.resolved-args` as usual.
+
+- **At start time**: `KitRunnerCommand.buildAugmentedEnv()` detects a `kit-ref` arg in
+  the installed config, reads `TARGET` from `.resolved-args`, loads the target kit's
+  `kit.yaml`, and appends `TARGET_*` vars derived from its endpoints.
+
+**Alternative considered:** a top-level `target:` key in `kit.yaml` (not an arg).
+Rejected because args already have variable, description, and required semantics. Reusing
+the arg system means no new parsing path and the target appears naturally in `kit info`.
+
+**Alternative considered:** injecting all running kits' endpoints always (e.g.,
+`CLICKHOUSE_JDBC_URL` always present). Rejected because it creates env var pollution and
+doesn't solve the multi-instance naming problem.
+
+### 2. Instance directory name = `<kit>-<target>`
+
+`BaseInstallCommand.renderAndWrite()` already takes `kitName: String` as the directory
+key. `KitInstallCommand` computes `instanceName = "${config.name}-$target"` when a
+`kit-ref` arg is present, and passes that as `kitName`. No change to `BaseInstallCommand`
+or `CommandLineParser` — the scanner already uses `kitDir.name` as the subcommand name.
+
+`runningKits` naturally stores instance names (`sysbench-clickhouse`, `sysbench-mysql`)
+since `ClusterStateManager.markKitRunning(name)` is called with whatever name the running
+command knows itself as.
+
+### 3. `TARGET_*` env var naming convention
+
+For each endpoint type declared in the target kit's `kit.yaml`:
+
+| Endpoint type | Vars injected |
+|---------------|---------------|
+| `jdbc`        | `TARGET_JDBC_URL`, `TARGET_JDBC_USER`, `TARGET_JDBC_DRIVER` |
+| `postgresql`  | `TARGET_PG_HOST`, `TARGET_PG_PORT`, `TARGET_PG_USER`, `TARGET_PG_DATABASE` |
+| `mysql`       | `TARGET_MYSQL_HOST`, `TARGET_MYSQL_PORT`, `TARGET_MYSQL_USER`, `TARGET_MYSQL_DATABASE` |
+| `http`        | `TARGET_HTTP_URL` |
+
+The node IP is resolved from cluster state using the endpoint's `node-type` (same logic
+as `KitJdbcSqlService`). The `user` comes from the target kit's `capabilities` block (sql
+capability). The `database` for wire-protocol endpoints comes from a new optional
+`database` field on `KitEndpoint`.
+
+### 4. New `KitEndpointResolver` service
+
+Target endpoint resolution is extracted into a dedicated `KitEndpointResolver` service
+rather than added to `KitRunnerCommand` or `TemplateVariables`. This keeps `TemplateVariables`
+as a pure cluster-state view and gives the resolver a single responsibility:
+`resolveTargetVars(targetKitDir: File, clusterState: ClusterState): Map<String, String>`.
+
+`KitRunnerCommand` calls this service when it detects a `kit-ref` arg in the installed
+config, merging the result into `augmentedEnv`.
+
+### 5. `capability` field on `kit-ref` arg is advisory at this stage
+
+The `capability` field (e.g., `capability: sql`) on a `kit-ref` arg declares the
+intended requirement. In this first version the framework logs a warning but does not
+fail-fast if the target kit does not declare that capability — endpoint availability is
+the actual enforced contract. Hard validation can be added once bench kit authors have
+real usage patterns.
+
+## Risks / Trade-offs
+
+- **Instance name collision**: Two installs of `sysbench --target clickhouse` produce the
+  same directory. `collision-check: true` on bench kits will catch this with the existing
+  collision detection path. Bench kit authors should set `collision-check: true`.
+
+- **Target kit not installed**: If `sysbench-clickhouse start` runs but the `clickhouse/`
+  directory is missing or has no readable `kit.yaml`, `KitEndpointResolver` returns an
+  empty map and the script gets no `TARGET_*` vars. The script will fail with a clear
+  missing-variable error. This is acceptable fail-fast behaviour.
+
+- **wire-protocol endpoint info is partial without `database`**: The new `database` field
+  on `KitEndpoint` is optional. If absent, `TARGET_PG_DATABASE` / `TARGET_MYSQL_DATABASE`
+  are empty strings. Kit authors must add the field for wire-protocol bench kits to work.
+
+## Migration Plan
+
+No cluster migration required — clusters are ephemeral. New `EndpointType` values
+(`POSTGRESQL`, `MYSQL`) are additive; existing `kit.yaml` files continue to parse
+correctly. The `kit-ref` `ArgType` is additive — existing kits with no `kit-ref` args
+are unaffected.

--- a/openspec/changes/sql-benchmarking-framework/proposal.md
+++ b/openspec/changes/sql-benchmarking-framework/proposal.md
@@ -1,0 +1,54 @@
+## Why
+
+easy-db-lab is adding support for many SQL databases. There is currently no way to run
+SQL benchmarking tools (sysbench, YCSB, pgbench, HammerDB, etc.) against those databases,
+and no mechanism for one kit to discover and connect to another running kit's endpoints.
+Without this, comparing database performance in the same cluster is not possible.
+
+## What Changes
+
+- `kit.yaml` gains a new arg type `kit-ref` that declares a cross-kit dependency on a
+  running kit's SQL endpoints. Installing a bench kit with `--target <kit>` creates a
+  named instance directory `<bench>-<target>/`, enabling multiple bench kits to run
+  simultaneously against different databases.
+- `KitEndpoint.EndpointType` gains two new values: `postgresql` (PostgreSQL wire protocol)
+  and `mysql` (MySQL wire protocol), alongside the existing `jdbc`, `http`, and `native`.
+- When a bench kit with a `kit-ref` arg starts, the framework resolves the named target
+  kit's endpoints from its `kit.yaml` and injects `TARGET_*` environment variables into
+  the start script (e.g., `TARGET_JDBC_URL`, `TARGET_PG_HOST`, `TARGET_MYSQL_HOST`).
+- Kit install creates a `<bench>-<target>/` directory and registers the instance as a
+  separate CLI subcommand, allowing `sysbench-clickhouse` and `sysbench-mysql` to run
+  simultaneously in the same cluster.
+- `runningKits` in `ClusterState` naturally tracks instance names (e.g.,
+  `sysbench-clickhouse`, `sysbench-mysql`) — no structural change required.
+
+## Capabilities
+
+### New Capabilities
+
+- `kit-cross-targeting`: A `kit-ref` arg type for bench kits that resolves a named
+  running kit's SQL endpoints into `TARGET_*` environment variables at start time,
+  and controls instance directory naming at install time.
+- `wire-protocol-endpoints`: `postgresql` and `mysql` endpoint types in `kit.yaml`,
+  producing `TARGET_PG_*` and `TARGET_MYSQL_*` env vars respectively.
+
+### Modified Capabilities
+
+- `kit-capabilities`: The arg type system gains a new `kit-ref` type. Validation at
+  install time checks that the named target kit is installed and declares the required
+  capability. This is a spec-level behaviour change — new requirement on the `args:`
+  block.
+
+## Impact
+
+- `services/KitConfig.kt` — add `KIT_REF` to `KitArgSpec.ArgType`; add `POSTGRESQL`
+  and `MYSQL` to `KitEndpoint.EndpointType`
+- `services/TemplateVariables.kt` — new `buildTargetEndpointVars()` that reads a target
+  kit's `kit.yaml` endpoints and produces `TARGET_*` vars
+- `commands/install/KitInstallCommand.kt` — detect `kit-ref` arg; resolve instance
+  directory name as `<kit>-<target>`; inject target endpoint vars at start time
+- `commands/install/KitRunnerCommand.kt` — inject `TARGET_*` vars from target kit
+  endpoints when a `kit-ref` arg is present in the installed config
+- `openspec/specs/kit-capabilities/spec.md` — delta: new `kit-ref` arg type requirements
+- `openspec/specs/kit-cross-targeting/spec.md` — new spec
+- `openspec/specs/wire-protocol-endpoints/spec.md` — new spec

--- a/openspec/changes/sql-benchmarking-framework/specs/kit-capabilities/spec.md
+++ b/openspec/changes/sql-benchmarking-framework/specs/kit-capabilities/spec.md
@@ -1,0 +1,14 @@
+## ADDED Requirements
+
+### Requirement: kit-ref is a valid arg type in the capabilities arg system
+The `capabilities` arg system (REQ-KCAP-001) already supports typed args (`string`,
+`int`, `boolean`, `float`). A new `kit-ref` type SHALL be valid in the `args:` block
+of any kit, with the same `flag`, `variable`, `description`, and `required` fields.
+
+#### Scenario: kit-ref arg parsed alongside other arg types
+- **WHEN** a `kit.yaml` declares args including one with `type: kit-ref`
+- **THEN** all args including the `kit-ref` entry deserialize without error
+
+#### Scenario: kit-ref arg appears in kit info output
+- **WHEN** the user runs `easy-db-lab kit info <bench-kit-name>`
+- **THEN** the `kit-ref` arg is listed with its flag, variable, and description

--- a/openspec/changes/sql-benchmarking-framework/specs/kit-cross-targeting/spec.md
+++ b/openspec/changes/sql-benchmarking-framework/specs/kit-cross-targeting/spec.md
@@ -1,0 +1,93 @@
+## ADDED Requirements
+
+### Requirement: kit-ref arg type for cross-kit targeting
+A kit arg with `type: kit-ref` SHALL declare a dependency on a running kit's SQL
+endpoints. The `capability` field is advisory metadata documenting intent; the `variable`
+field names the env var that stores the target kit name (conventionally `TARGET`).
+
+#### Scenario: kit-ref arg declared in kit.yaml
+- **WHEN** a `kit.yaml` contains an arg with `type: kit-ref`
+- **THEN** the arg is parsed without error and `KitArgSpec.type` is `KIT_REF`
+
+#### Scenario: Unknown arg types are ignored gracefully
+- **WHEN** a `kit.yaml` contains an arg with an unrecognised type
+- **THEN** deserialization does not throw; the arg defaults to `STRING` type
+
+### Requirement: Instance directory named after bench kit and target
+When a bench kit is installed and its `kit-ref` arg is provided, the install command
+SHALL create a directory named `<kit-name>-<target-kit-name>` in the cluster workspace
+rather than the kit's base name.
+
+#### Scenario: Bench kit installed with target
+- **WHEN** the user runs `easy-db-lab kit install sysbench --target clickhouse`
+- **THEN** a directory named `sysbench-clickhouse` is created in the cluster workspace
+- **AND** the directory contains the rendered kit files
+
+#### Scenario: Same bench kit installed with different target
+- **WHEN** the user runs `easy-db-lab kit install sysbench --target mysql`
+- **THEN** a directory named `sysbench-mysql` is created
+- **AND** the `sysbench-clickhouse` directory is unaffected
+
+#### Scenario: Bench kit appears as its own CLI subcommand
+- **WHEN** `sysbench-clickhouse` and `sysbench-mysql` directories exist in the workspace
+- **THEN** both `easy-db-lab sysbench-clickhouse` and `easy-db-lab sysbench-mysql` are
+  registered as CLI subcommands
+- **AND** each has independent `start`, `stop`, and `status` subcommands
+
+### Requirement: TARGET_* env vars injected at start time
+When a bench kit with a `kit-ref` arg is started, the framework SHALL read the target
+kit's `kit.yaml` from its directory in the workspace and inject `TARGET_*` environment
+variables derived from each declared endpoint into the start script's environment.
+
+#### Scenario: JDBC endpoint produces TARGET_JDBC_* vars
+- **WHEN** a bench kit starts with `TARGET=clickhouse`
+- **AND** `clickhouse/kit.yaml` declares a `jdbc` endpoint on port 30123 with scheme
+  `clickhouse` and path `/default?compress=0`
+- **AND** cluster state contains a db node with private IP `10.0.1.5`
+- **THEN** the start script environment contains:
+  - `TARGET_JDBC_URL=jdbc:clickhouse://10.0.1.5:30123/default?compress=0`
+  - `TARGET_JDBC_USER=default` (from the target kit's `sql` capability `user` field)
+  - `TARGET_JDBC_DRIVER=<driver-class>` (from the `sql` capability `driver-class` field,
+    or empty string if absent)
+
+#### Scenario: PostgreSQL wire endpoint produces TARGET_PG_* vars
+- **WHEN** a bench kit starts with `TARGET=somedb`
+- **AND** `somedb/kit.yaml` declares a `postgresql` endpoint on port 5432 with
+  `database: mydb` and `user: bench`
+- **AND** cluster state contains a db node with private IP `10.0.1.5`
+- **THEN** the start script environment contains:
+  - `TARGET_PG_HOST=10.0.1.5`
+  - `TARGET_PG_PORT=5432`
+  - `TARGET_PG_USER=bench`
+  - `TARGET_PG_DATABASE=mydb`
+
+#### Scenario: MySQL wire endpoint produces TARGET_MYSQL_* vars
+- **WHEN** a bench kit starts with `TARGET=somedb`
+- **AND** `somedb/kit.yaml` declares a `mysql` endpoint on port 3306 with `database: bench`
+- **AND** cluster state contains a db node with private IP `10.0.1.5`
+- **THEN** the start script environment contains:
+  - `TARGET_MYSQL_HOST=10.0.1.5`
+  - `TARGET_MYSQL_PORT=3306`
+  - `TARGET_MYSQL_USER=` (empty if not declared)
+  - `TARGET_MYSQL_DATABASE=bench`
+
+#### Scenario: Multiple endpoint types all injected
+- **WHEN** the target kit declares both a `jdbc` endpoint and a `postgresql` endpoint
+- **THEN** both `TARGET_JDBC_*` and `TARGET_PG_*` vars are present in the environment
+
+#### Scenario: Target kit directory missing
+- **WHEN** a bench kit starts with `TARGET=nonexistent`
+- **AND** no `nonexistent/` directory exists in the workspace
+- **THEN** no `TARGET_*` vars are injected
+- **AND** the start script proceeds (and fails naturally if it references those vars)
+
+### Requirement: runningKits tracks bench instances by instance name
+`ClusterState.runningKits` SHALL store the instance name (e.g., `sysbench-clickhouse`)
+for bench kit instances, not the base kit name. This allows multiple instances of the
+same bench kit to be tracked independently.
+
+#### Scenario: Two bench instances tracked independently
+- **WHEN** `sysbench-clickhouse start` and `sysbench-mysql start` both complete
+  successfully
+- **THEN** `runningKits` contains both `sysbench-clickhouse` and `sysbench-mysql`
+- **AND** stopping `sysbench-clickhouse` does not affect `sysbench-mysql`

--- a/openspec/changes/sql-benchmarking-framework/specs/wire-protocol-endpoints/spec.md
+++ b/openspec/changes/sql-benchmarking-framework/specs/wire-protocol-endpoints/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: postgresql endpoint type in kit.yaml
+`kit.yaml` SHALL support `type: postgresql` in the `endpoints:` list, representing a
+PostgreSQL wire-protocol listener. An optional `database` field names the default
+database.
+
+#### Scenario: postgresql endpoint declared and parsed
+- **WHEN** a `kit.yaml` contains an endpoint with `type: postgresql`
+- **THEN** `KitEndpoint.type` is `POSTGRESQL` with correct port and optional `database`
+
+#### Scenario: postgresql endpoint not in formatUrl
+- **WHEN** `KitEndpoint.formatUrl()` is called on a `POSTGRESQL` endpoint
+- **THEN** it returns the host:port string (same as `NATIVE`/`CQL`)
+
+### Requirement: mysql endpoint type in kit.yaml
+`kit.yaml` SHALL support `type: mysql` in the `endpoints:` list, representing a MySQL
+wire-protocol listener. An optional `database` field names the default database.
+
+#### Scenario: mysql endpoint declared and parsed
+- **WHEN** a `kit.yaml` contains an endpoint with `type: mysql`
+- **THEN** `KitEndpoint.type` is `MYSQL` with correct port and optional `database`
+
+### Requirement: database field on KitEndpoint
+`KitEndpoint` SHALL support an optional `database: String` field (default empty string)
+used by wire-protocol endpoints to identify the default database name.
+
+#### Scenario: database field present
+- **WHEN** an endpoint declares `database: mydb`
+- **THEN** `KitEndpoint.database` equals `"mydb"`
+
+#### Scenario: database field absent
+- **WHEN** an endpoint omits the `database` field
+- **THEN** `KitEndpoint.database` is an empty string

--- a/openspec/changes/sql-benchmarking-framework/tasks.md
+++ b/openspec/changes/sql-benchmarking-framework/tasks.md
@@ -1,0 +1,133 @@
+## 1. Endpoint model: new types and database field
+
+- [x] 1.1 Add `POSTGRESQL` and `MYSQL` to `KitEndpoint.EndpointType` enum in
+  `services/KitConfig.kt` with `@SerialName("postgresql")` and `@SerialName("mysql")`
+- [x] 1.2 Add optional `database: String = ""` field to `KitEndpoint` data class
+- [x] 1.3 Update `KitEndpoint.formatUrl()` to handle `POSTGRESQL` and `MYSQL` the same
+  as `NATIVE` (return `"$ip:$port"`)
+- [x] 1.4 Unit tests in `KitConfigTest`:
+  - `postgresql` endpoint deserializes with correct type, port, and `database` field
+  - `mysql` endpoint deserializes with correct type, port, and `database` field
+  - Existing endpoint types (`jdbc`, `http`, `native`, `cql`) unaffected
+  - `database` field absent → empty string default
+
+## 2. Arg model: kit-ref type
+
+- [x] 2.1 Add `KIT_REF` to `KitArgSpec.ArgType` enum in `services/KitConfig.kt` with
+  `@SerialName("kit-ref")`
+- [x] 2.2 Add optional `capability: String = ""` field to `KitArgSpec` data class
+  (advisory metadata; not enforced in this version)
+- [x] 2.3 Unit tests in `KitConfigTest`:
+  - Arg with `type: kit-ref` deserializes to `ArgType.KIT_REF`
+  - Arg with `type: kit-ref` and `capability: sql` deserializes with `capability = "sql"`
+  - Existing arg types (`string`, `int`, `boolean`, `float`) unaffected
+
+## 3. KitEndpointResolver service
+
+- [x] 3.1 Create `services/KitEndpointResolver.kt`:
+  - Interface: `resolveTargetVars(targetKitDir: File, clusterState: ClusterState): Map<String, String>`
+  - Implementation reads `kit.yaml` from `targetKitDir`; if missing or unreadable, returns empty map
+  - For each endpoint in the target kit's `endpoints:` list, resolves the node IP from
+    `clusterState` using the endpoint's `node-type` (via `ServerType.from()`)
+  - If no node of that type exists, skips that endpoint (no error)
+  - Produces vars per endpoint type:
+    - `JDBC` → `TARGET_JDBC_URL` (via `endpoint.formatUrl(ip)`), `TARGET_JDBC_USER`
+      (from first `sql` capability `user`), `TARGET_JDBC_DRIVER` (from `driver-class`)
+    - `POSTGRESQL` → `TARGET_PG_HOST`, `TARGET_PG_PORT`, `TARGET_PG_USER`,
+      `TARGET_PG_DATABASE`
+    - `MYSQL` → `TARGET_MYSQL_HOST`, `TARGET_MYSQL_PORT`, `TARGET_MYSQL_USER`,
+      `TARGET_MYSQL_DATABASE`
+    - `HTTP` → `TARGET_HTTP_URL` (via `endpoint.formatUrl(ip)`)
+- [x] 3.2 Register `KitEndpointResolver` as a Koin singleton in `ServicesModule.kt`
+- [x] 3.3 Unit tests in `KitEndpointResolverTest`:
+  - JDBC endpoint with db node → correct `TARGET_JDBC_URL`, `TARGET_JDBC_USER`,
+    `TARGET_JDBC_DRIVER`
+  - POSTGRESQL endpoint with db node → correct `TARGET_PG_*` vars
+  - MYSQL endpoint with db node → correct `TARGET_MYSQL_*` vars
+  - Target kit directory missing → returns empty map, no exception
+  - Target kit has unparseable `kit.yaml` → returns empty map, no exception
+  - Endpoint node-type has no nodes in cluster state → that endpoint skipped, others
+    still injected
+  - Multiple endpoint types on one target kit → all vars injected
+
+## 4. Install: instance directory naming
+
+- [x] 4.1 In `KitInstallCommand.execute()`, detect if any arg has `type == ArgType.KIT_REF`
+- [x] 4.2 If a `kit-ref` arg is present, read its resolved value from `argValues` and
+  compute `instanceName = "${config.name}-${targetValue}"`
+- [x] 4.3 Pass `instanceName` (instead of `config.name`) as the `kitName` parameter to
+  `renderAndWrite()`
+- [x] 4.4 Unit tests in `KitInstallCommandTest`:
+  - Kit config with `kit-ref` arg and `--target clickhouse` → directory created as
+    `sysbench-clickhouse`
+  - Kit config with no `kit-ref` arg → directory created as kit's own name (unchanged)
+
+## 5. Runtime: TARGET_* env var injection
+
+- [x] 5.1 In `KitRunnerCommand.buildAugmentedEnv()`, check if the installed kit config
+  has any arg with `type == ArgType.KIT_REF`
+- [x] 5.2 If found, read the target kit name from `resolvedArgs` using the arg's `variable`
+  field (typically `TARGET`)
+- [x] 5.3 Resolve `targetKitDir = File(kitDir.parentFile, targetKitName)` and call
+  `KitEndpointResolver.resolveTargetVars(targetKitDir, clusterState)`
+- [x] 5.4 Merge the returned vars into the augmented env (highest priority — overrides
+  any colliding key)
+- [x] 5.5 Inject `KitEndpointResolver` into `KitRunnerCommand` via Koin
+- [x] 5.6 Unit tests in `KitRunnerCommandTest`:
+  - Kit with `kit-ref` arg and valid target dir → `TARGET_JDBC_URL` present in env
+  - Kit with `kit-ref` arg and missing target dir → no `TARGET_*` vars, no exception
+  - Kit with no `kit-ref` arg → resolver not called, env unchanged
+
+## 6. Update existing kit.yaml files
+
+- [x] 6.1 Add `database` field to the ClickHouse `JDBC` endpoint in
+  `kits/clickhouse/kit.yaml` (value: `"default"`)
+- [x] 6.2 Add `database` field to the Presto `JDBC` endpoint in
+  `kits/presto/kit.yaml` (value: `""` or omit — Presto uses catalog.schema syntax)
+
+## 7. Documentation
+
+- [x] 7.1 Update `docs/` (user-facing) with a section on bench kits: how to install
+  with `--target`, the `TARGET_*` env vars available, and the multi-instance naming
+  convention
+- [x] 7.2 Update `kits/CLAUDE.md` or equivalent internal guide with the `kit-ref` arg
+  type, `postgresql`/`mysql` endpoint types, and the `database` field
+
+## 8. Sysbench reference kit
+
+- [x] 8.1 Create `src/main/resources/com/rustyrazorblade/easydblab/kits/sysbench/kit.yaml`:
+  - `type: app`, `collision-check: true`
+  - `--target` arg: `type: kit-ref`, `variable: TARGET`, `capability: sql`, required
+  - `--threads` arg: `type: int`, default `4`
+  - `--duration` arg: `type: int`, description "benchmark duration in seconds", default `60`
+  - `--workload` arg: `type: string`, default `oltp_read_write`
+    (sysbench built-in: `oltp_read_write`, `oltp_read_only`, `oltp_write_only`)
+  - `--scale` arg: `type: int`, description "number of rows per table (thousands)", default `10`
+  - `--tables` arg: `type: int`, default `10`
+
+- [x] 8.2 Create `bin/prepare.sh`:
+  - Detect driver from env: if `TARGET_MYSQL_HOST` is set use `--db-driver=mysql` with
+    `TARGET_MYSQL_*` vars; else if `TARGET_PG_HOST` is set use `--db-driver=pgsql` with
+    `TARGET_PG_*` vars; else exit 1 with a clear message
+  - Run `sysbench ... --tables=${TABLES} --table-size=${SCALE}000 ${WORKLOAD} prepare`
+    via `kubectl run sysbench-prepare-${KIT_NAME}` with `docker.io/severalnines/sysbench`
+    image, `--restart=Never`, using `KUBECONFIG`
+  - Wait for pod to complete (`kubectl wait --for=condition=complete`) then delete it
+
+- [x] 8.3 Create `bin/start.sh`:
+  - Same driver detection as `prepare.sh`
+  - Run sysbench benchmark as a long-running pod:
+    `kubectl run sysbench-${KIT_NAME}` with `--restart=Never`,
+    `sysbench ... --threads=${THREADS} --time=${DURATION} ${WORKLOAD} run`
+  - Tail pod logs so output is visible to the user
+
+- [x] 8.4 Create `bin/stop.sh`:
+  - Delete the running sysbench pod: `kubectl delete pod sysbench-${KIT_NAME} --ignore-not-found`
+  - Run sysbench cleanup job (same pattern as prepare): `${WORKLOAD} cleanup`
+
+- [x] 8.5 Validate end-to-end against TiDB (MySQL wire) and PostgreSQL (PG wire):
+  - `easy-db-lab kit install sysbench --target tidb` → creates `sysbench-tidb/`
+  - `easy-db-lab sysbench-tidb prepare` → loads test data
+  - `easy-db-lab sysbench-tidb start` → benchmark runs and outputs TPS/latency
+  - `easy-db-lab sysbench-tidb stop` → pod deleted, cleanup runs
+  - Repeat with `--target postgres`

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/install/KitInstallCommand.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/install/KitInstallCommand.kt
@@ -9,6 +9,7 @@ import com.rustyrazorblade.easydblab.services.KitType
 import com.rustyrazorblade.easydblab.services.StepExecutionContext
 import com.rustyrazorblade.easydblab.services.TemplateVariables
 import com.rustyrazorblade.easydblab.services.WorkloadStepExecutor
+import com.rustyrazorblade.easydblab.services.installConfigYaml
 import org.koin.core.component.inject
 import java.io.File
 
@@ -54,10 +55,14 @@ class KitInstallCommand(
             argValues.putIfAbsent(variable, default)
         }
 
+        validateKitRefCapability()
+
+        val instanceName = resolveInstanceName()
+
         if (config.collisionCheck && !force) {
-            val outputDir = File(context.workingDirectory, config.name)
+            val outputDir = File(context.workingDirectory, instanceName)
             if (outputDir.isDirectory && outputDir.listFiles().orEmpty().isNotEmpty()) {
-                eventBus.emit(Event.Install.CollisionDetected(kit = config.name))
+                eventBus.emit(Event.Install.CollisionDetected(kit = instanceName))
                 return
             }
         }
@@ -65,7 +70,7 @@ class KitInstallCommand(
         val storageSize = argValues.remove("STORAGE_SIZE").orEmpty()
         renderAndWrite(
             source = source,
-            kitName = config.name,
+            kitName = instanceName,
             storageSize = storageSize,
             extraVars = argValues.toMap(),
         )
@@ -74,10 +79,10 @@ class KitInstallCommand(
             val controlHost =
                 clusterState.getControlHost()
                     ?: error("No control node found in cluster state")
-            val kitDir = File(context.workingDirectory, config.name)
+            val kitDir = File(context.workingDirectory, instanceName)
             val variables =
                 TemplateVariables
-                    .from(state = clusterState, kitName = config.name, storageSize = storageSize)
+                    .from(state = clusterState, kitName = instanceName, storageSize = storageSize)
                     .toMap() + argValues
 
             runCatching {
@@ -87,7 +92,7 @@ class KitInstallCommand(
                         phase = Constants.Kit.PHASE_INSTALL,
                         context =
                             StepExecutionContext(
-                                kitName = config.name,
+                                kitName = instanceName,
                                 controlHost = controlHost,
                                 clusterState = clusterState,
                                 variables = variables,
@@ -100,4 +105,38 @@ class KitInstallCommand(
             }
         }
     }
+
+    /**
+     * Validates that the target kit declared by a kit-ref arg exposes the required capability.
+     * Fails fast with a clear error rather than letting the bench kit fail at runtime.
+     */
+    private fun validateKitRefCapability() {
+        val kitRefArg = config.kitRefArg ?: return
+        val requiredCapability = kitRefArg.capability.takeIf { it.isNotBlank() } ?: return
+        val targetName = argValues[kitRefArg.variable]?.takeIf { it.isNotBlank() } ?: return
+
+        val targetKitDir = File(context.workingDirectory, targetName)
+        val configFile = File(targetKitDir, Constants.Kit.CONFIG_FILE)
+        check(configFile.isFile) {
+            "Target kit '$targetName' is not installed (expected $configFile)"
+        }
+
+        val targetConfig = installConfigYaml.decodeFromString(KitConfig.serializer(), configFile.readText())
+        val hasCapability = targetConfig.capabilities.any { it.type == requiredCapability }
+        check(hasCapability) {
+            "Target kit '$targetName' does not have the '$requiredCapability' capability required by ${config.name}"
+        }
+    }
+
+    /**
+     * Computes the directory name for the installed kit. For kits with a kit-ref arg,
+     * the directory is named `<kit>-<target>` so the same bench kit can be installed
+     * against multiple databases simultaneously (e.g. sysbench-clickhouse, sysbench-mysql).
+     * For kits without a kit-ref arg, the directory is the kit's own name.
+     */
+    private fun resolveInstanceName(): String =
+        config.kitRefArg
+            ?.let { argValues[it.variable]?.takeIf { v -> v.isNotBlank() } }
+            ?.let { "${config.name}-$it" }
+            ?: config.name
 }

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/install/KitInstallCommandFactory.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/install/KitInstallCommandFactory.kt
@@ -73,7 +73,7 @@ class KitInstallCommandFactory(
         val resolvedDefault = resolveDefault(arg.default, templateVars)
         val picoType =
             when (arg.type) {
-                KitArgSpec.ArgType.STRING -> String::class.java
+                KitArgSpec.ArgType.STRING, KitArgSpec.ArgType.KIT_REF -> String::class.java
                 KitArgSpec.ArgType.BOOLEAN -> Boolean::class.java
                 KitArgSpec.ArgType.FLOAT -> Double::class.java
                 KitArgSpec.ArgType.INT -> Int::class.java

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/install/KitRunnerCommand.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/install/KitRunnerCommand.kt
@@ -8,6 +8,7 @@ import com.rustyrazorblade.easydblab.services.DashboardRef
 import com.rustyrazorblade.easydblab.services.GrafanaDashboardService
 import com.rustyrazorblade.easydblab.services.InstallStep
 import com.rustyrazorblade.easydblab.services.KitConfig
+import com.rustyrazorblade.easydblab.services.KitEndpointResolver
 import com.rustyrazorblade.easydblab.services.KitHookExecutor
 import com.rustyrazorblade.easydblab.services.KitMetrics
 import com.rustyrazorblade.easydblab.services.MetricsRegistryService
@@ -36,6 +37,7 @@ class KitRunnerCommand(
     private val workloadStepExecutor: WorkloadStepExecutor by inject()
     private val metricsRegistryService: MetricsRegistryService by inject()
     private val kitHookExecutor: KitHookExecutor by inject()
+    private val kitEndpointResolver: KitEndpointResolver by inject()
 
     private var processExitCode: Int = 0
 
@@ -75,7 +77,13 @@ class KitRunnerCommand(
         // argDefaults first so cluster-state values in base take precedence over kit defaults;
         // resolvedArgs overlays defaults with user-specified install-time values.
         val env = argDefaults + resolvedArgs + base + ("KUBECONFIG" to absoluteKubeconfig)
-        return env + ("BACKUP_NAME" to name)
+        val targetVars =
+            config
+                ?.kitRefArg
+                ?.let { resolvedArgs[it.variable]?.takeIf { v -> v.isNotBlank() } }
+                ?.let { kitEndpointResolver.resolveTargetVars(File(kitDir.parentFile, it), clusterState) }
+                .orEmpty()
+        return env + ("BACKUP_NAME" to name) + targetVars
     }
 
     /**

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/mcp/ChannelMessageBuffer.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/mcp/ChannelMessageBuffer.kt
@@ -84,7 +84,7 @@ class ChannelMessageBuffer(
      * @param message The message to clean
      * @return The cleaned message
      */
-    private fun cleanMessage(message: String): String {
+    internal fun cleanMessage(message: String): String {
         // Remove ANSI escape sequences (e.g., color codes)
         // Pattern matches ESC followed by [ and any number of digits, semicolons, and letters
         val noAnsi = message.replace(Regex("\u001b\\[[0-9;]*[a-zA-Z]"), "")

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/KitConfig.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/KitConfig.kt
@@ -48,6 +48,7 @@ data class KitEndpoint(
     val type: EndpointType,
     val scheme: String = "",
     val path: String = "",
+    val database: String = "",
 ) {
     @Serializable
     enum class EndpointType {
@@ -65,6 +66,12 @@ data class KitEndpoint(
 
         @SerialName("cql")
         CQL,
+
+        @SerialName("postgresql")
+        POSTGRESQL,
+
+        @SerialName("mysql")
+        MYSQL,
     }
 
     /** Formats a connection URL for this endpoint using [ip] as the host address. */
@@ -74,7 +81,45 @@ data class KitEndpoint(
             EndpointType.HTTPS -> "https://$ip:$port$path"
             EndpointType.JDBC -> "jdbc:$scheme://$ip:$port$path"
             EndpointType.NATIVE, EndpointType.CQL -> "$ip:$port"
+            EndpointType.POSTGRESQL -> "postgresql://$ip:$port/$database"
+            EndpointType.MYSQL -> "mysql://$ip:$port/$database"
         }
+
+    /**
+     * Produces TARGET_* environment variables for this endpoint given the resolved [ip]
+     * and the kit's [sqlCap]. Returns an empty map for endpoint types with no TARGET_*
+     * convention (HTTPS, NATIVE, CQL).
+     */
+    fun toTargetVars(
+        ip: String,
+        sqlCap: KitCapability?,
+    ): Map<String, String> {
+        val sqlUser = sqlCap?.user.orEmpty()
+        return when (type) {
+            EndpointType.JDBC ->
+                mapOf(
+                    "TARGET_JDBC_URL" to formatUrl(ip),
+                    "TARGET_JDBC_USER" to sqlUser,
+                    "TARGET_JDBC_DRIVER" to sqlCap?.driverClass.orEmpty(),
+                )
+            EndpointType.POSTGRESQL ->
+                mapOf(
+                    "TARGET_PG_HOST" to ip,
+                    "TARGET_PG_PORT" to port.toString(),
+                    "TARGET_PG_USER" to sqlUser,
+                    "TARGET_PG_DATABASE" to database,
+                )
+            EndpointType.MYSQL ->
+                mapOf(
+                    "TARGET_MYSQL_HOST" to ip,
+                    "TARGET_MYSQL_PORT" to port.toString(),
+                    "TARGET_MYSQL_USER" to sqlUser,
+                    "TARGET_MYSQL_DATABASE" to database,
+                )
+            EndpointType.HTTP -> mapOf("TARGET_HTTP_URL" to formatUrl(ip))
+            else -> emptyMap()
+        }
+    }
 }
 
 @Serializable
@@ -173,6 +218,8 @@ data class KitConfig(
     val type: KitType? = null,
     val capabilities: List<KitCapability> = emptyList(),
 ) {
+    val kitRefArg: KitArgSpec? get() = args.firstOrNull { it.type == KitArgSpec.ArgType.KIT_REF }
+
     fun stepsForPhase(phaseName: String): List<InstallStep> =
         when (phaseName) {
             Constants.Kit.PHASE_INSTALL -> install
@@ -217,6 +264,7 @@ data class KitArgSpec(
     val required: Boolean = false,
     val type: ArgType = ArgType.STRING,
     val default: String = "",
+    val capability: String = "",
 ) {
     @Serializable
     enum class ArgType {
@@ -231,6 +279,9 @@ data class KitArgSpec(
 
         @SerialName("int")
         INT,
+
+        @SerialName("kit-ref")
+        KIT_REF,
     }
 }
 

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/KitEndpointResolver.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/KitEndpointResolver.kt
@@ -1,0 +1,74 @@
+package com.rustyrazorblade.easydblab.services
+
+import com.rustyrazorblade.easydblab.Constants
+import com.rustyrazorblade.easydblab.configuration.ClusterState
+import com.rustyrazorblade.easydblab.configuration.ServerType
+import io.github.oshai.kotlinlogging.KotlinLogging
+import java.io.File
+
+/**
+ * Resolves the SQL endpoint details of a target kit into TARGET_* environment variables.
+ *
+ * When a bench kit starts with a kit-ref arg (e.g. --target clickhouse), this service
+ * reads the target kit's kit.yaml from its workspace directory and produces env vars
+ * such as TARGET_JDBC_URL, TARGET_PG_HOST, and TARGET_MYSQL_HOST. The bench kit's
+ * start script uses these vars without needing to know which database it is targeting.
+ */
+interface KitEndpointResolver {
+    /**
+     * Reads [targetKitDir]'s kit.yaml and returns TARGET_* env vars for each declared
+     * endpoint, resolving host IPs from [clusterState]. Returns an empty map if the
+     * directory or kit.yaml is missing or unparseable.
+     */
+    fun resolveTargetVars(
+        targetKitDir: File,
+        clusterState: ClusterState,
+    ): Map<String, String>
+}
+
+class DefaultKitEndpointResolver : KitEndpointResolver {
+    private val log = KotlinLogging.logger {}
+
+    override fun resolveTargetVars(
+        targetKitDir: File,
+        clusterState: ClusterState,
+    ): Map<String, String> {
+        val configFile = File(targetKitDir, Constants.Kit.CONFIG_FILE)
+        if (!configFile.isFile) {
+            log.debug { "Target kit directory '${targetKitDir.name}' has no kit.yaml — no TARGET_* vars injected" }
+            return emptyMap()
+        }
+
+        val kitConfig =
+            try {
+                installConfigYaml.decodeFromString(KitConfig.serializer(), configFile.readText())
+            } catch (e: Exception) {
+                log.warn(e) { "Failed to parse kit.yaml for '${targetKitDir.name}' — no TARGET_* vars injected" }
+                return emptyMap()
+            }
+
+        val sqlCap = kitConfig.capabilities.firstOrNull { it.type == "sql" }
+        val result = mutableMapOf<String, String>()
+
+        for (endpoint in kitConfig.endpoints) {
+            val serverType =
+                try {
+                    ServerType.from(endpoint.nodeType)
+                } catch (e: Exception) {
+                    log.debug {
+                        "Unknown node-type '${endpoint.nodeType}' in '${targetKitDir.name}' endpoint '${endpoint.name}' — skipping"
+                    }
+                    continue
+                }
+            val ip = clusterState.hosts[serverType]?.firstOrNull()?.privateIp
+            if (ip == null) {
+                log.debug { "No nodes of type '${endpoint.nodeType}' in cluster state — skipping endpoint '${endpoint.name}'" }
+                continue
+            }
+
+            result.putAll(endpoint.toTargetVars(ip, sqlCap))
+        }
+
+        return result
+    }
+}

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/ServicesModule.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/ServicesModule.kt
@@ -76,6 +76,7 @@ val servicesModule =
         factoryOf(::InstallTemplateResolver)
         factoryOf(::WorkloadStepExecutor)
         factory<KitHookExecutor> { DefaultKitHookExecutor(get(), get(), get()) }
+        singleOf(::DefaultKitEndpointResolver) bind KitEndpointResolver::class
         factoryOf(::DefaultOtelSyncService) bind OtelSyncService::class
         factoryOf(::DefaultMetricsRegistryService) bind MetricsRegistryService::class
         factory<VictoriaBackupService> { DefaultVictoriaBackupService(get(), get()) }

--- a/src/main/resources/com/rustyrazorblade/easydblab/kits/clickhouse/kit.yaml
+++ b/src/main/resources/com/rustyrazorblade/easydblab/kits/clickhouse/kit.yaml
@@ -26,6 +26,7 @@ endpoints:
     type: jdbc
     scheme: clickhouse
     path: /default?compress=0
+    database: "default"
 args:
   - flag: --clickhouse-version
     variable: CLICKHOUSE_VERSION

--- a/src/main/resources/com/rustyrazorblade/easydblab/kits/sysbench/bin/prepare.sh.template
+++ b/src/main/resources/com/rustyrazorblade/easydblab/kits/sysbench/bin/prepare.sh.template
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SYSBENCH_IMAGE="docker.io/severalnines/sysbench"
+POD_NAME="sysbench-prepare-${KIT_NAME}"
+
+if [ -n "${TARGET_MYSQL_HOST:-}" ]; then
+  DB_ARGS="--db-driver=mysql \
+    --mysql-host=${TARGET_MYSQL_HOST} \
+    --mysql-port=${TARGET_MYSQL_PORT} \
+    --mysql-user=${TARGET_MYSQL_USER} \
+    --mysql-db=${TARGET_MYSQL_DATABASE}"
+
+  # TiDB and MySQL do not ship with the sbtest database — create it before sysbench prepare.
+  CREATE_POD="sysbench-createdb-${KIT_NAME}"
+  echo "Creating database ${TARGET_MYSQL_DATABASE} on ${TARGET_MYSQL_HOST}:${TARGET_MYSQL_PORT}..."
+  kubectl --kubeconfig="${KUBECONFIG}" run "${CREATE_POD}" \
+    --image="mysql:8.0" \
+    --restart=Never \
+    --command -- mysql \
+      -h "${TARGET_MYSQL_HOST}" \
+      -P "${TARGET_MYSQL_PORT}" \
+      -u "${TARGET_MYSQL_USER}" \
+      -e "CREATE DATABASE IF NOT EXISTS \`${TARGET_MYSQL_DATABASE}\`;"
+  kubectl --kubeconfig="${KUBECONFIG}" wait \
+    --for=jsonpath='{.status.phase}'=Succeeded \
+    --timeout=60s \
+    pod/"${CREATE_POD}"
+  kubectl --kubeconfig="${KUBECONFIG}" delete pod "${CREATE_POD}" --ignore-not-found
+
+elif [ -n "${TARGET_PG_HOST:-}" ]; then
+  DB_ARGS="--db-driver=pgsql \
+    --pgsql-host=${TARGET_PG_HOST} \
+    --pgsql-port=${TARGET_PG_PORT} \
+    --pgsql-user=${TARGET_PG_USER} \
+    --pgsql-db=${TARGET_PG_DATABASE}"
+else
+  echo "Error: no supported database endpoint found. Ensure the target kit exposes a MySQL or PostgreSQL wire protocol endpoint." >&2
+  exit 1
+fi
+
+echo "Preparing sysbench data: ${TABLES} tables, ${SCALE}000 rows each..."
+
+kubectl --kubeconfig="${KUBECONFIG}" run "${POD_NAME}" \
+  --image="${SYSBENCH_IMAGE}" \
+  --restart=Never \
+  --command -- sysbench \
+    ${DB_ARGS} \
+    --tables="${TABLES}" \
+    --table-size="${SCALE}000" \
+    "${WORKLOAD}" prepare
+
+echo "Waiting for prepare pod to complete..."
+kubectl --kubeconfig="${KUBECONFIG}" wait \
+  --for=jsonpath='{.status.phase}'=Succeeded \
+  --timeout=600s \
+  pod/"${POD_NAME}"
+
+kubectl --kubeconfig="${KUBECONFIG}" delete pod "${POD_NAME}" --ignore-not-found
+echo "Data preparation complete."

--- a/src/main/resources/com/rustyrazorblade/easydblab/kits/sysbench/bin/start.sh.template
+++ b/src/main/resources/com/rustyrazorblade/easydblab/kits/sysbench/bin/start.sh.template
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SYSBENCH_IMAGE="docker.io/severalnines/sysbench"
+POD_NAME="sysbench-${KIT_NAME}"
+VICTORIA_URL="http://${CONTROL_HOST_PRIVATE}:8428/api/v1/import/prometheus"
+
+if [ -n "${TARGET_MYSQL_HOST:-}" ]; then
+  DB_ARGS="--db-driver=mysql \
+    --mysql-host=${TARGET_MYSQL_HOST} \
+    --mysql-port=${TARGET_MYSQL_PORT} \
+    --mysql-user=${TARGET_MYSQL_USER} \
+    --mysql-db=${TARGET_MYSQL_DATABASE}"
+elif [ -n "${TARGET_PG_HOST:-}" ]; then
+  DB_ARGS="--db-driver=pgsql \
+    --pgsql-host=${TARGET_PG_HOST} \
+    --pgsql-port=${TARGET_PG_PORT} \
+    --pgsql-user=${TARGET_PG_USER} \
+    --pgsql-db=${TARGET_PG_DATABASE}"
+else
+  echo "Error: no supported database endpoint found. Ensure the target kit exposes a MySQL or PostgreSQL wire protocol endpoint." >&2
+  exit 1
+fi
+
+echo "Starting sysbench: workload=${WORKLOAD}, threads=${THREADS}, duration=${DURATION}s..."
+
+kubectl --kubeconfig="${KUBECONFIG}" run "${POD_NAME}" \
+  --image="${SYSBENCH_IMAGE}" \
+  --restart=Never \
+  --command -- sysbench \
+    ${DB_ARGS} \
+    --threads="${THREADS}" \
+    --time="${DURATION}" \
+    --report-interval=10 \
+    --percentile=99 \
+    "${WORKLOAD}" run
+
+kubectl --kubeconfig="${KUBECONFIG}" wait \
+  --for=condition=ready \
+  --timeout=60s \
+  pod/"${POD_NAME}"
+
+# Stream logs, echo every line, and push interval stats to VictoriaMetrics.
+# Interval lines match: "[ Ns ] thds: N tps: N.NN qps: N.NN ... lat (ms,99%): N.NN err/s: N.NN ..."
+kubectl --kubeconfig="${KUBECONFIG}" logs -f "${POD_NAME}" | while IFS= read -r line; do
+  echo "$line"
+  if [[ "$line" =~ ^\[\ [0-9]+s\ \] ]]; then
+    read -r TPS QPS LAT ERR <<< "$(echo "$line" | awk '{
+      for (i=1; i<=NF; i++) {
+        if ($i == "tps:") tps=$(i+1)
+        if ($i == "qps:") qps=$(i+1)
+        if ($i == "err/s:") err=$(i+1)
+        if ($i ~ /99%\):/) lat=$(i+1)
+      }
+      print tps, qps, lat, err
+    }')"
+    curl -sf --max-time 2 -X POST "${VICTORIA_URL}" \
+      --data-binary "sysbench_tps{kit=\"${KIT_NAME}\"} ${TPS:-0}
+sysbench_qps{kit=\"${KIT_NAME}\"} ${QPS:-0}
+sysbench_lat_p99_ms{kit=\"${KIT_NAME}\"} ${LAT:-0}
+sysbench_errors_per_second{kit=\"${KIT_NAME}\"} ${ERR:-0}" 2>/dev/null || true
+  fi
+done

--- a/src/main/resources/com/rustyrazorblade/easydblab/kits/sysbench/bin/stop.sh.template
+++ b/src/main/resources/com/rustyrazorblade/easydblab/kits/sysbench/bin/stop.sh.template
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+POD_NAME="sysbench-${KIT_NAME}"
+
+echo "Stopping sysbench run pod..."
+kubectl --kubeconfig="${KUBECONFIG}" delete pod "${POD_NAME}" --ignore-not-found
+
+if [ -n "${TARGET_MYSQL_HOST:-}" ]; then
+  DB_ARGS="--db-driver=mysql \
+    --mysql-host=${TARGET_MYSQL_HOST} \
+    --mysql-port=${TARGET_MYSQL_PORT} \
+    --mysql-user=${TARGET_MYSQL_USER} \
+    --mysql-db=${TARGET_MYSQL_DATABASE}"
+elif [ -n "${TARGET_PG_HOST:-}" ]; then
+  DB_ARGS="--db-driver=pgsql \
+    --pgsql-host=${TARGET_PG_HOST} \
+    --pgsql-port=${TARGET_PG_PORT} \
+    --pgsql-user=${TARGET_PG_USER} \
+    --pgsql-db=${TARGET_PG_DATABASE}"
+else
+  echo "Warning: no database endpoint found, skipping cleanup." >&2
+  exit 0
+fi
+
+echo "Running sysbench cleanup..."
+CLEANUP_POD="sysbench-cleanup-${KIT_NAME}"
+kubectl --kubeconfig="${KUBECONFIG}" run "${CLEANUP_POD}" \
+  --image="docker.io/severalnines/sysbench" \
+  --restart=Never \
+  --command -- sysbench \
+    ${DB_ARGS} \
+    --tables="${TABLES}" \
+    "${WORKLOAD}" cleanup
+
+kubectl --kubeconfig="${KUBECONFIG}" wait \
+  --for=jsonpath='{.status.phase}'=Succeeded \
+  --timeout=300s \
+  pod/"${CLEANUP_POD}"
+
+kubectl --kubeconfig="${KUBECONFIG}" delete pod "${CLEANUP_POD}" --ignore-not-found
+echo "Sysbench stopped and data cleaned up."

--- a/src/main/resources/com/rustyrazorblade/easydblab/kits/sysbench/dashboards/sysbench.json
+++ b/src/main/resources/com/rustyrazorblade/easydblab/kits/sysbench/dashboards/sysbench.json
@@ -1,0 +1,247 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "datasource", "uid": "grafana" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Client-side sysbench benchmark metrics — TPS, QPS, P99 latency, and errors pushed from the start script",
+  "editable": true,
+  "graphTooltip": 1,
+  "id": null,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": 10,
+      "title": "Throughput",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 1 },
+      "id": 1,
+      "options": {
+        "legend": { "calcs": ["mean", "max", "lastNotNull"], "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sysbench_tps{kit=~\"$kit\"}",
+          "legendFormat": "{{kit}}",
+          "refId": "A"
+        }
+      ],
+      "title": "TPS (Transactions per Second)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 1 },
+      "id": 2,
+      "options": {
+        "legend": { "calcs": ["mean", "max", "lastNotNull"], "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sysbench_qps{kit=~\"$kit\"}",
+          "legendFormat": "{{kit}}",
+          "refId": "A"
+        }
+      ],
+      "title": "QPS (Queries per Second)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 9 },
+      "id": 11,
+      "title": "Latency & Errors",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 10 },
+      "id": 3,
+      "options": {
+        "legend": { "calcs": ["mean", "max", "lastNotNull"], "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sysbench_lat_p99_ms{kit=~\"$kit\"}",
+          "legendFormat": "{{kit}}",
+          "refId": "A"
+        }
+      ],
+      "title": "P99 Latency (ms)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 10 },
+      "id": 4,
+      "options": {
+        "legend": { "calcs": ["mean", "max", "lastNotNull"], "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sysbench_errors_per_second{kit=~\"$kit\"}",
+          "legendFormat": "{{kit}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Errors per Second",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 38,
+  "tags": ["sysbench", "benchmark"],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "VictoriaMetrics",
+        "type": "datasource"
+      },
+      {
+        "current": {},
+        "datasource": { "type": "prometheus", "uid": "${datasource}" },
+        "definition": "label_values(sysbench_tps, kit)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Kit",
+        "multi": true,
+        "name": "kit",
+        "options": [],
+        "query": {
+          "query": "label_values(sysbench_tps, kit)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Sysbench Benchmark",
+  "uid": "sysbench",
+  "version": 1
+}

--- a/src/main/resources/com/rustyrazorblade/easydblab/kits/sysbench/kit.yaml
+++ b/src/main/resources/com/rustyrazorblade/easydblab/kits/sysbench/kit.yaml
@@ -1,0 +1,38 @@
+name: sysbench
+type: app
+description: sysbench SQL benchmarking kit — install with --target to point at a running database kit
+version: "1.0.0"
+collision-check: true
+
+args:
+  - flag: --target
+    variable: TARGET
+    type: kit-ref
+    capability: sql
+    description: "Name of the running database kit to benchmark (e.g. clickhouse, tidb)"
+    required: true
+  - flag: --threads
+    variable: THREADS
+    type: int
+    description: "Number of concurrent threads"
+    default: "4"
+  - flag: --duration
+    variable: DURATION
+    type: int
+    description: "Benchmark duration in seconds"
+    default: "60"
+  - flag: --workload
+    variable: WORKLOAD
+    type: string
+    description: "sysbench built-in workload (oltp_read_write, oltp_read_only, oltp_write_only)"
+    default: "oltp_read_write"
+  - flag: --scale
+    variable: SCALE
+    type: int
+    description: "Number of rows per table (in thousands)"
+    default: "10"
+  - flag: --tables
+    variable: TABLES
+    type: int
+    description: "Number of tables"
+    default: "10"

--- a/src/main/resources/com/rustyrazorblade/easydblab/kits/tidb/kit.yaml
+++ b/src/main/resources/com/rustyrazorblade/easydblab/kits/tidb/kit.yaml
@@ -25,12 +25,17 @@ runtime:
   selector: "app.kubernetes.io/instance=tidb"
   namespace: default
 endpoints:
-  - name: "MySQL"
+  - name: "MySQL JDBC"
     node-type: app
     port: 30400
     type: jdbc
     scheme: mysql
     path: "/?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC"
+  - name: "MySQL wire"
+    node-type: app
+    port: 30400
+    type: mysql
+    database: "sbtest"
 args:
   - flag: --version
     variable: TIDB_VERSION

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/commands/install/KitInstallCommandTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/commands/install/KitInstallCommandTest.kt
@@ -1,0 +1,184 @@
+package com.rustyrazorblade.easydblab.commands.install
+
+import com.rustyrazorblade.easydblab.BaseKoinTest
+import com.rustyrazorblade.easydblab.Context
+import com.rustyrazorblade.easydblab.configuration.ClusterHost
+import com.rustyrazorblade.easydblab.configuration.ClusterState
+import com.rustyrazorblade.easydblab.configuration.ClusterStateManager
+import com.rustyrazorblade.easydblab.configuration.InitConfig
+import com.rustyrazorblade.easydblab.configuration.ServerType
+import com.rustyrazorblade.easydblab.services.InstallTemplateResolver
+import com.rustyrazorblade.easydblab.services.KitArgSpec
+import com.rustyrazorblade.easydblab.services.KitConfig
+import com.rustyrazorblade.easydblab.services.TemplateService
+import com.rustyrazorblade.easydblab.services.TemplateVariables
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import org.koin.core.module.Module
+import org.koin.dsl.module
+import org.koin.test.get
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import java.io.File
+
+/**
+ * Tests that KitInstallCommand creates the right directory name based on kit-ref args.
+ */
+class KitInstallCommandTest : BaseKoinTest() {
+    private val mockClusterStateManager: ClusterStateManager = mock()
+    private val mockResolver: InstallTemplateResolver = mock()
+
+    @TempDir
+    lateinit var templateDir: File
+
+    override fun additionalTestModules(): List<Module> =
+        listOf(
+            module {
+                single<ClusterStateManager> { mockClusterStateManager }
+                single { TemplateService(get(), get()) }
+                single<InstallTemplateResolver> { mockResolver }
+            },
+        )
+
+    private val clusterState =
+        ClusterState(
+            name = "test-cluster",
+            versions = mutableMapOf(),
+            s3Bucket = "test-bucket",
+            initConfig = InitConfig(region = "us-west-2", name = "test-cluster"),
+            hosts =
+                mapOf(
+                    ServerType.Control to listOf(ClusterHost("1.2.3.4", "10.0.0.1", "control0", "us-west-2a", "i-ctrl")),
+                    ServerType.Stress to listOf(ClusterHost("2.3.4.5", "10.0.1.1", "app0", "us-west-2a", "i-app0")),
+                    ServerType.Cassandra to listOf(ClusterHost("3.4.5.6", "10.0.2.1", "db0", "us-west-2a", "i-db0")),
+                ),
+        )
+
+    private val sysbenchConfig =
+        KitConfig(
+            name = "sysbench",
+            type = null,
+            args =
+                listOf(
+                    KitArgSpec(
+                        flag = "--target",
+                        variable = "TARGET",
+                        type = KitArgSpec.ArgType.KIT_REF,
+                    ),
+                ),
+        )
+
+    private lateinit var factory: KitInstallCommandFactory
+    private lateinit var source: InstallTemplateResolver.TemplateSource.Directory
+    private lateinit var workingDir: File
+
+    @BeforeEach
+    fun setup() {
+        workingDir = get<Context>().workingDirectory
+        whenever(mockClusterStateManager.load()).thenReturn(clusterState)
+        whenever(mockResolver.listTemplateFiles(org.mockito.kotlin.any())).thenReturn(emptyList())
+        whenever(mockResolver.readInstallYamlContent(org.mockito.kotlin.any())).thenReturn(null)
+        val templateVars = TemplateVariables.from(state = clusterState, kitName = "", storageSize = "").toMap()
+        factory = KitInstallCommandFactory(templateVars)
+        source = InstallTemplateResolver.TemplateSource.Directory(templateDir)
+    }
+
+    private fun buildAndRun(
+        config: KitConfig,
+        argValues: Map<String, String>,
+    ) {
+        val cl = factory.build(config, source)
+        val cmd = cl.commandSpec.userObject() as KitInstallCommand
+        argValues.forEach { (k, v) -> cmd.argValues[k] = v }
+        cmd.execute()
+    }
+
+    @Test
+    fun `kit without kit-ref arg creates directory named after kit`() {
+        val config = KitConfig(name = "mydb", type = null)
+        buildAndRun(config, emptyMap())
+        assertThat(File(workingDir, "mydb")).isDirectory()
+    }
+
+    @Test
+    fun `kit with kit-ref arg creates directory named kit-target`() {
+        buildAndRun(sysbenchConfig, mapOf("TARGET" to "clickhouse"))
+        assertThat(File(workingDir, "sysbench-clickhouse")).isDirectory()
+        assertThat(File(workingDir, "sysbench")).doesNotExist()
+    }
+
+    @Test
+    fun `two installs with different targets create separate directories`() {
+        buildAndRun(sysbenchConfig, mapOf("TARGET" to "clickhouse"))
+        buildAndRun(sysbenchConfig, mapOf("TARGET" to "mysql"))
+        assertThat(File(workingDir, "sysbench-clickhouse")).isDirectory()
+        assertThat(File(workingDir, "sysbench-mysql")).isDirectory()
+    }
+
+    @Test
+    fun `kit-ref with capability passes when target has that capability`() {
+        val benchConfig =
+            KitConfig(
+                name = "sysbench",
+                type = null,
+                args =
+                    listOf(
+                        KitArgSpec(flag = "--target", variable = "TARGET", type = KitArgSpec.ArgType.KIT_REF, capability = "sql"),
+                    ),
+            )
+        // Write a target kit with the sql capability
+        val targetDir = File(workingDir, "tidb").also { it.mkdirs() }
+        File(targetDir, "kit.yaml").writeText(
+            """
+            name: tidb
+            capabilities:
+              - type: sql
+                user: root
+            """.trimIndent(),
+        )
+
+        buildAndRun(benchConfig, mapOf("TARGET" to "tidb"))
+        assertThat(File(workingDir, "sysbench-tidb")).isDirectory()
+    }
+
+    @Test
+    fun `kit-ref with capability fails when target lacks that capability`() {
+        val benchConfig =
+            KitConfig(
+                name = "sysbench",
+                type = null,
+                args =
+                    listOf(
+                        KitArgSpec(flag = "--target", variable = "TARGET", type = KitArgSpec.ArgType.KIT_REF, capability = "sql"),
+                    ),
+            )
+        val targetDir = File(workingDir, "presto").also { it.mkdirs() }
+        File(targetDir, "kit.yaml").writeText("name: presto\n")
+
+        assertThatThrownBy { buildAndRun(benchConfig, mapOf("TARGET" to "presto")) }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("sql")
+            .hasMessageContaining("presto")
+    }
+
+    @Test
+    fun `kit-ref fails when target kit is not installed`() {
+        val benchConfig =
+            KitConfig(
+                name = "sysbench",
+                type = null,
+                args =
+                    listOf(
+                        KitArgSpec(flag = "--target", variable = "TARGET", type = KitArgSpec.ArgType.KIT_REF, capability = "sql"),
+                    ),
+            )
+
+        assertThatThrownBy { buildAndRun(benchConfig, mapOf("TARGET" to "doesnotexist")) }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("doesnotexist")
+            .hasMessageContaining("not installed")
+    }
+}

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/commands/install/KitRunnerCommandTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/commands/install/KitRunnerCommandTest.kt
@@ -8,7 +8,9 @@ import com.rustyrazorblade.easydblab.configuration.ClusterState
 import com.rustyrazorblade.easydblab.configuration.ClusterStateManager
 import com.rustyrazorblade.easydblab.configuration.InitConfig
 import com.rustyrazorblade.easydblab.configuration.ServerType
+import com.rustyrazorblade.easydblab.services.DefaultKitEndpointResolver
 import com.rustyrazorblade.easydblab.services.GrafanaDashboardService
+import com.rustyrazorblade.easydblab.services.KitEndpointResolver
 import com.rustyrazorblade.easydblab.services.KitHookExecutor
 import com.rustyrazorblade.easydblab.services.MetricsRegistryService
 import com.rustyrazorblade.easydblab.services.WorkloadStepExecutor
@@ -45,6 +47,15 @@ class KitRunnerCommandTest : BaseKoinTest() {
             instanceId = "i-ctrl",
         )
 
+    private val dbHost =
+        ClusterHost(
+            publicIp = "3.4.5.6",
+            privateIp = "10.0.2.1",
+            alias = "db0",
+            availabilityZone = "us-west-2a",
+            instanceId = "i-db0",
+        )
+
     private val clusterState =
         ClusterState(
             name = "test-cluster",
@@ -54,6 +65,7 @@ class KitRunnerCommandTest : BaseKoinTest() {
             hosts =
                 mapOf(
                     ServerType.Control to listOf(controlHost),
+                    ServerType.Cassandra to listOf(dbHost),
                 ),
         )
 
@@ -65,6 +77,7 @@ class KitRunnerCommandTest : BaseKoinTest() {
                 single<WorkloadStepExecutor> { mockWorkloadStepExecutor }
                 single<MetricsRegistryService> { mockMetricsRegistryService }
                 single<KitHookExecutor> { mockKitHookExecutor }
+                single<KitEndpointResolver> { DefaultKitEndpointResolver() }
             },
         )
 
@@ -452,6 +465,101 @@ class KitRunnerCommandTest : BaseKoinTest() {
         )
         command("mydb", "stop").call()
         verify(mockClusterStateManager).removeRunningWorkload("mydb")
+    }
+
+    private fun writeResolvedArgs(
+        kitName: String,
+        vars: Map<String, String>,
+    ) {
+        val dir = File(workingDir, kitName).also { it.mkdirs() }
+        File(dir, Constants.Kit.RESOLVED_ARGS_FILE).writeText(
+            vars.entries.joinToString("\n") { (k, v) -> "$k=$v" } + "\n",
+        )
+    }
+
+    @Test
+    fun `kit with kit-ref arg and valid target injects TARGET_JDBC_URL into script env`() {
+        // Write target kit.yaml with JDBC endpoint
+        File(File(workingDir, "clickhouse").also { it.mkdirs() }, "kit.yaml").writeText(
+            """
+            name: clickhouse
+            capabilities:
+              - type: sql
+                user: default
+                driver-class: com.clickhouse.jdbc.ClickHouseDriver
+            endpoints:
+              - name: JDBC
+                node-type: db
+                port: 8123
+                type: jdbc
+                scheme: clickhouse
+                path: /default
+            """.trimIndent(),
+        )
+        // Write bench kit.yaml with kit-ref arg
+        writeKitYaml(
+            "sysbench-clickhouse",
+            """
+            name: sysbench
+            args:
+              - flag: --target
+                variable: TARGET
+                type: kit-ref
+            """.trimIndent(),
+        )
+        writeResolvedArgs("sysbench-clickhouse", mapOf("TARGET" to "clickhouse"))
+
+        val outputFile = File(workingDir, "target_jdbc_url.txt")
+        writeScript(
+            "sysbench-clickhouse",
+            "start",
+            """echo "${'$'}TARGET_JDBC_URL" > "${outputFile.absolutePath}"""",
+        )
+
+        command("sysbench-clickhouse", "start").call()
+
+        assertThat(outputFile.readText().trim()).isEqualTo("jdbc:clickhouse://10.0.2.1:8123/default")
+    }
+
+    @Test
+    fun `kit with kit-ref arg and missing target dir produces no TARGET vars and no exception`() {
+        writeKitYaml(
+            "sysbench-missing",
+            """
+            name: sysbench
+            args:
+              - flag: --target
+                variable: TARGET
+                type: kit-ref
+            """.trimIndent(),
+        )
+        writeResolvedArgs("sysbench-missing", mapOf("TARGET" to "doesnotexist"))
+
+        val outputFile = File(workingDir, "target_url.txt")
+        writeScript(
+            "sysbench-missing",
+            "start",
+            """echo "${'$'}TARGET_JDBC_URL" > "${outputFile.absolutePath}"""",
+        )
+
+        val exitCode = command("sysbench-missing", "start").call()
+
+        assertThat(exitCode).isEqualTo(0)
+        assertThat(outputFile.readText().trim()).isEmpty()
+    }
+
+    @Test
+    fun `kit without kit-ref arg does not inject TARGET vars`() {
+        val outputFile = File(workingDir, "target_url.txt")
+        writeScript(
+            "mydb",
+            "start",
+            """echo "${'$'}TARGET_JDBC_URL" > "${outputFile.absolutePath}"""",
+        )
+
+        command("mydb", "start").call()
+
+        assertThat(outputFile.readText().trim()).isEmpty()
     }
 
     @Test

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/mcp/ChannelMessageBufferTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/mcp/ChannelMessageBufferTest.kt
@@ -384,69 +384,6 @@ class ChannelMessageBufferTest {
         val messages = buffer.getMessages()
         assertEquals(messageCount, messages.size)
     }
-
-    @Test
-    fun `special characters in messages are handled`() {
-        buffer.start()
-        val specialMessage = "Message with \"quotes\", \n newlines, \t tabs, and unicode: 🎉"
-        sendEvent(OutputEvent.MessageEvent(specialMessage))
-
-        val messages = buffer.getMessages()
-        assertEquals(1, messages.size)
-        // Newlines should be replaced with spaces, tabs preserved as whitespace
-        assertTrue(messages[0].contains("Message with \"quotes\", newlines, tabs, and unicode: 🎉"))
-    }
-
-    @Test
-    fun `ANSI escape sequences are stripped from messages`() {
-        buffer.start()
-        val coloredMessage = "Use \u001b[32measy-db-lab list\u001b[39m to see versions"
-        sendEvent(OutputEvent.MessageEvent(coloredMessage))
-
-        val messages = buffer.getMessages()
-        assertEquals(1, messages.size)
-        assertTrue(messages[0].contains("Use easy-db-lab list to see versions"))
-        assertFalse(messages[0].contains("\u001b"))
-        assertFalse(messages[0].contains("[32m"))
-        assertFalse(messages[0].contains("[39m"))
-    }
-
-    @Test
-    fun `newlines are replaced with spaces`() {
-        buffer.start()
-        val multilineMessage = "Line 1\nLine 2\r\nLine 3\rLine 4"
-        sendEvent(OutputEvent.MessageEvent(multilineMessage))
-
-        val messages = buffer.getMessages()
-        assertEquals(1, messages.size)
-        assertTrue(messages[0].contains("Line 1 Line 2 Line 3 Line 4"))
-        assertFalse(messages[0].contains("\n"))
-        assertFalse(messages[0].contains("\r"))
-    }
-
-    @Test
-    fun `multiple spaces are collapsed into single space`() {
-        buffer.start()
-        val spacedMessage = "Word1    Word2     Word3"
-        sendEvent(OutputEvent.MessageEvent(spacedMessage))
-
-        val messages = buffer.getMessages()
-        assertEquals(1, messages.size)
-        assertTrue(messages[0].contains("Word1 Word2 Word3"))
-    }
-
-    @Test
-    fun `complex ANSI sequences are stripped`() {
-        buffer.start()
-        val complexMessage = "\u001b[1;33mYellow Bold\u001b[0m normal \u001b[31;1mRed Bold\u001b[0m"
-        sendEvent(OutputEvent.MessageEvent(complexMessage))
-
-        val messages = buffer.getMessages()
-        assertEquals(1, messages.size)
-        assertTrue(messages[0].contains("Yellow Bold normal Red Bold"))
-        assertFalse(messages[0].contains("\u001b"))
-    }
-
     // ========== Start/Stop Tests ==========
 
     @Test

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/mcp/CleanMessageTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/mcp/CleanMessageTest.kt
@@ -1,0 +1,56 @@
+package com.rustyrazorblade.easydblab.mcp
+
+import kotlinx.coroutines.channels.Channel
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests the message sanitization logic in ChannelMessageBuffer in isolation —
+ * no async machinery, no channel consumer, no timing dependencies.
+ */
+class CleanMessageTest {
+    private val buffer = ChannelMessageBuffer(Channel(Channel.UNLIMITED))
+
+    @Test
+    fun `newlines are replaced with spaces`() {
+        assertThat(buffer.cleanMessage("Line 1\nLine 2\r\nLine 3\rLine 4"))
+            .isEqualTo("Line 1 Line 2 Line 3 Line 4")
+    }
+
+    @Test
+    fun `multiple spaces are collapsed into single space`() {
+        assertThat(buffer.cleanMessage("Word1    Word2     Word3"))
+            .isEqualTo("Word1 Word2 Word3")
+    }
+
+    @Test
+    fun `ANSI color codes are stripped`() {
+        val esc = ""
+        assertThat(buffer.cleanMessage("Use $esc[32measy-db-lab list$esc[39m to see versions"))
+            .isEqualTo("Use easy-db-lab list to see versions")
+    }
+
+    @Test
+    fun `complex ANSI sequences are stripped`() {
+        val esc = ""
+        assertThat(buffer.cleanMessage("$esc[1;33mYellow Bold$esc[0m normal $esc[31;1mRed Bold$esc[0m"))
+            .isEqualTo("Yellow Bold normal Red Bold")
+    }
+
+    @Test
+    fun `special characters and unicode are preserved`() {
+        assertThat(buffer.cleanMessage("Message with \"quotes\", \n newlines, \t tabs, and unicode: 🎉"))
+            .isEqualTo("Message with \"quotes\", newlines, tabs, and unicode: 🎉")
+    }
+
+    @Test
+    fun `leading and trailing whitespace is trimmed`() {
+        assertThat(buffer.cleanMessage("  hello world  "))
+            .isEqualTo("hello world")
+    }
+
+    @Test
+    fun `empty string is preserved`() {
+        assertThat(buffer.cleanMessage("")).isEqualTo("")
+    }
+}

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/services/KitConfigTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/services/KitConfigTest.kt
@@ -925,4 +925,230 @@ class KitConfigTest {
         assertThat(config.capabilities).hasSize(1)
         assertThat(config.capabilities[0].type).isEqualTo("tpch-load")
     }
+
+    // -------------------------------------------------------------------------
+    // wire-protocol endpoint types (postgresql, mysql) and database field
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `parses postgresql endpoint with port and database`() {
+        val config =
+            parse(
+                """
+                name: mydb
+                endpoints:
+                  - name: "PostgreSQL wire"
+                    node-type: db
+                    port: 5432
+                    type: postgresql
+                    database: mydb
+                """.trimIndent(),
+            )
+        val endpoint = config.endpoints.single()
+        assertThat(endpoint.type).isEqualTo(KitEndpoint.EndpointType.POSTGRESQL)
+        assertThat(endpoint.port).isEqualTo(5432)
+        assertThat(endpoint.database).isEqualTo("mydb")
+    }
+
+    @Test
+    fun `parses mysql endpoint with port and database`() {
+        val config =
+            parse(
+                """
+                name: mydb
+                endpoints:
+                  - name: "MySQL wire"
+                    node-type: db
+                    port: 3306
+                    type: mysql
+                    database: bench
+                """.trimIndent(),
+            )
+        val endpoint = config.endpoints.single()
+        assertThat(endpoint.type).isEqualTo(KitEndpoint.EndpointType.MYSQL)
+        assertThat(endpoint.port).isEqualTo(3306)
+        assertThat(endpoint.database).isEqualTo("bench")
+    }
+
+    @Test
+    fun `database field defaults to empty string when absent`() {
+        val config =
+            parse(
+                """
+                name: mydb
+                endpoints:
+                  - name: "JDBC"
+                    node-type: db
+                    port: 30123
+                    type: jdbc
+                    scheme: clickhouse
+                """.trimIndent(),
+            )
+        assertThat(config.endpoints.single().database).isEmpty()
+    }
+
+    @Test
+    fun `existing endpoint types unaffected by new types`() {
+        val config =
+            parse(
+                """
+                name: mydb
+                endpoints:
+                  - name: "HTTP"
+                    node-type: app
+                    port: 8080
+                    type: http
+                  - name: "JDBC"
+                    node-type: db
+                    port: 30123
+                    type: jdbc
+                    scheme: clickhouse
+                  - name: "Native"
+                    node-type: db
+                    port: 9000
+                    type: native
+                  - name: "CQL"
+                    node-type: db
+                    port: 9042
+                    type: cql
+                """.trimIndent(),
+            )
+        assertThat(config.endpoints.map { it.type }).containsExactly(
+            KitEndpoint.EndpointType.HTTP,
+            KitEndpoint.EndpointType.JDBC,
+            KitEndpoint.EndpointType.NATIVE,
+            KitEndpoint.EndpointType.CQL,
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // kit-ref arg type and capability field
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `parses kit-ref arg type`() {
+        val config =
+            parse(
+                """
+                name: sysbench
+                args:
+                  - flag: --target
+                    variable: TARGET
+                    type: kit-ref
+                    capability: sql
+                    description: Kit to benchmark
+                    required: true
+                """.trimIndent(),
+            )
+        val arg = config.args.single()
+        assertThat(arg.type).isEqualTo(KitArgSpec.ArgType.KIT_REF)
+        assertThat(arg.capability).isEqualTo("sql")
+        assertThat(arg.variable).isEqualTo("TARGET")
+    }
+
+    @Test
+    fun `capability field defaults to empty string when absent`() {
+        val config =
+            parse(
+                """
+                name: mydb
+                args:
+                  - flag: --workers
+                    variable: WORKERS
+                    type: int
+                """.trimIndent(),
+            )
+        assertThat(config.args.single().capability).isEmpty()
+    }
+
+    @Test
+    fun `kit-ref arg parses alongside other arg types`() {
+        val config =
+            parse(
+                """
+                name: sysbench
+                args:
+                  - flag: --target
+                    variable: TARGET
+                    type: kit-ref
+                  - flag: --threads
+                    variable: THREADS
+                    type: int
+                  - flag: --workload
+                    variable: WORKLOAD
+                    type: string
+                """.trimIndent(),
+            )
+        assertThat(config.args.map { it.type }).containsExactly(
+            KitArgSpec.ArgType.KIT_REF,
+            KitArgSpec.ArgType.INT,
+            KitArgSpec.ArgType.STRING,
+        )
+    }
+}
+
+/**
+ * Tests for KitEndpoint.toTargetVars — ensures each endpoint type produces the correct TARGET_* vars.
+ */
+class KitEndpointToTargetVarsTest {
+    private val sqlCap = KitCapability(type = "sql", user = "bench", driverClass = "com.example.Driver")
+
+    private fun endpoint(
+        type: KitEndpoint.EndpointType,
+        port: Int = 5432,
+        scheme: String = "",
+        path: String = "",
+        database: String = "testdb",
+    ) = KitEndpoint(name = "test", nodeType = "db", port = port, type = type, scheme = scheme, path = path, database = database)
+
+    @Test
+    fun `jdbc endpoint produces TARGET_JDBC vars`() {
+        val vars =
+            endpoint(
+                KitEndpoint.EndpointType.JDBC,
+                port = 8123,
+                scheme = "clickhouse",
+                path = "/default",
+            ).toTargetVars("10.0.0.1", sqlCap)
+        assertThat(vars["TARGET_JDBC_URL"]).isEqualTo("jdbc:clickhouse://10.0.0.1:8123/default")
+        assertThat(vars["TARGET_JDBC_USER"]).isEqualTo("bench")
+        assertThat(vars["TARGET_JDBC_DRIVER"]).isEqualTo("com.example.Driver")
+    }
+
+    @Test
+    fun `postgresql endpoint produces TARGET_PG vars`() {
+        val vars = endpoint(KitEndpoint.EndpointType.POSTGRESQL, port = 5432, database = "benchdb").toTargetVars("10.0.0.2", sqlCap)
+        assertThat(vars["TARGET_PG_HOST"]).isEqualTo("10.0.0.2")
+        assertThat(vars["TARGET_PG_PORT"]).isEqualTo("5432")
+        assertThat(vars["TARGET_PG_USER"]).isEqualTo("bench")
+        assertThat(vars["TARGET_PG_DATABASE"]).isEqualTo("benchdb")
+    }
+
+    @Test
+    fun `mysql endpoint produces TARGET_MYSQL vars`() {
+        val vars = endpoint(KitEndpoint.EndpointType.MYSQL, port = 3306, database = "sbtest").toTargetVars("10.0.0.3", sqlCap)
+        assertThat(vars["TARGET_MYSQL_HOST"]).isEqualTo("10.0.0.3")
+        assertThat(vars["TARGET_MYSQL_PORT"]).isEqualTo("3306")
+        assertThat(vars["TARGET_MYSQL_USER"]).isEqualTo("bench")
+        assertThat(vars["TARGET_MYSQL_DATABASE"]).isEqualTo("sbtest")
+    }
+
+    @Test
+    fun `http endpoint produces TARGET_HTTP_URL`() {
+        val vars = endpoint(KitEndpoint.EndpointType.HTTP, port = 8080, database = "").toTargetVars("10.0.0.4", null)
+        assertThat(vars["TARGET_HTTP_URL"]).isEqualTo("http://10.0.0.4:8080")
+    }
+
+    @Test
+    fun `native and cql endpoints produce no vars`() {
+        assertThat(endpoint(KitEndpoint.EndpointType.NATIVE).toTargetVars("10.0.0.5", sqlCap)).isEmpty()
+        assertThat(endpoint(KitEndpoint.EndpointType.CQL).toTargetVars("10.0.0.5", sqlCap)).isEmpty()
+    }
+
+    @Test
+    fun `null sql capability produces empty user and driver`() {
+        val vars = endpoint(KitEndpoint.EndpointType.JDBC, scheme = "postgresql").toTargetVars("10.0.0.6", null)
+        assertThat(vars["TARGET_JDBC_USER"]).isEmpty()
+        assertThat(vars["TARGET_JDBC_DRIVER"]).isEmpty()
+    }
 }

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/services/KitEndpointResolverTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/services/KitEndpointResolverTest.kt
@@ -1,0 +1,258 @@
+package com.rustyrazorblade.easydblab.services
+
+import com.rustyrazorblade.easydblab.configuration.ClusterHost
+import com.rustyrazorblade.easydblab.configuration.ClusterState
+import com.rustyrazorblade.easydblab.configuration.ServerType
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+/**
+ * Tests for DefaultKitEndpointResolver — resolves target kit endpoints into TARGET_* env vars.
+ */
+class KitEndpointResolverTest {
+    @TempDir
+    lateinit var workspaceDir: File
+
+    private lateinit var resolver: KitEndpointResolver
+
+    private val dbHost =
+        ClusterHost(
+            publicIp = "1.2.3.4",
+            privateIp = "10.0.1.5",
+            alias = "db0",
+            availabilityZone = "us-west-2a",
+            instanceId = "i-db0",
+        )
+
+    private val clusterState =
+        ClusterState(
+            name = "test-cluster",
+            versions = mutableMapOf(),
+            hosts = mutableMapOf(ServerType.Cassandra to listOf(dbHost)),
+        )
+
+    @BeforeEach
+    fun setup() {
+        resolver = DefaultKitEndpointResolver()
+    }
+
+    private fun writeKitYaml(
+        kitName: String,
+        yaml: String,
+    ): File {
+        val kitDir = File(workspaceDir, kitName).also { it.mkdirs() }
+        File(kitDir, "kit.yaml").writeText(yaml)
+        return kitDir
+    }
+
+    @Test
+    fun `jdbc endpoint produces TARGET_JDBC vars`() {
+        val kitDir =
+            writeKitYaml(
+                "clickhouse",
+                """
+                name: clickhouse
+                capabilities:
+                  - type: sql
+                    user: default
+                    driver-class: com.clickhouse.jdbc.ClickHouseDriver
+                endpoints:
+                  - name: JDBC
+                    node-type: db
+                    port: 30123
+                    type: jdbc
+                    scheme: clickhouse
+                    path: /default?compress=0
+                """.trimIndent(),
+            )
+
+        val vars = resolver.resolveTargetVars(kitDir, clusterState)
+
+        assertThat(vars["TARGET_JDBC_URL"]).isEqualTo("jdbc:clickhouse://10.0.1.5:30123/default?compress=0")
+        assertThat(vars["TARGET_JDBC_USER"]).isEqualTo("default")
+        assertThat(vars["TARGET_JDBC_DRIVER"]).isEqualTo("com.clickhouse.jdbc.ClickHouseDriver")
+    }
+
+    @Test
+    fun `postgresql endpoint produces TARGET_PG vars`() {
+        val kitDir =
+            writeKitYaml(
+                "mydb",
+                """
+                name: mydb
+                capabilities:
+                  - type: sql
+                    user: bench
+                endpoints:
+                  - name: PostgreSQL wire
+                    node-type: db
+                    port: 5432
+                    type: postgresql
+                    database: benchdb
+                """.trimIndent(),
+            )
+
+        val vars = resolver.resolveTargetVars(kitDir, clusterState)
+
+        assertThat(vars["TARGET_PG_HOST"]).isEqualTo("10.0.1.5")
+        assertThat(vars["TARGET_PG_PORT"]).isEqualTo("5432")
+        assertThat(vars["TARGET_PG_USER"]).isEqualTo("bench")
+        assertThat(vars["TARGET_PG_DATABASE"]).isEqualTo("benchdb")
+    }
+
+    @Test
+    fun `mysql endpoint produces TARGET_MYSQL vars`() {
+        val kitDir =
+            writeKitYaml(
+                "tidb",
+                """
+                name: tidb
+                capabilities:
+                  - type: sql
+                    user: root
+                endpoints:
+                  - name: MySQL wire
+                    node-type: db
+                    port: 4000
+                    type: mysql
+                    database: test
+                """.trimIndent(),
+            )
+
+        val vars = resolver.resolveTargetVars(kitDir, clusterState)
+
+        assertThat(vars["TARGET_MYSQL_HOST"]).isEqualTo("10.0.1.5")
+        assertThat(vars["TARGET_MYSQL_PORT"]).isEqualTo("4000")
+        assertThat(vars["TARGET_MYSQL_USER"]).isEqualTo("root")
+        assertThat(vars["TARGET_MYSQL_DATABASE"]).isEqualTo("test")
+    }
+
+    @Test
+    fun `multiple endpoint types all injected`() {
+        val kitDir =
+            writeKitYaml(
+                "multidb",
+                """
+                name: multidb
+                capabilities:
+                  - type: sql
+                    user: admin
+                endpoints:
+                  - name: JDBC
+                    node-type: db
+                    port: 5432
+                    type: jdbc
+                    scheme: postgresql
+                  - name: PG wire
+                    node-type: db
+                    port: 5432
+                    type: postgresql
+                    database: mydb
+                """.trimIndent(),
+            )
+
+        val vars = resolver.resolveTargetVars(kitDir, clusterState)
+
+        assertThat(vars).containsKey("TARGET_JDBC_URL")
+        assertThat(vars).containsKey("TARGET_PG_HOST")
+    }
+
+    @Test
+    fun `missing target kit directory returns empty map`() {
+        val missingDir = File(workspaceDir, "doesnotexist")
+
+        val vars = resolver.resolveTargetVars(missingDir, clusterState)
+
+        assertThat(vars).isEmpty()
+    }
+
+    @Test
+    fun `unparseable kit yaml returns empty map`() {
+        val kitDir = File(workspaceDir, "broken").also { it.mkdirs() }
+        File(kitDir, "kit.yaml").writeText("this: is: not: valid: yaml: {{{{")
+
+        val vars = resolver.resolveTargetVars(kitDir, clusterState)
+
+        assertThat(vars).isEmpty()
+    }
+
+    @Test
+    fun `endpoint whose node type has no nodes in cluster state is skipped`() {
+        val kitDir =
+            writeKitYaml(
+                "appkit",
+                """
+                name: appkit
+                endpoints:
+                  - name: HTTP
+                    node-type: app
+                    port: 8080
+                    type: http
+                """.trimIndent(),
+            )
+        // clusterState has no app/stress nodes
+
+        val vars = resolver.resolveTargetVars(kitDir, clusterState)
+
+        assertThat(vars).doesNotContainKey("TARGET_HTTP_URL")
+    }
+
+    @Test
+    fun `http endpoint produces TARGET_HTTP_URL`() {
+        val appHost =
+            ClusterHost(
+                publicIp = "2.3.4.5",
+                privateIp = "10.0.2.5",
+                alias = "app0",
+                availabilityZone = "us-west-2a",
+                instanceId = "i-app0",
+            )
+        val stateWithApp =
+            ClusterState(
+                name = "test-cluster",
+                versions = mutableMapOf(),
+                hosts = mutableMapOf(ServerType.Stress to listOf(appHost)),
+            )
+        val kitDir =
+            writeKitYaml(
+                "presto",
+                """
+                name: presto
+                endpoints:
+                  - name: HTTP
+                    node-type: app
+                    port: 8080
+                    type: http
+                """.trimIndent(),
+            )
+
+        val vars = resolver.resolveTargetVars(kitDir, stateWithApp)
+
+        assertThat(vars["TARGET_HTTP_URL"]).isEqualTo("http://10.0.2.5:8080")
+    }
+
+    @Test
+    fun `no sql capability produces empty user and driver`() {
+        val kitDir =
+            writeKitYaml(
+                "noauth",
+                """
+                name: noauth
+                endpoints:
+                  - name: JDBC
+                    node-type: db
+                    port: 5432
+                    type: jdbc
+                    scheme: postgresql
+                """.trimIndent(),
+            )
+
+        val vars = resolver.resolveTargetVars(kitDir, clusterState)
+
+        assertThat(vars["TARGET_JDBC_USER"]).isEmpty()
+        assertThat(vars["TARGET_JDBC_DRIVER"]).isEmpty()
+    }
+}

--- a/test-plans/tidb-sysbench-benchmark.md
+++ b/test-plans/tidb-sysbench-benchmark.md
@@ -1,0 +1,133 @@
+# TiDB + Sysbench Benchmark
+
+End-to-end OLTP benchmark of TiDB using sysbench `oltp_read_write`. Validates the full
+sysbench kit lifecycle: install → prepare → start (with metrics push) → stop.
+
+## Cluster Configuration
+
+| Node type | Count | Role |
+|-----------|-------|------|
+| control   | 1     | K3s control plane, observability stack |
+| db        | 1     | TiKV (row store) + TiFlash (columnar) |
+| app       | 1     | TiDB SQL layer + PD (placement driver) |
+
+## Prerequisites
+
+- AWS credentials configured with `sandbox-admin` profile
+- Tailscale running on the developer machine (required for Grafana access and metrics push)
+- Project built: `./gradlew installDist`
+
+---
+
+## Steps
+
+### 1. Set up cluster workspace
+
+```bash
+CLUSTER_DIR="clusters/tidb-sysbench-$(date +%Y%m%d-%H%M%S)"
+mkdir -p "$CLUSTER_DIR"
+bin/create-easy-db-lab-wrapper "$CLUSTER_DIR"
+EDB="$CLUSTER_DIR/easy-db-lab"
+```
+
+### 2. Initialize cluster
+
+```bash
+$EDB init --name tidb-sysbench --db-nodes 1 --app-nodes 1
+```
+
+### 3. Build the binary
+
+```bash
+./gradlew installDist
+```
+
+### 4. Bring up cluster
+
+```bash
+$EDB up
+```
+
+Wait for all nodes to be provisioned and K3s to be running (~5 min).
+
+### 5. Install and start TiDB
+
+```bash
+$EDB kit install tidb
+$EDB tidb start
+```
+
+All four components must reach Ready: PD → TiKV → TiDB → TiFlash. Expect 10–15 min.
+
+### 6. Install sysbench targeting TiDB
+
+```bash
+$EDB kit install sysbench --target tidb --threads 8 --duration 300 --tables 10 --scale 10
+```
+
+This installs into `sysbench-tidb/` in the cluster workspace.
+
+### 7. Prepare test data
+
+Creates the `sbtest` database and loads 10 tables × 10,000 rows:
+
+```bash
+$EDB sysbench-tidb prepare
+```
+
+Expect ~3–5 min. Watch pod logs for progress:
+
+```bash
+kubectl --kubeconfig="$CLUSTER_DIR/kubeconfig" logs -f sysbench-prepare-sysbench-tidb
+```
+
+### 8. Run the benchmark
+
+```bash
+$EDB sysbench-tidb start
+```
+
+Sysbench reports TPS/QPS/P95 latency every 10 seconds. Metrics are pushed live to
+VictoriaMetrics over Tailscale. The command streams output until the benchmark completes
+(`--duration 300` = 5 min run).
+
+### 9. View metrics in Grafana
+
+Open Grafana at `http://<CONTROL_HOST_PRIVATE>:3000` (check `$CLUSTER_DIR/state.json` for
+the control node's private IP):
+
+- **Sysbench Benchmark** dashboard — client-side TPS, QPS, P95 latency, errors
+- Select `Kit = sysbench-tidb` from the dropdown
+
+### 10. Stop and clean up
+
+```bash
+$EDB sysbench-tidb stop     # drops sbtest tables, deletes pod
+$EDB tidb stop               # tears down TiDB cluster resources
+$EDB down --auto-approve     # terminates EC2 instances
+```
+
+---
+
+## Validation Checklist
+
+- [ ] `tidb start` completes — all four components (pd, tikv, tidb, tiflash) are Ready
+- [ ] `sysbench-tidb prepare` creates the `sbtest` database and exits with code 0
+- [ ] `sysbench-tidb start` streams interval stats (TPS/QPS/latency every 10s)
+- [ ] Metrics appear in Grafana **Sysbench Benchmark** dashboard within 30s of start
+- [ ] `sysbench-tidb stop` exits cleanly; no orphaned pods remain
+- [ ] `tidb stop` removes TiDB cluster resources cleanly
+
+## Notes
+
+- `--scale 10` = 10,000 rows per table. Use `--scale 100` (100k rows) for heavier load.
+- For parallel multi-database comparison, install sysbench twice:
+  ```bash
+  $EDB kit install sysbench --target tidb     --threads 8 --duration 300
+  $EDB kit install sysbench --target clickhouse --threads 8 --duration 300
+  $EDB sysbench-tidb start &
+  $EDB sysbench-clickhouse start &
+  ```
+  Both appear as separate series in the Sysbench Benchmark dashboard.
+- The `mysql:8.0` image used in the create-db pod connects with no password, matching
+  TiDB's default root account.


### PR DESCRIPTION
## Summary

- Adds a `kit-ref` arg type so bench kits can target a running database kit at install time (`kit install sysbench --target tidb`)
- Multi-instance directory naming: installing with `--target <db>` creates `<kit>-<db>/` so the same bench kit can run against multiple databases simultaneously
- `KitEndpointResolver` reads the target kit's endpoints and injects `TARGET_MYSQL_*`, `TARGET_PG_*`, `TARGET_JDBC_*`, `TARGET_HTTP_URL` env vars into the bench kit's start script
- New `mysql` and `postgresql` endpoint types with a `database` field
- Sysbench reference kit: prepare/start/stop against MySQL or PG wire; pushes TPS, QPS, P99 latency, errors/s to VictoriaMetrics; auto-installs a Grafana dashboard
- Validated end-to-end against TiDB (MySQL wire); PostgreSQL validation blocked on the postgres branch which depends on this branch's multi-instance naming

Closes #688