### PR TITLE
docs(kits): add user guide pages for sysbench and tidb kits

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -19,6 +19,8 @@
     - [Backup & Restore](user-guide/clickhouse-backup-restore.md)
   - [Presto](user-guide/install-presto.md)
   - [Trino](user-guide/install-trino.md)
+  - [TiDB](user-guide/tidb.md)
+  - [Sysbench](user-guide/sysbench.md)
 - [Monitoring](user-guide/monitoring.md)
   - [Profiling](user-guide/profiling.md)
   - [Metrics](user-guide/victoria-metrics.md)

--- a/docs/user-guide/clickhouse.md
+++ b/docs/user-guide/clickhouse.md
@@ -131,6 +131,13 @@ After deployment, ClickHouse is accessible via:
 | Play UI | `http://<db-node-ip>:8123/play` | Interactive web query interface |
 | HTTP API | `http://<db-node-ip>:8123` | REST API for queries |
 | Native Protocol | `<db-node-ip>:9000` | High-performance binary protocol |
+| MySQL wire | `<db-node-ip>:9004` | MySQL-compatible protocol (`mysql -h <ip> -P 9004 -u default`) |
+| PostgreSQL wire | `<db-node-ip>:9005` | PostgreSQL-compatible protocol (`psql -h <ip> -p 9005 -U default`) |
+
+The MySQL and PostgreSQL interfaces are protocol-compatible, not dialect-compatible:
+queries sent over them are parsed as ClickHouse SQL. They are handy for connecting
+standard clients and drivers, but tools that emit MySQL- or PostgreSQL-specific DDL
+will not work unmodified.
 
 ## Creating Tables
 
@@ -346,6 +353,8 @@ This ensures `clickhouse-X` always runs on `dbX`, providing:
 |------|---------|
 | 8123 | HTTP interface |
 | 9000 | Native protocol |
+| 9004 | MySQL wire protocol |
+| 9005 | PostgreSQL wire protocol |
 | 9009 | Inter-server communication |
 | 9363 | Metrics |
 | 2181 | Keeper client |

--- a/docs/user-guide/kits.md
+++ b/docs/user-guide/kits.md
@@ -4,8 +4,8 @@ A kit is a self-contained package of configuration and scripts that installs, st
 and optionally backs up a workload on your cluster. Each kit defines its full lifecycle in a
 `kit.yaml` file using typed steps — no Kubernetes YAML wrangling required.
 
-easy-db-lab ships with built-in kits (ClickHouse, Presto). You can also create your own kits
-for any workload you want to benchmark or test.
+easy-db-lab ships with built-in kits (ClickHouse, Presto, Trino, TiDB, sysbench). You can
+also create your own kits for any workload you want to benchmark or test.
 
 ## Discovering kits
 
@@ -42,26 +42,30 @@ Bench kits are a special class of kit that run against an already-running databa
 require a `--target` flag pointing at the installed database kit you want to benchmark.
 
 ```bash
-# Install sysbench targeting your running ClickHouse instance
-easy-db-lab kit install sysbench --target clickhouse
+# Install sysbench targeting your running TiDB instance
+easy-db-lab kit install sysbench --target tidb
 
 # Run the prepare, start, and stop lifecycle as usual
-easy-db-lab sysbench-clickhouse prepare
-easy-db-lab sysbench-clickhouse start
-easy-db-lab sysbench-clickhouse stop
+easy-db-lab sysbench-tidb prepare
+easy-db-lab sysbench-tidb start
+easy-db-lab sysbench-tidb stop
 ```
 
-The kit is installed into a directory named `<bench-kit>-<target>` (e.g. `sysbench-clickhouse`).
+The kit is installed into a directory named `<bench-kit>-<target>` (e.g. `sysbench-tidb`).
 This lets you run the same bench kit against multiple databases simultaneously and compare results:
 
 ```bash
-easy-db-lab kit install sysbench --target clickhouse
 easy-db-lab kit install sysbench --target tidb
+easy-db-lab kit install sysbench --target my-custom-db
 
 # Both run at the same time — compare results in Grafana
-easy-db-lab sysbench-clickhouse start
 easy-db-lab sysbench-tidb start
+easy-db-lab sysbench-my-custom-db start
 ```
+
+The target must expose a wire protocol endpoint the bench tool can speak — sysbench
+supports MySQL and PostgreSQL. See [Sysbench](sysbench.md) for the full lifecycle,
+flags, and metrics.
 
 ### TARGET_* environment variables
 

