### PR TITLE
feat(kit): add Trino query engine kit with federation support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -147,6 +147,7 @@ dependencies {
     // Cassandra Driver
     implementation(libs.cassandra.driver.core)
     implementation(libs.presto.jdbc)
+    implementation(libs.trino.jdbc)
     implementation(libs.clickhouse.jdbc)
     implementation(libs.mysql.connector.j)
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -18,6 +18,7 @@
   - [ClickHouse](user-guide/clickhouse.md)
     - [Backup & Restore](user-guide/clickhouse-backup-restore.md)
   - [Presto](user-guide/install-presto.md)
+  - [Trino](user-guide/install-trino.md)
 - [Monitoring](user-guide/monitoring.md)
   - [Profiling](user-guide/profiling.md)
   - [Metrics](user-guide/victoria-metrics.md)

--- a/docs/user-guide/install-trino.md
+++ b/docs/user-guide/install-trino.md
@@ -1,0 +1,124 @@
+# Install Trino
+
+The `install trino` command scaffolds a Trino deployment using the Trino Helm chart. It generates scripts and a `values.yaml` in a local `trino/` directory. Once installed, use `easy-db-lab trino start` and `easy-db-lab trino stop` to manage it.
+
+Trino is stateless — it does not use persistent volumes. Queries run in-memory on app (`type=app`) nodes.
+
+## Prerequisites
+
+- Cluster is up (`easy-db-lab up`)
+- App nodes are provisioned (at least one `ServerType.Stress` node)
+- `kubectl` and `helm` are available on the control node
+- Environment is sourced: `source env.sh`
+
+## Quick Start
+
+```bash
+easy-db-lab kit install trino
+easy-db-lab trino start
+```
+
+## Flags
+
+| Flag | Default | Description |
+|---|---|---|
+| `--version` | `474` | Trino release version to deploy |
+| `--workers` | app node count | Number of Trino worker pods |
+
+## What Gets Generated
+
+```
+trino/
+├── README.md                    # Usage instructions for this cluster
+├── values.yaml                  # Helm values for the Trino chart
+├── catalogs/
+│   ├── cassandra.properties     # Cassandra connector config
+│   └── clickhouse.properties    # ClickHouse JDBC connector config
+└── bin/
+    ├── start.sh                 # Deploy sequence
+    ├── stop.sh                  # Teardown sequence
+    ├── uninstall.sh             # Remove Helm release
+    └── update-catalogs.sh       # Re-renders Trino catalog config from running kits
+```
+
+## Managing Trino
+
+After installation, use the CLI to start and stop:
+
+```bash
+# Deploy Trino
+easy-db-lab trino start
+
+# Stop Trino (scale to zero, no data loss)
+easy-db-lab trino stop
+```
+
+## Automatic Catalog Management
+
+Trino has built-in support for two catalogs that wire up automatically:
+
+- **Cassandra** — uses the Cassandra connector, pointing at the cluster's Cassandra nodes
+- **ClickHouse** — uses the ClickHouse JDBC connector, pointing at the cluster's ClickHouse nodes
+
+When either of those kits starts or stops, Trino detects the change via a `post-workload-start`
+/ `post-workload-stop` hook and re-renders its catalog configuration automatically. No restart
+of Trino is needed.
+
+```bash
+# Start Cassandra — Trino wires up the cassandra catalog automatically
+easy-db-lab cassandra start
+
+# Start ClickHouse — Trino wires up the clickhouse catalog automatically
+easy-db-lab kit install clickhouse
+easy-db-lab clickhouse start
+```
+
+## Node Placement
+
+Trino workers are scheduled on `type=app` nodes using `nodeSelector: type: app`.
+
+## Connecting
+
+After `easy-db-lab trino start` completes, the Trino coordinator is accessible within the cluster. Connect using the SOCKS5 proxy or a port-forward:
+
+```bash
+kubectl port-forward svc/trino 8080:8080
+```
+
+Then connect with any Trino-compatible client at `jdbc:trino://localhost:8080`.
+
+You can also use the built-in SQL command:
+
+```bash
+easy-db-lab trino sql "SELECT count(*) FROM cassandra.mykeyspace.mytable"
+```
+
+## Adding Trino Catalogs for Custom Kits
+
+If you install a custom kit via `--from` and want Trino to connect to it, drop a
+`trino-catalog.properties` file in the kit's installed directory:
+
+```
+my-kit/
+├── bin/
+│   ├── start.sh
+│   └── stop.sh
+└── trino-catalog.properties    # Trino picks this up automatically
+```
+
+The file follows the standard [Trino connector properties](https://trino.io/docs/current/connector.html) format:
+
+```properties
+connector.name=postgresql
+connection-url=jdbc:postgresql://localhost:5432/mydb
+connection-user=trino
+connection-password=
+```
+
+`update-catalogs.sh` scans all sibling kit directories for this file. When found, the catalog
+is added to Trino's configuration under a name matching the kit directory name. No restart of
+Trino is required — the script runs `helm upgrade` with the merged catalog values.
+
+## Presto vs Trino
+
+Trino is the open-source fork of Presto (previously known as PrestoSQL). Both are supported as independent kits. Choose Trino for the active open-source community and Presto for compatibility with Meta's Presto ecosystem.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -65,6 +65,7 @@ jedis = "7.4.0"
 # Other
 classgraph = "4.8.184"
 presto-jdbc = "0.289"
+trino-jdbc = "474"
 clickhouse-jdbc = "0.7.2"
 mysql-connector-j = "9.3.0"
 resilience4j = "2.4.0"
@@ -184,6 +185,7 @@ fabric8-kubernetes-server-mock = { module = "io.fabric8:kubernetes-server-mock",
 # Cassandra Driver
 cassandra-driver-core = { module = "org.apache.cassandra:java-driver-core", version.ref = "cassandra-driver" }
 presto-jdbc = { module = "com.facebook.presto:presto-jdbc", version.ref = "presto-jdbc" }
+trino-jdbc = { module = "io.trino:trino-jdbc", version.ref = "trino-jdbc" }
 clickhouse-jdbc = { module = "com.clickhouse:clickhouse-jdbc", version.ref = "clickhouse-jdbc" }
 mysql-connector-j = { module = "com.mysql:mysql-connector-j", version.ref = "mysql-connector-j" }
 

--- a/openspec/changes/add-trino-kit/.openspec.yaml
+++ b/openspec/changes/add-trino-kit/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-09

--- a/openspec/changes/add-trino-kit/design.md
+++ b/openspec/changes/add-trino-kit/design.md
@@ -1,0 +1,65 @@
+## Context
+
+easy-db-lab has a Presto kit that deploys Presto via the `prestodb/presto` Helm chart onto app nodes. Trino is the open-source fork of Presto (forked in 2019 as PrestoSQL, renamed Trino in 2021). The two projects have diverged enough that sharing kit code would create maintenance risk — they use different Helm charts, different deployment names, and different JDBC driver classes.
+
+The existing Presto kit provides the implementation blueprint. The catalog-hook system (`post-workload-start` / `post-workload-stop`) is already in place and functional; Trino just needs its own kit that participates in it.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Deliver a fully independent Trino kit mirroring the Presto kit's structure
+- Wire catalog hooks for Cassandra and ClickHouse connectors
+- Support `--version` flag for Trino release selection
+- Provide `trino sql` command via the `sql` capability
+- Rename `--clickhouse-version` to `--version` in the ClickHouse kit
+
+**Non-Goals:**
+- Shared base between Presto and Trino kits — deliberate decision to avoid divergence headaches
+- Trino-specific Grafana dashboards (can be added later)
+- Trino metrics-catalog.json beyond a placeholder (metrics shape TBD once deployed)
+
+## Decisions
+
+### 1. Fully independent kit (no shared code)
+
+**Decision**: Two separate kits with no shared scripts or templates.
+
+**Rationale**: Presto and Trino already diverge on Helm chart structure, deployment names, JDBC drivers, and catalog property conventions. A shared base would require conditional logic throughout every script. Independent kits are easier to reason about and modify independently.
+
+**Alternatives considered**: A base `update-catalogs.sh` parameterised by engine name — rejected because the catalog property format differs between engines and the complexity would grow with every new connector.
+
+### 2. Catalog connector file naming
+
+**Decision**: Trino's hook script scans for `trino-catalog.properties` in sibling kit directories (analogous to Presto's scan for `presto-catalog.properties`).
+
+**Rationale**: This is the existing extensibility mechanism for custom workloads installed via `--from`. Consistent naming makes the pattern discoverable. Built-in connector support (Cassandra, ClickHouse) lives in `kits/trino/catalogs/` and is added based on `RUNNING_KITS`.
+
+### 3. Metrics port
+
+**Decision**: Scrape port 8080 (Trino's built-in JMX metrics endpoint at `/v1/jmx/mbean`).
+
+**Rationale**: Trino exposes Prometheus-compatible metrics at port 8080. No separate JMX exporter needed (unlike Presto which uses port 9090).
+
+### 4. `--version` flag standardisation
+
+**Decision**: Rename `--clickhouse-version` to `--version` in the ClickHouse kit, and use `--version` from the start in Trino.
+
+**Rationale**: All versioned kits should use the same flag name. `--clickhouse-version` is redundant — the subcommand already establishes context.
+
+**Impact**: Breaking change to ClickHouse install CLI. Acceptable — clusters are ephemeral, no existing installs to migrate.
+
+### 5. Pyroscope profiling
+
+**Decision**: Wire Pyroscope the same way as Presto — patch coordinator and worker deployments after Helm install to inject the Java agent as a `JAVA_TOOL_OPTIONS` env var with a host-path volume.
+
+**Rationale**: Trino is a JVM workload; the same profiling approach applies. The Pyroscope agent JAR is baked into the AMI at `/usr/local/pyroscope/`.
+
+## Risks / Trade-offs
+
+- **Trino Helm chart API changes** → Mitigation: pin to a specific chart version in `values.yaml`; the `--version` flag controls the Trino app version independently.
+- **Catalog property differences accumulate over time** → Acceptable: independent kits make this easy to address per-kit without cross-contamination.
+- **ClickHouse `--version` rename breaks existing scripts** → Acceptable: ephemeral clusters; no long-lived deployments.
+
+## Migration Plan
+
+No migration needed. Clusters are ephemeral. Existing Presto kit is unchanged. ClickHouse flag rename takes effect on the next `kit install clickhouse` invocation.

--- a/openspec/changes/add-trino-kit/proposal.md
+++ b/openspec/changes/add-trino-kit/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+easy-db-lab supports Presto for federated SQL queries against running database kits, but Trino — the more widely-used open-source fork — is missing. Teams running Trino in production have no equivalent lab environment. We also take this opportunity to standardize the version flag across versioned kits (`--clickhouse-version` → `--version`).
+
+## What Changes
+
+- **New Trino kit** at `kits/trino/` as a fully independent kit (no shared code with Presto) with:
+  - Helm-based deployment via `trinodb/trino` chart targeting app nodes
+  - `--version` flag for selecting the Trino release
+  - Catalog connectors for Cassandra and ClickHouse (wired via `post-workload-start`/`post-workload-stop` hooks)
+  - Sibling-directory scan for `trino-catalog.properties` (extensibility for custom workloads)
+  - Pyroscope profiling agent patched onto coordinator and worker deployments
+  - `trino sql` command via the `sql` capability and `io.trino.jdbc.TrinoDriver`
+- **Rename `--clickhouse-version` to `--version`** in the ClickHouse kit for consistency
+
+## Capabilities
+
+### New Capabilities
+
+- `trino`: Trino kit lifecycle, catalog connector management, and SQL execution against a running Trino cluster
+
+### Modified Capabilities
+
+- `clickhouse`: `--clickhouse-version` flag renamed to `--version` (consistent with all versioned kits)
+
+## Impact
+
+- New kit resource directory: `src/main/resources/com/rustyrazorblade/easydblab/kits/trino/`
+- New spec: `openspec/specs/trino/spec.md`
+- Modified: `src/main/resources/com/rustyrazorblade/easydblab/kits/clickhouse/kit.yaml` (flag rename)
+- Modified: `openspec/specs/clickhouse/spec.md` (flag rename requirement)
+- New Gradle dependency: Trino JDBC driver (`io.trino:trino-jdbc`)
+- No Kotlin source changes required — kit is entirely shell scripts + kit.yaml

--- a/openspec/changes/add-trino-kit/specs/clickhouse/spec.md
+++ b/openspec/changes/add-trino-kit/specs/clickhouse/spec.md
@@ -1,0 +1,12 @@
+## MODIFIED Requirements
+
+### Requirement: Version Selection Flag
+The ClickHouse kit MUST accept a `--version` flag (not `--clickhouse-version`) at install time to select the ClickHouse server image version.
+
+#### Scenario: Custom version with --version
+- **WHEN** the user runs `kit install clickhouse --version 25.4`
+- **THEN** the deployed ClickHouse uses image version 25.4
+
+#### Scenario: Default version
+- **WHEN** the user runs `kit install clickhouse` without `--version`
+- **THEN** the kit deploys the default ClickHouse version (`latest`)

--- a/openspec/changes/add-trino-kit/specs/trino/spec.md
+++ b/openspec/changes/add-trino-kit/specs/trino/spec.md
@@ -1,0 +1,74 @@
+## ADDED Requirements
+
+### Requirement: Kit Lifecycle
+The system MUST support installing, starting, stopping, and uninstalling Trino via the kit mechanism. Trino deploys via the `trinodb/trino` Helm chart onto app nodes.
+
+#### Scenario: Install and start Trino
+- **WHEN** the user runs `kit install trino` and then `trino start`
+- **THEN** Trino is deployed via Helm on app nodes with the requested worker count
+
+#### Scenario: Stop Trino
+- **WHEN** the user runs `trino stop`
+- **THEN** the Trino coordinator and worker deployments are scaled to zero replicas
+
+#### Scenario: Restart Trino after stop
+- **WHEN** the user runs `trino start` after a prior stop
+- **THEN** Trino is re-deployed without requiring re-installation
+
+#### Scenario: No app nodes
+- **WHEN** the user runs `kit install trino` on a cluster with no app nodes
+- **THEN** an error is emitted and installation is aborted
+
+### Requirement: Version Selection
+The Trino kit MUST accept a `--version` flag at install time to select the Trino release to deploy.
+
+#### Scenario: Custom version
+- **WHEN** the user runs `kit install trino --version 469`
+- **THEN** the deployed Trino image uses version 469
+
+#### Scenario: Default version
+- **WHEN** the user runs `kit install trino` without `--version`
+- **THEN** the kit deploys a pinned default Trino version
+
+### Requirement: Catalog Connector Management
+The Trino kit MUST automatically update its catalog configuration when other database kits start or stop, so Trino can query those databases without manual reconfiguration.
+
+#### Scenario: Cassandra catalog added on start
+- **WHEN** a Cassandra workload is running and Trino starts (or Trino is running and Cassandra starts)
+- **THEN** Trino's Helm release is upgraded with a Cassandra catalog entry using `connector.name=cassandra`
+
+#### Scenario: ClickHouse catalog added on start
+- **WHEN** a ClickHouse workload is running and Trino starts (or Trino is running and ClickHouse starts)
+- **THEN** Trino's Helm release is upgraded with a ClickHouse catalog entry using `connector.name=clickhouse`
+
+#### Scenario: Catalog removed on stop
+- **WHEN** a database workload stops while Trino is running
+- **THEN** Trino's Helm release is upgraded removing that workload's catalog entry
+
+#### Scenario: Custom workload catalog
+- **WHEN** a custom workload directory contains a `trino-catalog.properties` file
+- **THEN** that file is included as a catalog entry in the next Helm upgrade
+
+### Requirement: SQL Execution
+The `trino sql` command SHALL execute SQL statements against a running Trino cluster. SQL execution is provided via the `sql` capability declared in `trino/kit.yaml`.
+
+The Trino JDBC driver (`io.trino:trino-jdbc`) MUST be declared as a dependency and force-loaded via `driver-class: io.trino.jdbc.TrinoDriver` in the capability declaration.
+
+#### Scenario: Inline SQL
+- **WHEN** the user runs `trino sql "SELECT count(*) FROM cassandra.keyspace.table"`
+- **THEN** the query is submitted via JDBC and results are displayed in tabular format
+
+#### Scenario: SQL from file
+- **WHEN** the user runs `trino sql --file query.sql`
+- **THEN** the SQL from the file is executed against the Trino cluster
+
+#### Scenario: No app nodes
+- **WHEN** no app nodes exist in cluster state
+- **THEN** an error is emitted before any connection is made
+
+### Requirement: Pyroscope Profiling
+Trino coordinator and worker deployments SHALL be patched after Helm install to attach the Pyroscope Java profiling agent, enabling continuous profiling in Grafana.
+
+#### Scenario: Profiling agent attached
+- **WHEN** Trino starts successfully
+- **THEN** both coordinator and worker pods have the Pyroscope agent injected via `JAVA_TOOL_OPTIONS` and the `/usr/local/pyroscope` host-path volume is mounted

--- a/openspec/changes/add-trino-kit/tasks.md
+++ b/openspec/changes/add-trino-kit/tasks.md
@@ -1,0 +1,33 @@
+## 1. ClickHouse Kit: Rename --version Flag
+
+- [x] 1.1 Rename `--clickhouse-version` flag to `--version` and variable `CLICKHOUSE_VERSION` in `kits/clickhouse/kit.yaml`
+- [x] 1.2 Update all references to `__CLICKHOUSE_VERSION__` in ClickHouse kit templates to use `__VERSION__`
+- [x] 1.3 Update `openspec/specs/clickhouse/spec.md` to reflect the renamed flag
+
+## 2. Trino Kit: Core Files
+
+- [x] 2.1 Add Trino JDBC driver dependency (`io.trino:trino-jdbc`) to `build.gradle.kts`
+- [x] 2.2 Create `kits/trino/kit.yaml` with `--version` arg, `sql` capability, endpoints, metrics (port 8080), and catalog hooks
+- [x] 2.3 Create `kits/trino/values.yaml.template` with coordinator/worker node selectors and worker count
+- [x] 2.4 Create `kits/trino/README.md.template`
+
+## 3. Trino Kit: Shell Scripts
+
+- [x] 3.1 Create `kits/trino/bin/start.sh.template` — helm repo add + `update-catalogs.sh`, then patch coordinator and worker deployments for Pyroscope, then rollout wait
+- [x] 3.2 Create `kits/trino/bin/stop.sh.template` — scale coordinator and worker to zero replicas
+- [x] 3.3 Create `kits/trino/bin/uninstall.sh.template` — helm uninstall the trino release
+- [x] 3.4 Create `kits/trino/bin/update-catalogs.sh.template` — build catalog YAML from `RUNNING_KITS` + sibling `trino-catalog.properties` scan, then `helm upgrade --install`
+
+## 4. Trino Kit: Catalog Connector Files
+
+- [x] 4.1 Create `kits/trino/catalogs/cassandra.properties.template` with `connector.name=cassandra` and `__DB_NODE_IPS__`
+- [x] 4.2 Create `kits/trino/catalogs/clickhouse.properties.template` with `connector.name=clickhouse` and unprefixed JDBC properties
+
+## 5. Trino Kit: Observability
+
+- [x] 5.1 Create `kits/trino/metrics-catalog.json` (placeholder matching Presto structure, port 8080)
+
+## 6. Spec and Documentation
+
+- [x] 6.1 Create `openspec/specs/trino/spec.md` from the change spec
+- [x] 6.2 Update user docs (`docs/`) to include Trino kit reference

--- a/openspec/specs/clickhouse/spec.md
+++ b/openspec/specs/clickhouse/spec.md
@@ -53,3 +53,12 @@ SQL execution is provided via the `sql` capability declared in `clickhouse/kit.y
   **THEN** the query is submitted via JDBC and results are displayed in tabular format.
 - **WHEN** the user runs `clickhouse sql --file query.sql`, **THEN** the SQL from the file is executed.
 - **WHEN** no db nodes exist in cluster state, **THEN** an error is emitted before any connection is made.
+
+### REQ-CH-006: Version Selection
+
+The ClickHouse kit MUST accept a `--version` flag at install time to select the ClickHouse server image version. The flag MUST NOT use the prefix form `--clickhouse-version`.
+
+**Scenarios:**
+
+- **WHEN** the user runs `kit install clickhouse --version 25.4`, **THEN** the deployed ClickHouse uses image version 25.4.
+- **WHEN** the user runs `kit install clickhouse` without `--version`, **THEN** the kit deploys with the default version (`latest`).

--- a/openspec/specs/trino/spec.md
+++ b/openspec/specs/trino/spec.md
@@ -1,0 +1,56 @@
+# Trino
+
+Manages the Trino kit lifecycle, catalog connector management, and SQL execution against a running Trino cluster.
+
+## Requirements
+
+### REQ-TRN-001: Kit Lifecycle
+
+The system MUST support installing, starting, stopping, and uninstalling Trino via the kit mechanism. Trino deploys via the `trinodb/trino` Helm chart onto app nodes.
+
+**Scenarios:**
+
+- **GIVEN** a running cluster, **WHEN** the user runs `kit install trino` and then `trino start`, **THEN** Trino is deployed via Helm on app nodes with the requested worker count.
+- **WHEN** the user runs `trino stop`, **THEN** the Trino coordinator and worker deployments are scaled to zero replicas.
+- **WHEN** the user runs `trino start` after a prior stop, **THEN** Trino is re-deployed without requiring re-installation.
+- **WHEN** the user runs `kit install trino` on a cluster with no app nodes, **THEN** an error is emitted and installation is aborted.
+
+### REQ-TRN-002: Version Selection
+
+The Trino kit MUST accept a `--version` flag at install time to select the Trino release to deploy.
+
+**Scenarios:**
+
+- **WHEN** the user runs `kit install trino --version 469`, **THEN** the deployed Trino image uses version 469.
+- **WHEN** the user runs `kit install trino` without `--version`, **THEN** the kit deploys the default pinned Trino version.
+
+### REQ-TRN-003: Catalog Connector Management
+
+The Trino kit MUST automatically update its catalog configuration when other database kits start or stop, so Trino can query those databases without manual reconfiguration.
+
+**Scenarios:**
+
+- **WHEN** a Cassandra workload is running and Trino starts (or Trino is running and Cassandra starts), **THEN** Trino's Helm release is upgraded with a Cassandra catalog using `connector.name=cassandra`.
+- **WHEN** a ClickHouse workload is running and Trino starts (or Trino is running and ClickHouse starts), **THEN** Trino's Helm release is upgraded with a ClickHouse catalog using `connector.name=clickhouse`.
+- **WHEN** a database workload stops while Trino is running, **THEN** Trino's Helm release is upgraded removing that workload's catalog entry.
+- **WHEN** a custom workload directory contains a `trino-catalog.properties` file, **THEN** that file is included as a catalog entry in the next Helm upgrade.
+
+### REQ-TRN-004: SQL Execution
+
+The `trino sql` command SHALL execute SQL statements against a running Trino cluster. SQL execution is provided via the `sql` capability declared in `trino/kit.yaml`.
+
+The Trino JDBC driver (`io.trino:trino-jdbc`) MUST be declared as a Gradle dependency and force-loaded via `driver-class: io.trino.jdbc.TrinoDriver` in the capability declaration.
+
+**Scenarios:**
+
+- **WHEN** the user runs `trino sql "SELECT count(*) FROM cassandra.keyspace.table"`, **THEN** the query is submitted via JDBC and results are displayed in tabular format.
+- **WHEN** the user runs `trino sql --file query.sql`, **THEN** the SQL from the file is executed against the Trino cluster.
+- **WHEN** no app nodes exist in cluster state, **THEN** an error is emitted before any connection is made.
+
+### REQ-TRN-005: Pyroscope Profiling
+
+Trino coordinator and worker deployments SHALL be patched after Helm install to attach the Pyroscope Java profiling agent.
+
+**Scenarios:**
+
+- **WHEN** Trino starts successfully, **THEN** both coordinator and worker pods have the Pyroscope agent injected via `JAVA_TOOL_OPTIONS` and the `/usr/local/pyroscope` host-path volume is mounted.

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/otel/OtelManifestBuilder.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/otel/OtelManifestBuilder.kt
@@ -70,7 +70,8 @@ class OtelManifestBuilder(
             val jobName = data["job-name"] ?: return@mapNotNull null
             val port = data["port"]?.toIntOrNull() ?: return@mapNotNull null
             val path = data["path"] ?: "/metrics"
-            WorkloadScrapeConfig(jobName = jobName, port = port, path = path)
+            val username = data["username"] ?: ""
+            WorkloadScrapeConfig(jobName = jobName, port = port, path = path, username = username)
         }
     }
 
@@ -184,6 +185,7 @@ class OtelManifestBuilder(
                                 replacement = "\${env:CLUSTER_NAME}",
                             ),
                         ),
+                    basicAuth = if (config.username.isNotBlank()) PrometheusBasicAuth(username = config.username) else null,
                 )
             }
         // 8-space indent matches the depth of `- job_name:` entries under

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/otel/PrometheusScrapeJob.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/otel/PrometheusScrapeJob.kt
@@ -1,15 +1,26 @@
 package com.rustyrazorblade.easydblab.configuration.otel
 
+import kotlinx.serialization.EncodeDefault
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
+data class PrometheusBasicAuth(
+    val username: String,
+    val password: String = "",
+)
+
+@Serializable
+@OptIn(ExperimentalSerializationApi::class)
 data class PrometheusScrapeJob(
     @SerialName("job_name") val jobName: String,
     @SerialName("scrape_interval") val scrapeInterval: String,
     @SerialName("static_configs") val staticConfigs: List<PrometheusStaticConfig>,
     @SerialName("metrics_path") val metricsPath: String,
     @SerialName("relabel_configs") val relabelConfigs: List<PrometheusRelabelConfig>,
+    @EncodeDefault(EncodeDefault.Mode.NEVER)
+    @SerialName("basic_auth") val basicAuth: PrometheusBasicAuth? = null,
 )
 
 @Serializable

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/otel/WorkloadScrapeConfig.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/otel/WorkloadScrapeConfig.kt
@@ -2,9 +2,15 @@ package com.rustyrazorblade.easydblab.configuration.otel
 
 /**
  * Scrape target for a running K8s workload, read from the metrics registry ConfigMaps.
+ *
+ * Note: only username-based basic auth is supported. Password is intentionally omitted —
+ * Trino's FIXED auth mode requires only a username with no real password. If a future kit
+ * needs password-based scrape auth, extend this class, KitMetrics.Scrape, PrometheusBasicAuth,
+ * and OtelManifestBuilder.buildConfigMap() together.
  */
 data class WorkloadScrapeConfig(
     val jobName: String,
     val port: Int,
     val path: String,
+    val username: String = "",
 )

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/KitConfig.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/KitConfig.kt
@@ -25,6 +25,7 @@ sealed class KitMetrics {
         val port: Int,
         val path: String = "/metrics",
         val job: String = "",
+        val username: String = "",
     ) : KitMetrics()
 
     @Serializable

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/MetricsRegistryService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/MetricsRegistryService.kt
@@ -64,11 +64,12 @@ class DefaultMetricsRegistryService(
                         namespace = Constants.K8s.NAMESPACE,
                         name = configMapName,
                         data =
-                            mapOf(
-                                "job-name" to jobName,
-                                "port" to target.port.toString(),
-                                "path" to target.path,
-                            ),
+                            buildMap {
+                                put("job-name", jobName)
+                                put("port", target.port.toString())
+                                put("path", target.path)
+                                if (target.username.isNotBlank()) put("username", target.username)
+                            },
                         labels =
                             mapOf(
                                 Constants.K8s.WORKLOAD_METRICS_LABEL to "true",

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/TemplateVariables.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/TemplateVariables.kt
@@ -28,6 +28,7 @@ data class TemplateVariables(
     val appNodeIps: String,
     val runningKits: String,
     val vpcCidr: String,
+    val opensearchEndpoint: String,
 ) {
     fun toMap(): Map<String, String> =
         mapOf(
@@ -49,6 +50,7 @@ data class TemplateVariables(
             "APP_NODE_IPS" to appNodeIps,
             "RUNNING_KITS" to runningKits,
             "VPC_CIDR" to vpcCidr,
+            "OPENSEARCH_ENDPOINT" to opensearchEndpoint,
         )
 
     companion object {
@@ -88,6 +90,7 @@ data class TemplateVariables(
                 // cidr is null until 'up' resolves and persists it; DEFAULT_CIDR is a safe
                 // fallback because templates using VPC_CIDR only execute post-up
                 vpcCidr = state.initConfig?.cidr ?: Constants.Vpc.DEFAULT_CIDR,
+                opensearchEndpoint = state.openSearchDomain?.endpoint.orEmpty(),
             )
         }
     }

--- a/src/main/resources/com/rustyrazorblade/easydblab/kits/clickhouse/clickhouseinstallation.yaml.template
+++ b/src/main/resources/com/rustyrazorblade/easydblab/kits/clickhouse/clickhouseinstallation.yaml.template
@@ -112,7 +112,7 @@ spec:
         spec:
           containers:
             - name: clickhouse
-              image: clickhouse/clickhouse-server:__CLICKHOUSE_VERSION__
+              image: clickhouse/clickhouse-server:__VERSION__
           affinity:
             nodeAffinity:
               requiredDuringSchedulingIgnoredDuringExecution:

--- a/src/main/resources/com/rustyrazorblade/easydblab/kits/clickhouse/kit.yaml
+++ b/src/main/resources/com/rustyrazorblade/easydblab/kits/clickhouse/kit.yaml
@@ -28,8 +28,8 @@ endpoints:
     path: /default?compress=0
     database: "default"
 args:
-  - flag: --clickhouse-version
-    variable: CLICKHOUSE_VERSION
+  - flag: --version
+    variable: VERSION
     description: "ClickHouse server image version (e.g. 25.4, 24.8)"
     type: string
     default: "latest"

--- a/src/main/resources/com/rustyrazorblade/easydblab/kits/tidb/tidbcluster.yaml.template
+++ b/src/main/resources/com/rustyrazorblade/easydblab/kits/tidb/tidbcluster.yaml.template
@@ -30,6 +30,14 @@ spec:
     # forwards to Tempo. The `opentelemetry.*` config keys do not exist in v8.x and will be
     # rejected at startup — use [opentracing] instead.
     config: |
+      [noop]
+        enable-noop-functions = true
+      [prepared-plan-cache]
+        enabled = true
+      [stmt-summary]
+        enable = true
+      [tikv-client]
+        grpc-connection-count = 4
       [opentracing]
         enable = true
       [opentracing.sampler]

--- a/src/main/resources/com/rustyrazorblade/easydblab/kits/trino/README.md.template
+++ b/src/main/resources/com/rustyrazorblade/easydblab/kits/trino/README.md.template
@@ -1,0 +1,89 @@
+# Trino on __KIT_NAME__ cluster
+
+Workload: Trino — stateless, targets app nodes
+Version: __VERSION__
+Workers: __WORKERS__
+App nodes: __APP_NODE_COUNT__
+Region: __REGION__
+
+## Quick start
+
+```bash
+./start.sh    # install Trino via Helm, wait for ready
+./stop.sh     # scale Trino to zero (no persistent data)
+```
+
+## Built-in catalogs
+
+Catalogs for co-located databases are added automatically when their services are running:
+
+| Catalog      | Connector    | When added                          |
+|--------------|--------------|-------------------------------------|
+| `cassandra`  | Cassandra    | When `cassandra` is in RUNNING_KITS |
+| `clickhouse` | ClickHouse   | When `clickhouse` is in RUNNING_KITS |
+| `opensearch` | OpenSearch   | When cluster has an OpenSearch domain |
+| `tidb`       | MySQL        | When `tidb` is in RUNNING_KITS        |
+
+## Custom catalogs
+
+You can add your own Trino catalogs — extra data sources, federation views, or
+external databases — without modifying any kit files.
+
+### Option 1: Drop a `trino-catalog.properties` file in a sibling directory
+
+Any sibling kit workspace directory that contains a `trino-catalog.properties`
+file is picked up automatically by `update-catalogs.sh`:
+
+```
+clusters/my-cluster/
+├── trino/               ← this kit
+└── my-other-db/
+    └── trino-catalog.properties   ← auto-discovered
+```
+
+The catalog name is taken from the directory name (`my-other-db`). This is the
+recommended approach for ad-hoc databases and custom --from kits.
+
+Example `trino-catalog.properties` for a MySQL database:
+```properties
+connector.name=mysql
+connection-url=jdbc:mysql://my-host:3306
+connection-user=root
+connection-password=secret
+```
+
+### Option 2: Edit the override file directly
+
+`update-catalogs.sh` writes a Helm values override to `.catalogs-override.yaml`
+before each `helm upgrade`. You can also edit this file by hand and run
+`./update-catalogs.sh` to apply changes:
+
+```yaml
+additionalCatalogs:
+  my_catalog: |
+    connector.name=tpch
+    tpch.splits-per-node=4
+```
+
+### Re-applying catalog changes
+
+After adding or changing catalogs, run:
+
+```bash
+./bin/update-catalogs.sh
+```
+
+This re-runs `helm upgrade` with the new catalog values. Running queries in
+progress are not interrupted — Trino restarts gracefully.
+
+### Connector reference
+
+Trino ships with connectors for many systems. Common ones:
+
+- [Cassandra](https://trino.io/docs/current/connector/cassandra.html)
+- [ClickHouse](https://trino.io/docs/current/connector/clickhouse.html)
+- [OpenSearch](https://trino.io/docs/current/connector/opensearch.html)
+- [MySQL](https://trino.io/docs/current/connector/mysql.html)
+- [PostgreSQL](https://trino.io/docs/current/connector/postgresql.html)
+- [TPCH (built-in benchmark data)](https://trino.io/docs/current/connector/tpch.html)
+- [Black Hole (dev/testing)](https://trino.io/docs/current/connector/blackhole.html)

--- a/src/main/resources/com/rustyrazorblade/easydblab/kits/trino/bin/start.sh.template
+++ b/src/main/resources/com/rustyrazorblade/easydblab/kits/trino/bin/start.sh.template
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export KUBECONFIG="${SCRIPT_DIR}/../../__KUBECONFIG__"
+
+echo "Installing Trino..."
+helm repo add trinodb https://trinodb.github.io/charts 2>/dev/null || true
+
+# Install and configure catalogs in one step (update-catalogs.sh owns the helm install)
+"${SCRIPT_DIR}/update-catalogs.sh"
+
+PYROSCOPE_OPTS="-javaagent:/usr/local/pyroscope/pyroscope.jar -Dpyroscope.application.name=trino -Dpyroscope.server.address=http://${CONTROL_HOST_PRIVATE}:4040 -Dpyroscope.format=jfr -Dpyroscope.profiler.event=cpu -Dpyroscope.profiler.alloc=512k -Dpyroscope.profiler.lock=10ms"
+
+PYROSCOPE_VOLUME='[{"name":"pyroscope-agent","hostPath":{"path":"/usr/local/pyroscope"}}]'
+PYROSCOPE_MOUNT='[{"name":"pyroscope-agent","mountPath":"/usr/local/pyroscope","readOnly":true}]'
+
+echo "Patching coordinator: hostPort + Pyroscope profiling agent..."
+COORD_PATCH=$(jq -n \
+  --argjson vols "$PYROSCOPE_VOLUME" \
+  --argjson mounts "$PYROSCOPE_MOUNT" \
+  --arg opts "${PYROSCOPE_OPTS} -Dpyroscope.labels=cluster=${CLUSTER_NAME},component=coordinator" \
+  '{spec:{template:{spec:{
+    volumes:$vols,
+    containers:[{name:"trino-coordinator",ports:[{containerPort:8080,hostPort:8080}],env:[{name:"JAVA_TOOL_OPTIONS",value:$opts}],
+      volumeMounts:$mounts}]
+  }}}}')
+kubectl patch deployment trino-coordinator \
+  --namespace default \
+  --type=strategic \
+  -p="$COORD_PATCH"
+
+echo "Patching worker: Pyroscope profiling agent..."
+WORKER_PATCH=$(jq -n \
+  --argjson vols "$PYROSCOPE_VOLUME" \
+  --argjson mounts "$PYROSCOPE_MOUNT" \
+  --arg opts "${PYROSCOPE_OPTS} -Dpyroscope.labels=cluster=${CLUSTER_NAME},component=worker" \
+  '{spec:{template:{spec:{
+    volumes:$vols,
+    containers:[{name:"trino-worker",env:[{name:"JAVA_TOOL_OPTIONS",value:$opts}],
+      volumeMounts:$mounts}]
+  }}}}')
+kubectl patch deployment trino-worker \
+  --namespace default \
+  --type=strategic \
+  -p="$WORKER_PATCH"
+
+echo "Waiting for rollout to complete..."
+# Delete coordinator pod explicitly: rolling restart fails with hostPort conflicts
+# when only one app node is available. Deleting the pod lets the deployment
+# controller create a replacement that picks up ConfigMap changes.
+kubectl delete pod -n default -l 'app.kubernetes.io/name=trino,app.kubernetes.io/component=coordinator' \
+  --ignore-not-found
+kubectl rollout status deployment/trino-coordinator --namespace default --timeout=180s
+kubectl rollout status deployment/trino-worker --namespace default --timeout=180s
+
+echo "Trino is ready. Workers: __WORKERS__"

--- a/src/main/resources/com/rustyrazorblade/easydblab/kits/trino/bin/stop.sh.template
+++ b/src/main/resources/com/rustyrazorblade/easydblab/kits/trino/bin/stop.sh.template
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export KUBECONFIG="${SCRIPT_DIR}/../../__KUBECONFIG__"
+
+echo "Stopping Trino..."
+kubectl scale deployment trino-coordinator trino-worker \
+  --replicas=0 \
+  --namespace default
+
+echo "Trino stopped."

--- a/src/main/resources/com/rustyrazorblade/easydblab/kits/trino/bin/uninstall.sh.template
+++ b/src/main/resources/com/rustyrazorblade/easydblab/kits/trino/bin/uninstall.sh.template
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export KUBECONFIG="${SCRIPT_DIR}/../../__KUBECONFIG__"
+
+echo "Uninstalling Trino..."
+helm uninstall trino --namespace default --ignore-not-found
+
+echo "Trino uninstalled."

--- a/src/main/resources/com/rustyrazorblade/easydblab/kits/trino/bin/update-catalogs.sh.template
+++ b/src/main/resources/com/rustyrazorblade/easydblab/kits/trino/bin/update-catalogs.sh.template
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKLOAD_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+CATALOGS_DIR="${SCRIPT_DIR}/../catalogs"
+CATALOG_YAML="${SCRIPT_DIR}/../.catalogs-override.yaml"
+export KUBECONFIG="${SCRIPT_DIR}/../../__KUBECONFIG__"
+
+catalog_content=""
+
+# Add a catalog entry from a properties file
+add_catalog() {
+    local name="$1"
+    local props_file="$2"
+    catalog_content+="  ${name}: |"$'\n'
+    while IFS= read -r line; do
+        catalog_content+="    ${line}"$'\n'
+    done < "$props_file"
+}
+
+# Infrastructure databases (not kits): add catalog when endpoint is known
+OPENSEARCH_PROPS="${CATALOGS_DIR}/opensearch.properties"
+if [ -f "$OPENSEARCH_PROPS" ] && grep -qE 'opensearch.host=.+' "$OPENSEARCH_PROPS"; then
+    echo "Adding catalog for infrastructure db: opensearch"
+    add_catalog "opensearch" "$OPENSEARCH_PROPS"
+fi
+
+# Natively supported workloads: check catalogs/ directory
+if [ -n "${RUNNING_KITS:-}" ]; then
+    IFS=',' read -ra workloads <<< "$RUNNING_KITS"
+    for workload in "${workloads[@]}"; do
+        props="${CATALOGS_DIR}/${workload}.properties"
+        if [ -f "$props" ]; then
+            echo "Adding catalog for running workload: $workload"
+            add_catalog "$workload" "$props"
+        fi
+    done
+fi
+
+# Custom --from workloads: scan sibling directories for trino-catalog.properties
+for props in "${WORKLOAD_ROOT}"/*/trino-catalog.properties; do
+    [ -f "$props" ] || continue
+    workload=$(basename "$(dirname "$props")")
+    echo "Adding catalog from custom workload: $workload"
+    add_catalog "$workload" "$props"
+done
+
+# Write override file and run helm upgrade
+EXTRA_VALUES=()
+if [ -n "$catalog_content" ]; then
+    printf "additionalCatalogs:\n%s" "$catalog_content" > "$CATALOG_YAML"
+    EXTRA_VALUES=(--values "$CATALOG_YAML")
+fi
+helm upgrade --install trino trinodb/trino \
+  --namespace default \
+  --create-namespace \
+  --values "${SCRIPT_DIR}/../values.yaml" \
+  "${EXTRA_VALUES[@]}"
+
+# The coordinator uses hostPort:8080. On a single app node a rolling update
+# deadlocks — new pod can't bind the port while the old pod holds it. Deleting
+# the pod lets the controller replace it cleanly.
+kubectl delete pod -n default \
+  -l 'app.kubernetes.io/name=trino,app.kubernetes.io/component=coordinator' \
+  --ignore-not-found
+kubectl rollout status deployment/trino-coordinator --namespace default --timeout=180s
+
+echo "Trino catalog update complete."

--- a/src/main/resources/com/rustyrazorblade/easydblab/kits/trino/catalogs/cassandra.properties.template
+++ b/src/main/resources/com/rustyrazorblade/easydblab/kits/trino/catalogs/cassandra.properties.template
@@ -1,0 +1,4 @@
+connector.name=cassandra
+cassandra.contact-points=__DB_NODE_IPS__
+cassandra.native-protocol-port=9042
+cassandra.load-policy.dc-aware.local-dc=__REGION__

--- a/src/main/resources/com/rustyrazorblade/easydblab/kits/trino/catalogs/clickhouse.properties.template
+++ b/src/main/resources/com/rustyrazorblade/easydblab/kits/trino/catalogs/clickhouse.properties.template
@@ -1,0 +1,4 @@
+connector.name=clickhouse
+connection-url=jdbc:clickhouse://clickhouse-clickhouse.default.svc.cluster.local:8123/default
+connection-user=default
+connection-password=

--- a/src/main/resources/com/rustyrazorblade/easydblab/kits/trino/catalogs/opensearch.properties.template
+++ b/src/main/resources/com/rustyrazorblade/easydblab/kits/trino/catalogs/opensearch.properties.template
@@ -1,0 +1,8 @@
+# Note: the Trino OpenSearch connector does not support AWS SigV4 request signing.
+# This catalog works only when the domain has fine-grained access control disabled
+# (open access policy). Requests to a standard AWS OpenSearch domain will return 403.
+connector.name=opensearch
+opensearch.host=__OPENSEARCH_ENDPOINT__
+opensearch.port=443
+opensearch.tls.enabled=true
+opensearch.ignore-publish-address=true

--- a/src/main/resources/com/rustyrazorblade/easydblab/kits/trino/catalogs/tidb.properties.template
+++ b/src/main/resources/com/rustyrazorblade/easydblab/kits/trino/catalogs/tidb.properties.template
@@ -1,0 +1,4 @@
+connector.name=mysql
+connection-url=jdbc:mysql://tidb-nodeport.default.svc.cluster.local:4000/?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC
+connection-user=root
+connection-password=

--- a/src/main/resources/com/rustyrazorblade/easydblab/kits/trino/dashboards/trino.json
+++ b/src/main/resources/com/rustyrazorblade/easydblab/kits/trino/dashboards/trino.json
@@ -1,0 +1,382 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Trino query engine metrics: query activity, memory, throughput, and CPU",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": 1,
+      "panels": [],
+      "title": "Query Activity",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Number of queries currently running",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 3, "w": 4, "x": 0, "y": 1 },
+      "id": 2,
+      "options": { "colorMode": "background", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"] }, "textMode": "auto" },
+      "targets": [{ "expr": "trino_execution_name_QueryManager_RunningQueries{job=\"trino\", cluster=\"$cluster\"}", "legendFormat": "Running", "refId": "A" }],
+      "title": "Running Queries",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Number of queries waiting in the queue",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 5 }, { "color": "red", "value": 20 }] },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 3, "w": 4, "x": 4, "y": 1 },
+      "id": 3,
+      "options": { "colorMode": "background", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"] }, "textMode": "auto" },
+      "targets": [{ "expr": "trino_execution_name_QueryManager_QueuedQueries{job=\"trino\", cluster=\"$cluster\"}", "legendFormat": "Queued", "refId": "A" }],
+      "title": "Queued Queries",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Number of queries fully blocked waiting for resources",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 1 }, { "color": "red", "value": 5 }] },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 3, "w": 4, "x": 8, "y": 1 },
+      "id": 4,
+      "options": { "colorMode": "background", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"] }, "textMode": "auto" },
+      "targets": [{ "expr": "trino_execution_name_QueryManager_FullyBlockedQueries{job=\"trino\", cluster=\"$cluster\"}", "legendFormat": "Blocked", "refId": "A" }],
+      "title": "Fully Blocked Queries",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Rate of successfully completed queries per second",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 3, "w": 4, "x": 12, "y": 1 },
+      "id": 5,
+      "options": { "colorMode": "background", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"] }, "textMode": "auto" },
+      "targets": [{ "expr": "rate(trino_execution_name_QueryManager_CompletedQueries_total{job=\"trino\", cluster=\"$cluster\"}[5m])", "legendFormat": "Completed/s", "refId": "A" }],
+      "title": "Completed Queries/sec",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Rate of failed queries per second — any non-zero value warrants investigation",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "red", "value": 0.01 }] },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 3, "w": 4, "x": 16, "y": 1 },
+      "id": 6,
+      "options": { "colorMode": "background", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"] }, "textMode": "auto" },
+      "targets": [{ "expr": "rate(trino_execution_name_QueryManager_FailedQueries_total{job=\"trino\", cluster=\"$cluster\"}[5m])", "legendFormat": "Failed/s", "refId": "A" }],
+      "title": "Failed Queries/sec",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Running, queued, and blocked query counts over time",
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "custom": { "fillOpacity": 10, "lineWidth": 1 }, "unit": "short" },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 4 },
+      "id": 7,
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        { "expr": "trino_execution_name_QueryManager_RunningQueries{job=\"trino\", cluster=\"$cluster\"}", "legendFormat": "Running {{instance}}", "refId": "A" },
+        { "expr": "trino_execution_name_QueryManager_QueuedQueries{job=\"trino\", cluster=\"$cluster\"}", "legendFormat": "Queued {{instance}}", "refId": "B" },
+        { "expr": "trino_execution_name_QueryManager_FullyBlockedQueries{job=\"trino\", cluster=\"$cluster\"}", "legendFormat": "Blocked {{instance}}", "refId": "C" }
+      ],
+      "title": "Query Counts Over Time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Rate of completed and failed queries per second",
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "custom": { "fillOpacity": 10, "lineWidth": 1 }, "unit": "reqps" },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 4 },
+      "id": 8,
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        { "expr": "rate(trino_execution_name_QueryManager_CompletedQueries_total{job=\"trino\", cluster=\"$cluster\"}[5m])", "legendFormat": "Completed {{instance}}", "refId": "A" },
+        { "expr": "rate(trino_execution_name_QueryManager_FailedQueries_total{job=\"trino\", cluster=\"$cluster\"}[5m])", "legendFormat": "Failed {{instance}}", "refId": "B" }
+      ],
+      "title": "Query Completion/Failure Rate",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 12 },
+      "id": 9,
+      "panels": [],
+      "title": "Memory",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Total memory available across the Trino cluster",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 3, "w": 4, "x": 0, "y": 13 },
+      "id": 10,
+      "options": { "colorMode": "background", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"] }, "textMode": "auto" },
+      "targets": [{ "expr": "trino_memory_name_ClusterMemoryManager_ClusterMemoryBytes{job=\"trino\", cluster=\"$cluster\"}", "legendFormat": "Total Memory", "refId": "A" }],
+      "title": "Cluster Total Memory",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Total memory currently reserved by all running queries",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 1 }] },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 3, "w": 4, "x": 4, "y": 13 },
+      "id": 11,
+      "options": { "colorMode": "background", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"] }, "textMode": "auto" },
+      "targets": [{ "expr": "trino_memory_name_ClusterMemoryManager_ClusterTotalMemoryReservation{job=\"trino\", cluster=\"$cluster\"}", "legendFormat": "Total Reserved", "refId": "A" }],
+      "title": "Total Memory Reservation",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "User (non-system) memory currently reserved by running queries",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 1 }] },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 3, "w": 4, "x": 8, "y": 13 },
+      "id": 12,
+      "options": { "colorMode": "background", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"] }, "textMode": "auto" },
+      "targets": [{ "expr": "trino_memory_name_ClusterMemoryManager_ClusterUserMemoryReservation{job=\"trino\", cluster=\"$cluster\"}", "legendFormat": "User Reserved", "refId": "A" }],
+      "title": "User Memory Reservation",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Total number of queries killed due to out-of-memory conditions — should be 0",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "red", "value": 1 }] },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 3, "w": 4, "x": 12, "y": 13 },
+      "id": 13,
+      "options": { "colorMode": "background", "orientation": "auto", "reduceOptions": { "calcs": ["lastNotNull"] }, "textMode": "auto" },
+      "targets": [{ "expr": "trino_memory_name_ClusterMemoryManager_QueriesKilledDueToOutOfMemory{job=\"trino\", cluster=\"$cluster\"}", "legendFormat": "OOM Kills", "refId": "A" }],
+      "title": "Queries Killed (OOM)",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Cluster memory capacity vs total and user memory reservations over time",
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "custom": { "fillOpacity": 10, "lineWidth": 1 }, "unit": "bytes" },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+      "id": 14,
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        { "expr": "trino_memory_name_ClusterMemoryManager_ClusterMemoryBytes{job=\"trino\", cluster=\"$cluster\"}", "legendFormat": "Total Capacity {{instance}}", "refId": "A" },
+        { "expr": "trino_memory_name_ClusterMemoryManager_ClusterTotalMemoryReservation{job=\"trino\", cluster=\"$cluster\"}", "legendFormat": "Total Reserved {{instance}}", "refId": "B" },
+        { "expr": "trino_memory_name_ClusterMemoryManager_ClusterUserMemoryReservation{job=\"trino\", cluster=\"$cluster\"}", "legendFormat": "User Reserved {{instance}}", "refId": "C" }
+      ],
+      "title": "Cluster Memory Over Time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Cumulative count of queries killed due to out-of-memory — any increase indicates memory pressure",
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "custom": { "fillOpacity": 10, "lineWidth": 1 }, "unit": "short" },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+      "id": 15,
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        { "expr": "trino_memory_name_ClusterMemoryManager_QueriesKilledDueToOutOfMemory{job=\"trino\", cluster=\"$cluster\"}", "legendFormat": "OOM Kills {{instance}}", "refId": "A" }
+      ],
+      "title": "OOM Kills Over Time",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 24 },
+      "id": 16,
+      "panels": [],
+      "title": "Throughput",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Data bytes read into tasks per second across all workers",
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "custom": { "fillOpacity": 10, "lineWidth": 1 }, "unit": "Bps" },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 25 },
+      "id": 17,
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        { "expr": "rate(trino_execution_name_SqlTaskManager_InputDataSize_total{job=\"trino\", cluster=\"$cluster\"}[5m])", "legendFormat": "Input Bytes/s {{instance}}", "refId": "A" },
+        { "expr": "rate(trino_execution_name_SqlTaskManager_OutputDataSize_total{job=\"trino\", cluster=\"$cluster\"}[5m])", "legendFormat": "Output Bytes/s {{instance}}", "refId": "B" }
+      ],
+      "title": "Task Data Throughput (Bytes)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Rows read and written by tasks per second across all workers",
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "custom": { "fillOpacity": 10, "lineWidth": 1 }, "unit": "rows/sec" },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 25 },
+      "id": 18,
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        { "expr": "rate(trino_execution_name_SqlTaskManager_InputPositions_total{job=\"trino\", cluster=\"$cluster\"}[5m])", "legendFormat": "Input Rows/s {{instance}}", "refId": "A" },
+        { "expr": "rate(trino_execution_name_SqlTaskManager_OutputPositions_total{job=\"trino\", cluster=\"$cluster\"}[5m])", "legendFormat": "Output Rows/s {{instance}}", "refId": "B" }
+      ],
+      "title": "Task Row Throughput",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "CPU seconds consumed by queries per second — indicates query execution intensity",
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "custom": { "fillOpacity": 10, "lineWidth": 1 }, "unit": "s/s" },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 33 },
+      "id": 19,
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
+      "targets": [
+        { "expr": "rate(trino_execution_name_QueryManager_ConsumedCpuTimeSecs_total{job=\"trino\", cluster=\"$cluster\"}[5m])", "legendFormat": "CPU s/s {{instance}}", "refId": "A" }
+      ],
+      "title": "Query CPU Consumption Rate",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "style": "dark",
+  "tags": ["trino"],
+  "templating": {
+    "list": [
+      {
+        "current": { "text": "VictoriaMetrics", "value": "VictoriaMetrics" },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "type": "datasource"
+      },
+      {
+        "current": {},
+        "datasource": { "type": "prometheus", "uid": "${datasource}" },
+        "definition": "label_values(up{job=\"trino\"}, cluster)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Cluster",
+        "multi": false,
+        "name": "cluster",
+        "options": [],
+        "query": {
+          "query": "label_values(up{job=\"trino\"}, cluster)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Trino Overview",
+  "uid": "trino-overview",
+  "version": 1
+}

--- a/src/main/resources/com/rustyrazorblade/easydblab/kits/trino/kit.yaml
+++ b/src/main/resources/com/rustyrazorblade/easydblab/kits/trino/kit.yaml
@@ -1,0 +1,43 @@
+name: trino
+type: app
+description: Scaffold Trino workload files (stateless, targets app nodes)
+collision-check: false
+metrics:
+  - type: scrape
+    port: 8080
+    path: /metrics
+    username: trino
+runtime:
+  type: helm
+  release: trino
+  namespace: default
+endpoints:
+  - name: "Trino UI"
+    node-type: app
+    port: 8080
+    type: http
+  - name: "JDBC"
+    node-type: app
+    port: 8080
+    type: jdbc
+    scheme: trino
+args:
+  - flag: --version
+    variable: VERSION
+    description: "Trino release version (e.g. 474, 469)"
+    type: string
+    default: "474"
+  - flag: --workers
+    variable: WORKERS
+    description: "Number of Trino workers (default: app node count)"
+    type: int
+    default: "${APP_NODE_COUNT}"
+hooks:
+  post-workload-start:
+    script: bin/update-catalogs.sh
+  post-workload-stop:
+    script: bin/update-catalogs.sh
+capabilities:
+  - type: sql
+    user: trino
+    driver-class: io.trino.jdbc.TrinoDriver

--- a/src/main/resources/com/rustyrazorblade/easydblab/kits/trino/metrics-catalog.json
+++ b/src/main/resources/com/rustyrazorblade/easydblab/kits/trino/metrics-catalog.json
@@ -1,0 +1,244 @@
+{
+  "workload": "trino",
+  "exported_at": "2026-06-10T17:00:50Z",
+  "series": [
+    {
+      "name": "trino_execution_name_QueryManager_CompletedQueries_total",
+      "labels": {
+        "cluster": "trino-metrics-7766a487-ec03-41d7-8d49-19846d7e4fc1",
+        "job": "trino",
+        "instance": "app0:8080",
+        "host_name": "app0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "app0",
+        "server_port": "8080",
+        "service_instance_id": "app0:8080",
+        "service_name": "trino",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "trino_execution_name_QueryManager_ConsumedCpuTimeSecs_total",
+      "labels": {
+        "cluster": "trino-metrics-7766a487-ec03-41d7-8d49-19846d7e4fc1",
+        "job": "trino",
+        "instance": "app0:8080",
+        "host_name": "app0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "app0",
+        "server_port": "8080",
+        "service_instance_id": "app0:8080",
+        "service_name": "trino",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "trino_execution_name_QueryManager_FailedQueries_total",
+      "labels": {
+        "cluster": "trino-metrics-7766a487-ec03-41d7-8d49-19846d7e4fc1",
+        "job": "trino",
+        "instance": "app0:8080",
+        "host_name": "app0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "app0",
+        "server_port": "8080",
+        "service_instance_id": "app0:8080",
+        "service_name": "trino",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "trino_execution_name_QueryManager_FullyBlockedQueries",
+      "labels": {
+        "cluster": "trino-metrics-7766a487-ec03-41d7-8d49-19846d7e4fc1",
+        "job": "trino",
+        "instance": "app0:8080",
+        "host_name": "app0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "app0",
+        "server_port": "8080",
+        "service_instance_id": "app0:8080",
+        "service_name": "trino",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "trino_execution_name_QueryManager_QueuedQueries",
+      "labels": {
+        "cluster": "trino-metrics-7766a487-ec03-41d7-8d49-19846d7e4fc1",
+        "job": "trino",
+        "instance": "app0:8080",
+        "host_name": "app0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "app0",
+        "server_port": "8080",
+        "service_instance_id": "app0:8080",
+        "service_name": "trino",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "trino_execution_name_QueryManager_RunningQueries",
+      "labels": {
+        "cluster": "trino-metrics-7766a487-ec03-41d7-8d49-19846d7e4fc1",
+        "job": "trino",
+        "instance": "app0:8080",
+        "host_name": "app0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "app0",
+        "server_port": "8080",
+        "service_instance_id": "app0:8080",
+        "service_name": "trino",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "trino_execution_name_SqlTaskManager_InputDataSize_total",
+      "labels": {
+        "cluster": "trino-metrics-7766a487-ec03-41d7-8d49-19846d7e4fc1",
+        "job": "trino",
+        "instance": "app0:8080",
+        "host_name": "app0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "app0",
+        "server_port": "8080",
+        "service_instance_id": "app0:8080",
+        "service_name": "trino",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "trino_execution_name_SqlTaskManager_InputPositions_total",
+      "labels": {
+        "cluster": "trino-metrics-7766a487-ec03-41d7-8d49-19846d7e4fc1",
+        "job": "trino",
+        "instance": "app0:8080",
+        "host_name": "app0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "app0",
+        "server_port": "8080",
+        "service_instance_id": "app0:8080",
+        "service_name": "trino",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "trino_execution_name_SqlTaskManager_OutputDataSize_total",
+      "labels": {
+        "cluster": "trino-metrics-7766a487-ec03-41d7-8d49-19846d7e4fc1",
+        "job": "trino",
+        "instance": "app0:8080",
+        "host_name": "app0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "app0",
+        "server_port": "8080",
+        "service_instance_id": "app0:8080",
+        "service_name": "trino",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "trino_execution_name_SqlTaskManager_OutputPositions_total",
+      "labels": {
+        "cluster": "trino-metrics-7766a487-ec03-41d7-8d49-19846d7e4fc1",
+        "job": "trino",
+        "instance": "app0:8080",
+        "host_name": "app0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "app0",
+        "server_port": "8080",
+        "service_instance_id": "app0:8080",
+        "service_name": "trino",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "trino_memory_name_ClusterMemoryManager_ClusterMemoryBytes",
+      "labels": {
+        "cluster": "trino-metrics-7766a487-ec03-41d7-8d49-19846d7e4fc1",
+        "job": "trino",
+        "instance": "app0:8080",
+        "host_name": "app0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "app0",
+        "server_port": "8080",
+        "service_instance_id": "app0:8080",
+        "service_name": "trino",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "trino_memory_name_ClusterMemoryManager_ClusterTotalMemoryReservation",
+      "labels": {
+        "cluster": "trino-metrics-7766a487-ec03-41d7-8d49-19846d7e4fc1",
+        "job": "trino",
+        "instance": "app0:8080",
+        "host_name": "app0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "app0",
+        "server_port": "8080",
+        "service_instance_id": "app0:8080",
+        "service_name": "trino",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "trino_memory_name_ClusterMemoryManager_ClusterUserMemoryReservation",
+      "labels": {
+        "cluster": "trino-metrics-7766a487-ec03-41d7-8d49-19846d7e4fc1",
+        "job": "trino",
+        "instance": "app0:8080",
+        "host_name": "app0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "app0",
+        "server_port": "8080",
+        "service_instance_id": "app0:8080",
+        "service_name": "trino",
+        "url_scheme": "http"
+      }
+    },
+    {
+      "name": "trino_memory_name_ClusterMemoryManager_QueriesKilledDueToOutOfMemory",
+      "labels": {
+        "cluster": "trino-metrics-7766a487-ec03-41d7-8d49-19846d7e4fc1",
+        "job": "trino",
+        "instance": "app0:8080",
+        "host_name": "app0",
+        "os_type": "linux",
+        "otel_scope_name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
+        "otel_scope_version": "0.154.0",
+        "server_address": "app0",
+        "server_port": "8080",
+        "service_instance_id": "app0:8080",
+        "service_name": "trino",
+        "url_scheme": "http"
+      }
+    }
+  ]
+}

--- a/src/main/resources/com/rustyrazorblade/easydblab/kits/trino/values.yaml.template
+++ b/src/main/resources/com/rustyrazorblade/easydblab/kits/trino/values.yaml.template
@@ -1,0 +1,17 @@
+server:
+  workers: __WORKERS__
+
+additionalConfigProperties:
+  - "web-ui.authentication.type=FIXED"
+  - "web-ui.user=trino"
+
+image:
+  tag: "__VERSION__"
+
+coordinator:
+  nodeSelector:
+    type: app
+
+worker:
+  nodeSelector:
+    type: app

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/commands/kit/KitInfoTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/commands/kit/KitInfoTest.kt
@@ -55,7 +55,7 @@ class KitInfoTest : BaseKoinTest() {
     fun `clickhouse info lists configurable args with flags and defaults`() {
         val output = buildInfo("clickhouse")
         assertThat(output).contains("Args:")
-        assertThat(output).contains("--clickhouse-version")
+        assertThat(output).contains("--version")
         assertThat(output).contains("--size")
         assertThat(output).contains("--replicas")
         assertThat(output).contains("(default:")

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/configuration/otel/OtelManifestBuilderTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/configuration/otel/OtelManifestBuilderTest.kt
@@ -111,4 +111,31 @@ class OtelManifestBuilderTest : BaseKoinTest() {
         assertThat(configMap.metadata.namespace).isEqualTo("default")
         assertThat(configMap.data).containsKey("otel-collector-config.yaml")
     }
+
+    @Test
+    fun `buildConfigMap with username generates basic_auth block in scrape job`() {
+        val scrapeConfigs =
+            listOf(
+                WorkloadScrapeConfig(jobName = "trino", port = 8080, path = "/metrics", username = "trino"),
+            )
+
+        val configMap = builder.buildConfigMap(scrapeConfigs)
+        val yaml = configMap.data["otel-collector-config.yaml"]!!
+
+        assertThat(yaml).contains("basic_auth:")
+        assertThat(yaml).contains("username: \"trino\"")
+    }
+
+    @Test
+    fun `buildConfigMap without username omits basic_auth block`() {
+        val scrapeConfigs =
+            listOf(
+                WorkloadScrapeConfig(jobName = "clickhouse", port = 9363, path = "/metrics"),
+            )
+
+        val configMap = builder.buildConfigMap(scrapeConfigs)
+        val yaml = configMap.data["otel-collector-config.yaml"]!!
+
+        assertThat(yaml).doesNotContain("basic_auth:")
+    }
 }

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/services/TemplateVariablesTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/services/TemplateVariablesTest.kt
@@ -6,6 +6,7 @@ import com.rustyrazorblade.easydblab.configuration.ClusterHost
 import com.rustyrazorblade.easydblab.configuration.ClusterState
 import com.rustyrazorblade.easydblab.configuration.ClusterStateManager
 import com.rustyrazorblade.easydblab.configuration.InitConfig
+import com.rustyrazorblade.easydblab.configuration.OpenSearchClusterState
 import com.rustyrazorblade.easydblab.configuration.ServerType
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -309,5 +310,44 @@ class TemplateVariablesTest : BaseKoinTest() {
         val vars = TemplateVariables.from(state = stateWith(), kitName = "clickhouse", storageSize = "100Gi")
 
         assertThat(vars.toMap()).containsKey("VPC_CIDR")
+    }
+
+    @Test
+    fun `from produces empty opensearchEndpoint when no opensearch domain`() {
+        val vars = TemplateVariables.from(state = stateWith(), kitName = "trino", storageSize = "0Gi")
+
+        assertThat(vars.opensearchEndpoint).isEmpty()
+    }
+
+    @Test
+    fun `from sets opensearchEndpoint from openSearchDomain endpoint`() {
+        val state =
+            stateWith().also {
+                it.openSearchDomain =
+                    OpenSearchClusterState(
+                        domainName = "my-domain",
+                        domainId = "id-123",
+                        endpoint = "search-my-domain-xyz.us-east-1.es.amazonaws.com",
+                    )
+            }
+        val vars = TemplateVariables.from(state = state, kitName = "trino", storageSize = "0Gi")
+
+        assertThat(vars.opensearchEndpoint).isEqualTo("search-my-domain-xyz.us-east-1.es.amazonaws.com")
+    }
+
+    @Test
+    fun `toMap includes OPENSEARCH_ENDPOINT key`() {
+        val state =
+            stateWith().also {
+                it.openSearchDomain =
+                    OpenSearchClusterState(
+                        domainName = "my-domain",
+                        domainId = "id-123",
+                        endpoint = "search-my-domain-xyz.us-east-1.es.amazonaws.com",
+                    )
+            }
+        val vars = TemplateVariables.from(state = state, kitName = "trino", storageSize = "0Gi")
+
+        assertThat(vars.toMap()).containsEntry("OPENSEARCH_ENDPOINT", "search-my-domain-xyz.us-east-1.es.amazonaws.com")
     }
 }

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -2,6 +2,7 @@
 <configuration>
     <!-- Console appender for WARN and above -->
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <target>System.err</target>
         <encoder>
             <pattern>%p %C{1}:%L [%t] %m%n</pattern>
         </encoder>

--- a/test-plans/trino-federation-cassandra-tidb.md
+++ b/test-plans/trino-federation-cassandra-tidb.md
@@ -1,0 +1,99 @@
+# Lab Plan: Trino Federation — Cassandra to TiDB
+
+## Objective
+
+Verify that Trino can query a Cassandra table and INSERT the data into TiDB using federation across both automatically-configured catalogs. Success is a TiDB table populated with rows sourced from Cassandra via a single Trino INSERT INTO ... SELECT statement.
+
+## Cluster Name
+
+trino-test
+
+## Datacenters
+
+single
+
+## Environment
+
+- 1 db node: `i4i.xlarge` (Cassandra + TiDB, local NVMe)
+- 1 app node: `i4i.xlarge` (Trino coordinator + worker, local NVMe)
+- No EBS volumes
+
+## Steps
+
+### 1. Provision the cluster
+
+```bash
+$EDB init trino-test -c 1 -s 1 -i i4i.xlarge -si i4i.xlarge --up
+```
+
+### 2. Start Cassandra
+
+```bash
+$EDB cassandra start
+```
+
+### 3. Install and start TiDB
+
+```bash
+$EDB kit install tidb
+$EDB tidb start
+```
+
+### 4. Install and start Trino
+
+```bash
+$EDB kit install trino
+$EDB trino start
+```
+
+### 5. Create a table in Cassandra and load data
+
+Create the keyspace and table, then insert a few rows:
+
+```bash
+$EDB cassandra cql "CREATE KEYSPACE IF NOT EXISTS demo WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};"
+$EDB cassandra cql "CREATE TABLE IF NOT EXISTS demo.users (id uuid PRIMARY KEY, name text, email text, created_at timestamp);"
+$EDB cassandra cql "INSERT INTO demo.users (id, name, email, created_at) VALUES (uuid(), 'Alice', 'alice@example.com', toTimestamp(now()));"
+$EDB cassandra cql "INSERT INTO demo.users (id, name, email, created_at) VALUES (uuid(), 'Bob', 'bob@example.com', toTimestamp(now()));"
+$EDB cassandra cql "INSERT INTO demo.users (id, name, email, created_at) VALUES (uuid(), 'Carol', 'carol@example.com', toTimestamp(now()));"
+$EDB cassandra cql "SELECT * FROM demo.users;"
+```
+
+### 6. Create the destination table in TiDB
+
+```bash
+$EDB tidb sql "CREATE DATABASE IF NOT EXISTS demo;"
+$EDB tidb sql "CREATE TABLE IF NOT EXISTS demo.users (id VARCHAR(36) PRIMARY KEY, name VARCHAR(255), email VARCHAR(255), created_at DATETIME);"
+```
+
+### 7. Verify Trino can see both catalogs
+
+```bash
+$EDB trino sql "SHOW CATALOGS;"
+$EDB trino sql "SELECT * FROM cassandra.demo.users LIMIT 5;"
+```
+
+### 8. Copy data from Cassandra to TiDB via Trino
+
+```bash
+$EDB trino sql "INSERT INTO tidb.demo.users SELECT CAST(id AS VARCHAR), name, email, created_at FROM cassandra.demo.users;"
+```
+
+### 9. Verify data landed in TiDB
+
+```bash
+$EDB tidb sql "SELECT * FROM demo.users;"
+```
+
+### 10. Tear down
+
+```bash
+$EDB down --auto-approve
+```
+
+## Notes
+
+- TiDB and Cassandra share the single db node — if memory is tight, TiDB pods may be slow to start. Give them up to 10 minutes.
+- Trino's Cassandra connector maps `uuid` to `VARCHAR` — the destination table uses `VARCHAR(36)` accordingly.
+- The `tidb` catalog is added automatically by Trino's `update-catalogs.sh` hook because `tidb` is in `RUNNING_KITS` when Trino starts. No manual catalog configuration needed.
+- If `SHOW CATALOGS` doesn't show `tidb`, run `$EDB trino update-catalogs` manually.

--- a/test-plans/trino-full-federation.md
+++ b/test-plans/trino-full-federation.md
@@ -1,0 +1,125 @@
+# Lab Plan: Trino Full Federation — Cassandra + TiDB + OpenSearch
+
+## Objective
+
+Verify Trino federates across all three supported data sources simultaneously:
+Cassandra (via Cassandra connector), TiDB (via MySQL connector), and AWS OpenSearch
+(via OpenSearch connector). Success is Trino returning data from all three catalogs
+in a single session with no manual catalog configuration.
+
+## Cluster Name
+
+trino-full
+
+## Datacenters
+
+single
+
+## Environment
+
+- 3 db nodes: `i4i.xlarge` (Cassandra + TiDB, local NVMe)
+- 1 app node: `i4i.xlarge` (Trino coordinator + worker, local NVMe)
+- AWS OpenSearch: 1 × `t3.small.search`, version 2.11
+
+## Steps
+
+### 1. Provision the cluster with OpenSearch
+
+```bash
+$EDB init trino-full -c 3 -s 1 -i i4i.xlarge -si i4i.xlarge \
+  --opensearch.enable \
+  --opensearch.instance.type t3.small.search \
+  --opensearch.version 2.11 \
+  --up
+```
+
+### 2. Start Cassandra
+
+```bash
+$EDB cassandra use 5.0
+$EDB cassandra start
+```
+
+### 3. Install and start TiDB
+
+```bash
+$EDB kit install tidb
+$EDB tidb start
+```
+
+### 4. Install and start Trino
+
+```bash
+$EDB kit install trino
+$EDB trino start
+```
+
+### 5. Verify all three catalogs are present
+
+```bash
+$EDB trino sql "SHOW CATALOGS;"
+```
+
+Expect: cassandra, tidb, opensearch all present.
+
+### 6. Load data into Cassandra via stress
+
+```bash
+$EDB cassandra stress start -- KeyValue -d 1m --rate 5k
+```
+
+Wait for the job to complete:
+
+```bash
+$EDB cassandra stress status
+```
+
+Verify row count:
+
+```bash
+$EDB cassandra cql "CONSISTENCY LOCAL_ONE; SELECT COUNT(*) FROM cassandra_easy_stress.keyvalue;"
+```
+
+### 7. Create a table and load data into TiDB
+
+```bash
+$EDB tidb sql "CREATE DATABASE IF NOT EXISTS demo;"
+$EDB tidb sql "CREATE TABLE IF NOT EXISTS demo.products (\`id\` INT PRIMARY KEY, \`name\` VARCHAR(100), \`price\` DECIMAL(10,2));"
+$EDB tidb sql "INSERT INTO demo.products VALUES (1, 'Widget', 9.99), (2, 'Gadget', 24.99), (3, 'Doohickey', 4.99);"
+```
+
+### 8. Index data into OpenSearch
+
+Get the OpenSearch endpoint from cluster status, then index documents from the control node:
+
+```bash
+$EDB status
+```
+
+```bash
+OS_ENDPOINT="<endpoint from status>"
+ssh -F sshConfig control0 "curl -s -X POST 'https://${OS_ENDPOINT}/products/_doc' -H 'Content-Type: application/json' -d '{\"id\": 1, \"name\": \"Widget\", \"category\": \"hardware\", \"in_stock\": true}'"
+ssh -F sshConfig control0 "curl -s -X POST 'https://${OS_ENDPOINT}/products/_doc' -H 'Content-Type: application/json' -d '{\"id\": 2, \"name\": \"Gadget\", \"category\": \"electronics\", \"in_stock\": true}'"
+ssh -F sshConfig control0 "curl -s -X POST 'https://${OS_ENDPOINT}/products/_doc' -H 'Content-Type: application/json' -d '{\"id\": 3, \"name\": \"Doohickey\", \"category\": \"hardware\", \"in_stock\": false}'"
+```
+
+### 9. Query all three catalogs via Trino
+
+```bash
+$EDB trino sql "SELECT key, value FROM cassandra.cassandra_easy_stress.keyvalue LIMIT 5;"
+$EDB trino sql "SELECT id, name, price FROM tidb.demo.products;"
+$EDB trino sql "SELECT name, category, in_stock FROM opensearch.default.products;"
+```
+
+### 10. Tear down
+
+```bash
+$EDB down --auto-approve
+```
+
+## Notes
+
+- Cassandra RF=3 on 3 nodes — LOCAL_ONE for COUNT(*) to avoid quorum issues.
+- TiDB and Cassandra share db nodes. Give TiDB up to 10 minutes to start on first boot.
+- The opensearch catalog is wired automatically via __OPENSEARCH_ENDPOINT__ at kit install time.
+- The tidb catalog is wired automatically because tidb is in RUNNING_KITS when trino starts.

--- a/test-plans/trino-metrics-discovery.md
+++ b/test-plans/trino-metrics-discovery.md
@@ -1,0 +1,149 @@
+# Lab Plan: Trino Metrics Discovery
+
+## Goal
+
+Spin up a Trino cluster with a Cassandra backend, run queries to generate execution metrics,
+export the full series catalog, and copy it back to the kit source so we can build a Grafana
+dashboard.
+
+## Environment
+
+- 3 DB nodes: `i4i.large` (2 vCPU / 16 GB / 468 GB local NVMe — runs Cassandra)
+- 1 App node: `m5.xlarge` (4 vCPU / 16 GB — runs Trino coordinator + worker)
+
+## Steps
+
+### 1. Create cluster workspace and provision
+
+```bash
+CLUSTER_DIR="clusters/trino-metrics-$(date +%Y%m%d-%H%M%S)"
+mkdir -p "$CLUSTER_DIR"
+bin/create-easy-db-lab-wrapper "$CLUSTER_DIR"
+EDB="$CLUSTER_DIR/easy-db-lab"
+$EDB init trino-metrics --db 3 --app 1 --instance i4i.large --stress-instance m5.xlarge --up
+```
+
+### 2. Start Cassandra
+
+```bash
+$EDB cassandra use 5.0
+$EDB cassandra update-config cassandra.patch.yaml
+$EDB cassandra start
+```
+
+Verify all nodes are up:
+
+```bash
+$EDB cassandra nt status
+```
+
+All 3 nodes must show `UN`. Retry after 30 seconds if any are down.
+
+### 3. Populate data with stress
+
+```bash
+$EDB cassandra stress start -- KeyValue -d 10m --threads 100
+```
+
+Wait 30 seconds for the keyspace and table to be created before continuing.
+
+### 4. Scaffold and start Trino
+
+```bash
+$EDB kit install trino --workers 1
+$EDB trino start
+```
+
+Because Cassandra is already running, `update-catalogs.sh` will include the Cassandra catalog
+automatically during install. Trino takes 2–3 minutes to become ready.
+
+### 5. Verify Trino can see the Cassandra catalog
+
+```bash
+APP_IP=$($EDB ip --private app0)
+$EDB exec run --type control -- bash -c "
+  RESULT=\$(curl -sf -X POST http://${APP_IP}:8080/v1/statement \
+    -H 'X-Trino-User: test' -H 'Content-Type: text/plain' \
+    -d 'SHOW CATALOGS')
+  while NEXT=\$(echo \"\$RESULT\" | jq -r '.nextUri // empty') && [ -n \"\$NEXT\" ]; do
+    sleep 0.5
+    RESULT=\$(curl -sf -H 'X-Trino-User: test' \"\$NEXT\")
+  done
+  echo \"\$RESULT\" | jq -r '.data[][]'
+"
+```
+
+`cassandra` must appear in the output.
+
+### 6. Run queries to generate execution metrics
+
+```bash
+APP_IP=$($EDB ip --private app0)
+for i in $(seq 1 20); do
+  $EDB exec run --type control -- bash -c "
+    RESULT=\$(curl -sf -X POST http://${APP_IP}:8080/v1/statement \
+      -H 'X-Trino-User: test' -H 'Content-Type: text/plain' \
+      -d 'SELECT count(*) FROM cassandra.baselines.keyvalue')
+    while NEXT=\$(echo \"\$RESULT\" | jq -r '.nextUri // empty') && [ -n \"\$NEXT\" ]; do
+      sleep 0.5
+      RESULT=\$(curl -sf -H 'X-Trino-User: test' \"\$NEXT\")
+    done
+    echo \"\$RESULT\" | jq -r '.data[][]'
+  "
+  echo "Query $i complete"
+done
+```
+
+Running 20 queries ensures query execution, task, and memory metrics are populated.
+
+### 7. Wait for metrics to flow into VictoriaMetrics
+
+```bash
+sleep 60
+```
+
+### 8. Export metrics catalog
+
+Run from the cluster workspace directory:
+
+```bash
+cd "$CLUSTER_DIR"
+../../bin/export-workload-metrics trino
+```
+
+### 9. Verify the catalog
+
+```bash
+cat "$CLUSTER_DIR/trino/metrics-catalog.json" | jq '.series | length'
+```
+
+Should be non-zero. If 0, wait another 60 seconds and retry.
+
+Spot-check for key execution metrics:
+
+```bash
+cat "$CLUSTER_DIR/trino/metrics-catalog.json" \
+  | jq -r '.series[].name' | sort -u | grep -E "query|task|memory|executor|jvm" | head -40
+```
+
+### 10. Copy catalog back to kit source
+
+```bash
+cp "$CLUSTER_DIR/trino/metrics-catalog.json" \
+  src/main/resources/com/rustyrazorblade/easydblab/kits/trino/metrics-catalog.json
+```
+
+### 11. Tear down
+
+```bash
+$EDB down --auto-approve
+```
+
+## After This Plan
+
+Once `metrics-catalog.json` is populated, build the Grafana dashboard:
+- Use `jq -r '.series[].name' | sort -u` to identify available metric names
+- Model after `dashboards/clickhouse.json` for layout
+- Key panels: active queries, queued queries, memory pool usage, GC pause time, CPU
+- Save to `dashboards/trino.json`
+- Register in `GrafanaDashboard` enum

--- a/test-plans/trino-opensearch-federation.md
+++ b/test-plans/trino-opensearch-federation.md
@@ -1,0 +1,130 @@
+# Lab Plan: Trino + OpenSearch Federation Verification
+
+## Objective
+
+Verify that Trino's OpenSearch catalog works end-to-end against an AWS OpenSearch domain
+provisioned by easy-db-lab. The domain uses an open access policy (no SigV4 required).
+Success is Trino returning rows from an OpenSearch index via SQL.
+
+## Cluster Name
+
+trino-opensearch
+
+## Datacenters
+
+single
+
+## Environment
+
+- 1 db node: `i4i.xlarge` (local NVMe, no EBS needed)
+- 1 app node: `i4i.xlarge` (local NVMe, Trino coordinator + worker)
+- AWS OpenSearch: 1 × `t3.small.search`, version 2.11
+
+## Steps
+
+### 1. Provision the cluster with OpenSearch
+
+```bash
+$EDB init trino-opensearch -c 1 -s 1 -i i4i.xlarge -si i4i.xlarge \
+  --opensearch.enable \
+  --opensearch.instance.type t3.small.search \
+  --opensearch.version 2.11 \
+  --up
+```
+
+Note: the cluster nodes come up in ~5 minutes. The OpenSearch domain takes an additional
+15–20 minutes to become active. Proceed to the next step to monitor it.
+
+### 2. Wait for OpenSearch domain to become active
+
+Poll until the domain endpoint appears and status is ACTIVE:
+
+```bash
+$EDB opensearch status
+```
+
+Repeat until the output shows an endpoint hostname. Then verify the endpoint is reachable
+from the control node:
+
+```bash
+OPENSEARCH_HOST=$(ssh -F sshConfig control0 "curl -s http://169.254.169.254/latest/meta-data/hostname" 2>/dev/null; $EDB status 2>&1 | grep -i opensearch | grep -o '[a-z0-9.-]*\.es\.amazonaws\.com' | head -1)
+```
+
+### 3. Install and start Trino
+
+```bash
+$EDB kit install trino
+$EDB trino start
+```
+
+The `update-catalogs.sh` hook fires automatically and wires the `opensearch` catalog
+from the `__OPENSEARCH_ENDPOINT__` template variable populated by cluster state.
+
+### 4. Verify Trino sees the OpenSearch catalog
+
+```bash
+$EDB trino sql "SHOW CATALOGS;"
+```
+
+Confirm `opensearch` appears in the output.
+
+### 5. Index test documents into OpenSearch
+
+Get the OpenSearch endpoint from cluster status, then POST documents via curl from
+the control node (which is inside the VPC):
+
+```bash
+$EDB status
+```
+
+Note the OpenSearch endpoint from the output (e.g. `search-xxx.region.es.amazonaws.com`),
+then index three documents:
+
+```bash
+OS_ENDPOINT="<endpoint from status output>"
+
+ssh -F sshConfig control0 "curl -s -X POST 'https://${OS_ENDPOINT}/test-index/_doc' \
+  -H 'Content-Type: application/json' \
+  -d '{\"name\": \"Alice\", \"score\": 95, \"city\": \"Seattle\"}'"
+
+ssh -F sshConfig control0 "curl -s -X POST 'https://${OS_ENDPOINT}/test-index/_doc' \
+  -H 'Content-Type: application/json' \
+  -d '{\"name\": \"Bob\", \"score\": 87, \"city\": \"Portland\"}'"
+
+ssh -F sshConfig control0 "curl -s -X POST 'https://${OS_ENDPOINT}/test-index/_doc' \
+  -H 'Content-Type: application/json' \
+  -d '{\"name\": \"Carol\", \"score\": 92, \"city\": \"Seattle\"}'"
+```
+
+Verify the index exists:
+
+```bash
+ssh -F sshConfig control0 "curl -s 'https://${OS_ENDPOINT}/test-index/_count'"
+```
+
+### 6. Query OpenSearch via Trino
+
+```bash
+$EDB trino sql "SHOW SCHEMAS IN opensearch;"
+$EDB trino sql "SHOW TABLES IN opensearch.default;"
+$EDB trino sql "SELECT * FROM opensearch.default.\"test-index\" LIMIT 10;"
+$EDB trino sql "SELECT city, COUNT(*) AS cnt FROM opensearch.default.\"test-index\" GROUP BY city;"
+```
+
+Success: Trino returns the three indexed documents and the GROUP BY aggregation
+shows Seattle=2, Portland=1.
+
+### 7. Tear down
+
+```bash
+$EDB down --auto-approve
+```
+
+## Notes
+
+- easy-db-lab provisions OpenSearch with `Principal: "*"` / `Action: "es:*"` and fine-grained
+  access control disabled by default — no SigV4 signing is required.
+- The OpenSearch catalog is wired automatically via `__OPENSEARCH_ENDPOINT__` when Trino starts.
+  If the catalog is missing, run `$EDB trino update-catalogs` manually.
+- Index names with hyphens must be double-quoted in Trino SQL: `"test-index"`.
+- The Trino OpenSearch connector maps each index to a table in the `default` schema.


### PR DESCRIPTION
## Summary

- Adds a Trino kit that deploys the Trino query engine via the trinodb Helm chart (coordinator + worker on app nodes)
- Auto-detects and configures catalogs for all co-running kits: Cassandra, ClickHouse, TiDB (MySQL connector), and OpenSearch infrastructure
- Exposes `__OPENSEARCH_ENDPOINT__` template variable from cluster state so the OpenSearch catalog is populated automatically when an OpenSearch domain is provisioned
- Integrates with the OTel metrics scraping pipeline and ships a Grafana dashboard
- Wires Pyroscope Java agent profiling on the coordinator and worker pods
- Standardizes `--version` flag across all versioned kits (ClickHouse and Trino)
- Ships a README with built-in catalog documentation and a custom catalog guide

Closes #694