--- a/docs/user-guide/sysbench.md
+++ b/docs/user-guide/sysbench.md
@@ -1,0 +1,118 @@
+# Sysbench
+
+The `sysbench` kit runs [sysbench](https://github.com/akopytov/sysbench) OLTP benchmarks
+against a running database kit. It is a bench kit: it does not deploy a database itself,
+but targets one you've already started, connecting over the MySQL or PostgreSQL wire
+protocol. Benchmark pods run inside the Kubernetes cluster, and per-interval results are
+pushed to VictoriaMetrics so you can watch throughput and latency live in Grafana.
+
+## Prerequisites
+
+- Cluster is up (`easy-db-lab up`)
+- A database kit with the `sql` capability is installed and running (e.g. [TiDB](tidb.md))
+- The target kit exposes a MySQL or PostgreSQL wire protocol endpoint — sysbench connects
+  over the wire protocol, not JDBC
+
+## Quick Start
+
+```bash
+# Start a database to benchmark
+easy-db-lab kit install tidb
+easy-db-lab tidb start
+
+# Install sysbench pointed at it
+easy-db-lab kit install sysbench --target tidb
+
+# Load data, run the benchmark, clean up
+easy-db-lab sysbench-tidb prepare
+easy-db-lab sysbench-tidb start
+easy-db-lab sysbench-tidb stop
+```
+
+The kit installs as `sysbench-<target>` — the instance name and the CLI subcommand both
+include the target, so multiple sysbench instances can run against different databases
+at the same time. See [Bench kits](kits.md#bench-kits--benchmarking-a-database) for how
+cross-kit targeting works.
+
+## Flags
+
+| Flag | Default | Description |
+|---|---|---|
+| `--target` | (required) | Name of the running database kit to benchmark |
+| `--threads` | `4` | Number of concurrent threads |
+| `--duration` | `60` | Benchmark duration in seconds |
+| `--workload` | `oltp_read_write` | sysbench built-in workload (`oltp_read_write`, `oltp_read_only`, `oltp_write_only`) |
+| `--scale` | `10` | Number of rows per table, in thousands |
+| `--tables` | `10` | Number of tables |
+
+Flags other than `--target` are baked in at install time and apply to every subsequent
+`prepare`/`start`/`stop`. To change them, reinstall the kit.
+
+## Lifecycle
+
+### prepare
+
+```bash
+easy-db-lab sysbench-tidb prepare
+```
+
+Creates the `sbtest` database on the target if it doesn't exist, then loads the test
+tables (`--tables` tables with `--scale` thousand rows each). Run this once before the
+first benchmark run.
+
+### start
+
+```bash
+easy-db-lab sysbench-tidb start
+```
+
+Runs the benchmark for `--duration` seconds, streaming sysbench's interval output to
+your terminal. Each 10-second interval report (TPS, QPS, p99 latency, errors/s) is also
+pushed to VictoriaMetrics.
+
+### stop
+
+```bash
+easy-db-lab sysbench-tidb stop
+```
+
+Kills any running benchmark pod and runs sysbench cleanup, dropping the test tables from
+the target database.
+
+## Comparing Databases
+
+Because each install is a separate named instance, you can benchmark several databases
+simultaneously and compare them side by side in Grafana:
+
+```bash
+easy-db-lab kit install sysbench --target tidb
+easy-db-lab kit install sysbench --target my-custom-db
+
+easy-db-lab sysbench-tidb prepare && easy-db-lab sysbench-tidb start
+easy-db-lab sysbench-my-custom-db prepare && easy-db-lab sysbench-my-custom-db start
+```
+
+Of the built-in kits, TiDB and ClickHouse expose MySQL and PostgreSQL wire endpoints.
+Any [custom kit](kits.md#installing-a-custom-kit) that declares a `mysql` or
+`postgresql` endpoint and the `sql` capability in its `kit.yaml` can be targeted the
+same way.
+
+Note that ClickHouse's wire interfaces parse queries as ClickHouse SQL, and sysbench's
+built-in `oltp_*` workloads issue MySQL-specific DDL during `prepare` — running them
+against ClickHouse unmodified will fail at table creation. Benchmarking ClickHouse with
+sysbench requires a custom Lua workload with ClickHouse-compatible schemas.
+
+## Metrics & Dashboard
+
+The kit ships a **Sysbench Benchmark** Grafana dashboard, installed automatically. During
+a run, these metrics are pushed to VictoriaMetrics, labelled by instance (`kit`):
+
+| Metric | Description |
+|--------|-------------|
+| `sysbench_tps` | Transactions per second |
+| `sysbench_qps` | Queries per second |
+| `sysbench_lat_p99_ms` | 99th percentile latency (ms) |
+| `sysbench_errors_per_second` | Errors per second |
+
+The `kit` label carries the instance name (e.g. `sysbench-tidb`), so runs against
+different targets plot as separate series on the same panel.

--- a/docs/user-guide/tidb.md
+++ b/docs/user-guide/tidb.md
@@ -1,0 +1,107 @@
+# TiDB
+
+The `tidb` kit deploys a [TiDB](https://www.pingcap.com/tidb/) HTAP cluster using the
+TiDB Operator. TiDB combines a MySQL-compatible SQL layer with two storage engines:
+TiKV (row store, for OLTP) and TiFlash (columnar store, for analytics) — letting you run
+transactional and analytical queries against the same data.
+
+## Prerequisites
+
+- Cluster is up (`easy-db-lab up`)
+- At least 1 db node (runs TiKV and TiFlash)
+- At least 1 app node (runs TiDB and PD)
+
+## Quick Start
+
+```bash
+easy-db-lab kit install tidb
+easy-db-lab tidb start
+easy-db-lab tidb sql "SELECT tidb_version()"
+```
+
+`tidb start` deploys the TiDB Operator-managed cluster and waits for each component
+(PD, TiKV, TiDB, TiFlash) to become Ready. TiFlash takes the longest — expect a few
+minutes on first start while images pull.
+
+## Flags
+
+| Flag | Default | Description |
+|---|---|---|
+| `--version` | `v8.5.2` | TiDB version to deploy |
+| `--replicas` | db node count | Number of TiKV and TiFlash replicas (one per db node) |
+
+## Cluster Layout
+
+| Component | Node type | Replicas | Role |
+|-----------|-----------|----------|------|
+| PD | app | 1 | Placement driver / metadata |
+| TiDB | app | one per app node | MySQL-compatible SQL layer |
+| TiKV | db | `--replicas` | Row store (Raft) |
+| TiFlash | db | `--replicas` | Columnar store (HTAP) |
+
+## Connecting
+
+TiDB speaks the MySQL wire protocol, exposed as NodePort 30400 on every cluster node:
+
+```bash
+mysql -h <node-ip> -P 30400 -u root
+```
+
+Or use the built-in SQL command, which resolves the endpoint for you:
+
+```bash
+easy-db-lab tidb sql "SHOW DATABASES"
+```
+
+## Using TiFlash
+
+Tables are not automatically replicated to TiFlash. Enable replication per table:
+
+```sql
+ALTER TABLE my_table SET TIFLASH REPLICA 1;
+```
+
+Once the replica is in place, TiDB's optimizer routes analytical queries to TiFlash
+automatically. To force it for a specific query:
+
+```sql
+SELECT /*+ read_from_storage(tiflash[my_table]) */ count(*) FROM my_table;
+```
+
+## Lifecycle
+
+```bash
+easy-db-lab tidb start       # deploy the TiDB cluster
+easy-db-lab tidb status      # show running state and endpoints
+easy-db-lab tidb stop        # tear down the TiDB cluster
+easy-db-lab tidb uninstall   # remove the TiDB Operator (requires stop first)
+```
+
+`uninstall` refuses to run while the TiDB cluster is still up — run `tidb stop` first.
+
+## Monitoring
+
+The kit registers four Prometheus scrape jobs with the cluster's observability stack
+automatically — no configuration needed:
+
+| Job label | Component | What it covers |
+|-----------|-----------|----------------|
+| `tidb-sql` | TiDB | Connections, query throughput, plan cache, errors |
+| `pd` | PD | Cluster health, TSO, region scheduling |
+| `tikv` | TiKV | Raft, RocksDB storage, coprocessor |
+| `tiflash` | TiFlash | MPP tasks, data exchange, storage throughput |
+
+Metrics are available in Grafana and VictoriaMetrics as soon as the kit starts.
+
+TiDB also exports traces to Tempo (via the OTel Collector's Jaeger receiver, since TiDB
+v8.x has no native OTLP support). Search for them in Grafana with `service.name=TiDB` —
+the tag is case-sensitive.
+
+## Benchmarking
+
+TiDB declares the `sql` capability, so bench kits can target it directly. See
+[Sysbench](sysbench.md):
+
+```bash
+easy-db-lab kit install sysbench --target tidb
+```

--- a/src/main/resources/com/rustyrazorblade/easydblab/kits/clickhouse/clickhouseinstallation.yaml.template
+++ b/src/main/resources/com/rustyrazorblade/easydblab/kits/clickhouse/clickhouseinstallation.yaml.template
@@ -36,6 +36,13 @@ spec:
             <allowed_disk>s3_backup</allowed_disk>
           </backups>
         </clickhouse>
+      # Enable explicitly rather than relying on the image's default config — the
+      # Altinity operator's generated config does not guarantee these listeners.
+      config.d/wire-protocols.xml: |
+        <clickhouse>
+          <mysql_port>9004</mysql_port>
+          <postgresql_port>9005</postgresql_port>
+        </clickhouse>
       config.d/prometheus.xml: |
         <clickhouse>
           <prometheus>

--- a/src/main/resources/com/rustyrazorblade/easydblab/kits/clickhouse/kit.yaml
+++ b/src/main/resources/com/rustyrazorblade/easydblab/kits/clickhouse/kit.yaml
@@ -27,6 +27,16 @@ endpoints:
     scheme: clickhouse
     path: /default?compress=0
     database: "default"
+  - name: "MySQL wire"
+    node-type: db
+    port: 30904
+    type: mysql
+    database: "default"
+  - name: "PostgreSQL wire"
+    node-type: db
+    port: 30905
+    type: postgresql
+    database: "default"
 args:
   - flag: --version
     variable: VERSION

--- a/src/main/resources/com/rustyrazorblade/easydblab/kits/clickhouse/nodeport-service.yaml.template
+++ b/src/main/resources/com/rustyrazorblade/easydblab/kits/clickhouse/nodeport-service.yaml.template
@@ -20,3 +20,11 @@ spec:
       port: 9363
       targetPort: 9363
       nodePort: 30936
+    - name: mysql
+      port: 9004
+      targetPort: 9004
+      nodePort: 30904
+    - name: postgresql
+      port: 9005
+      targetPort: 9005
+      nodePort: 30905

--- a/src/main/resources/com/rustyrazorblade/easydblab/kits/sysbench/kit.yaml
+++ b/src/main/resources/com/rustyrazorblade/easydblab/kits/sysbench/kit.yaml
@@ -9,7 +9,7 @@ args:
     variable: TARGET
     type: kit-ref
     capability: sql
-    description: "Name of the running database kit to benchmark (e.g. clickhouse, tidb)"
+    description: "Name of the running database kit to benchmark (e.g. tidb); must expose a MySQL or PostgreSQL wire endpoint"
     required: true
   - flag: --threads
     variable: THREADS


### PR DESCRIPTION
Closes #699

The sysbench (#688) and TiDB kits were merged without user-facing documentation. This adds dedicated mdbook pages for both, fixes misleading examples in the existing kits guide, and exposes ClickHouse's wire protocol endpoints.

## What's included

- **`docs/user-guide/tidb.md`** — new page covering prerequisites (≥1 db + ≥1 app node), install flags, cluster layout (PD/TiDB on app nodes, TiKV/TiFlash on db nodes), connecting via MySQL wire on NodePort 30400 and `tidb sql`, enabling TiFlash replicas per table, lifecycle commands, the four auto-registered Prometheus scrape jobs, and the Jaeger→Tempo trace bridge (`service.name=TiDB`).
- **`docs/user-guide/sysbench.md`** — new page covering the bench-kit model (`--target`, `sysbench-<target>` instance naming), all install flags, the `prepare`/`start`/`stop` lifecycle (including that `stop` drops the test tables), running multiple instances side by side, and the metrics pushed to VictoriaMetrics plus the bundled Sysbench Benchmark dashboard.
- **`docs/SUMMARY.md`** — both pages registered under the Kits section.
- **`docs/user-guide/kits.md`** — built-in kits list updated (was "ClickHouse, Presto"); bench-kit section now links to the sysbench page.

## Example fix

The existing bench-kit examples used `--target clickhouse`, but at the time the ClickHouse kit declared no MySQL/PostgreSQL wire endpoint — so that example installed fine but failed at `prepare`. Examples now use TiDB, the wire-endpoint requirement is documented, and the `--target` help text in `sysbench/kit.yaml` was corrected to match.

## ClickHouse wire protocol endpoints

The clickhouse-as-target oversight is also fixed here: the ClickHouse kit now enables the MySQL (9004) and PostgreSQL (9005) listeners explicitly via `config.d/wire-protocols.xml`, maps them through NodePort (30904/30905), and declares `mysql`/`postgresql` endpoints in `kit.yaml`, so bench kits targeting clickhouse receive `TARGET_MYSQL_*` and `TARGET_PG_*` variables.

Caveat (documented in both kit pages): ClickHouse's wire interfaces are protocol-compatible, not dialect-compatible — queries are parsed as ClickHouse SQL. sysbench's stock `oltp_*` workloads emit MySQL DDL that ClickHouse rejects at `prepare`, so benchmarking ClickHouse with sysbench still requires a custom Lua workload with ClickHouse-compatible schemas.