### PR TITLE
feat(aws): AWS SSO support + reliable, cached AMI builds

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -13,7 +13,7 @@
 ### AWS Requirements
 
 - **AWS Account**: A dedicated AWS account is recommended for lab environments
-- **AWS Access Key & Secret**: Credentials for programmatic access
+- **AWS Credentials**: Either static access key & secret, or a named profile — including an [AWS SSO (IAM Identity Center)](setup.md#using-aws-sso-iam-identity-center) profile
 - **IAM Permissions**: Permissions to create EC2, IAM, S3, and optionally EMR resources
 
 ```admonish tip

--- a/docs/getting-started/setup.md
+++ b/docs/getting-started/setup.md
@@ -39,11 +39,17 @@ The setup wizard will prompt you for:
 |--------|-------------|---------|
 | Email | Used to tag AWS resources for ownership | (required) |
 | AWS Region | Region for your clusters | us-west-2 |
-| AWS Access Key | Your AWS access key ID | (required) |
-| AWS Secret Key | Your AWS secret access key | (required) |
+| AWS Profile name | Named AWS profile to authenticate with — press Enter to enter credentials manually instead | (manual) |
+| AWS Access Key | Your AWS access key ID (only asked if no profile name was given) | (required) |
+| AWS Secret Key | Your AWS secret access key (only asked if no profile name was given) | (required) |
 | AxonOps Org | Optional: AxonOps organization name | (skip) |
 | AxonOps Key | Optional: AxonOps API key | (skip) |
-| AWS Profile | Optional: Named AWS profile | (skip) |
+
+```admonish note
+The AWS profile name is asked **first**. If you provide one, the access key and secret prompts are skipped — easy-db-lab resolves credentials through that profile (including [AWS SSO](#using-aws-sso-iam-identity-center) profiles). Static access keys are only collected when you leave the profile name blank.
+```
+
+setup-profile validates your credentials against AWS immediately (and then provisions resources), so your credentials must be usable **before** you run it. For static keys this is automatic; for an SSO profile, run `aws sso login` first (see below).
 
 ### What Gets Created
 
@@ -64,6 +70,65 @@ Your profile is saved to:
 
 ```admonish tip
 Use a different profile by setting `EASY_DB_LAB_PROFILE` environment variable before running setup.
+```
+
+### Using AWS SSO (IAM Identity Center)
+
+If your AWS access is provisioned through AWS SSO (IAM Identity Center) rather than long-lived access keys, easy-db-lab authenticates through a named AWS profile backed by an SSO session. You do **not** copy temporary credentials out of the AWS access portal — the tool resolves them automatically from your SSO login.
+
+```admonish warning
+The AWS access portal's "Command line or programmatic access" panel gives you a temporary access key, secret, **and session token**. Do not use these with easy-db-lab. The static-credential path has no field for a session token, so those credentials will not work. Use the SSO profile flow below instead.
+```
+
+**1. Define an SSO profile** in `~/.aws/config`:
+
+```ini
+[sso-session my-sso]
+sso_start_url = https://my-company.awsapps.com/start
+sso_region = us-east-1
+sso_registration_scopes = sso:account:access
+
+[profile edl]
+sso_session = my-sso
+sso_account_id = 123456789012
+sso_role_name = YourRoleName
+region = us-west-2
+```
+
+**2. Log in** to start an SSO session (this opens a browser):
+
+```bash
+aws sso login --profile edl
+```
+
+**3. Run setup-profile** and enter `edl` when prompted for the AWS profile name (leave the access key and secret blank):
+
+```bash
+easy-db-lab setup-profile
+```
+
+```admonish important
+Run `aws sso login` **before** `setup-profile`. setup-profile validates and provisions against AWS immediately, so it needs an active SSO session. This first-time `aws sso login` → `setup-profile` sequence is only needed once.
+```
+
+#### Day-to-day usage
+
+After the one-time setup, you do **not** sign in for every command. An `aws sso login` session lasts for hours (your organization sets the exact window), and easy-db-lab resolves and refreshes credentials from it automatically:
+
+```bash
+# Once per work session (e.g. each morning), or whenever the session expires:
+aws sso login --profile edl
+
+# Then run commands freely — no per-command authentication:
+easy-db-lab up
+easy-db-lab cassandra start
+easy-db-lab down --auto-approve
+```
+
+When the session expires, the next command fails with an authentication error directing you to log in again. Re-run `aws sso login --profile edl` and continue.
+
+```admonish note
+For operations that run longer than your SSO session window (e.g. an unattended overnight benchmark), the session can expire mid-run and a later AWS call may fail. For interactive, command-by-command use this does not come up.
 ```
 
 ## Step 2: Getting IAM Policies

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -142,6 +142,8 @@ awssdk-sts = { module = "software.amazon.awssdk:sts", version.ref = "awssdk" }
 awssdk-opensearch = { module = "software.amazon.awssdk:opensearch", version.ref = "awssdk" }
 awssdk-regions = { module = "software.amazon.awssdk:regions", version.ref = "awssdk" }
 awssdk-ecr = { module = "software.amazon.awssdk:ecr", version.ref = "awssdk" }
+awssdk-sso = { module = "software.amazon.awssdk:sso", version.ref = "awssdk" }
+awssdk-ssooidc = { module = "software.amazon.awssdk:ssooidc", version.ref = "awssdk" }
 
 # Docker
 docker-java = { module = "com.github.docker-java:docker-java", version.ref = "docker-java" }
@@ -213,7 +215,7 @@ koin = ["koin-core"]
 koin-test = ["koin-test", "koin-test-junit5"]
 
 # AWS SDK bundle
-awssdk = ["awssdk-ec2", "awssdk-iam", "awssdk-emr", "awssdk-s3", "awssdk-sts", "awssdk-opensearch", "awssdk-ecr"]
+awssdk = ["awssdk-ec2", "awssdk-iam", "awssdk-emr", "awssdk-s3", "awssdk-sts", "awssdk-opensearch", "awssdk-ecr", "awssdk-sso", "awssdk-ssooidc"]
 
 # Docker bundle
 docker = ["docker-java", "docker-java-transport-httpclient5"]

--- a/openspec/changes/add-aws-sso-support/.openspec.yaml
+++ b/openspec/changes/add-aws-sso-support/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-16

--- a/openspec/changes/add-aws-sso-support/design.md
+++ b/openspec/changes/add-aws-sso-support/design.md
@@ -1,0 +1,42 @@
+## Context
+
+easy-db-lab authenticates to AWS using AWS SDK v2. The credential provider is constructed in `providers/aws/AWSModule.kt:73-84`:
+
+- If `User.awsProfile` is non-empty → `ProfileCredentialsProvider.create(profile)`
+- Otherwise → `StaticCredentialsProvider` from `awsAccessKey` / `awsSecret`
+
+`ProfileCredentialsProvider` in SDK v2 is fully capable of resolving an SSO-backed profile (`sso_session` / `sso_start_url` in `~/.aws/config`, with a token cached by `aws sso login`). The only thing missing is the runtime machinery: the `sso` and `ssooidc` SDK modules. The `awssdk` bundle in `gradle/libs.versions.toml` currently lists only ec2, iam, emr, s3, sts, opensearch, and ecr. Without `sso`/`ssooidc` on the classpath, resolving an SSO profile throws a hard error at runtime (the SDK reports the `sso` module must be on the class path); it does not fall back.
+
+The fix is therefore a dependency/classpath change, not a credential-logic change.
+
+## Goals / Non-Goals
+
+**Goals:**
+- An AWS profile backed by an SSO session resolves credentials successfully through the existing profile path.
+- No change to credential-selection logic in `AWSModule.kt`.
+- Document the SSO setup flow for users.
+
+**Non-Goals:**
+- Migrating to `DefaultCredentialsProvider` or adding env-var / instance-profile credential chains for the CLI itself.
+- Orchestrating `aws sso login` from inside the tool — users establish the SSO session externally.
+- Any change to how credentials are delivered to provisioned EC2 nodes (instance profiles are unaffected).
+
+## Decisions
+
+**Decision: Add `awssdk-sso` and `awssdk-ssooidc` to the `awssdk` bundle.**
+Both modules share the existing `awssdk` version ref (2.42.33), so no version pinning is introduced. Adding them to the bundle means every consumer of the bundle (the root module) gets them on the runtime classpath, which is exactly where SSO resolution needs them.
+- *Alternative considered: add only `sso`.* Rejected — SSO token resolution requires `ssooidc` for the OIDC token exchange; `sso` alone is insufficient and would still fail.
+- *Alternative considered: switch to `DefaultCredentialsProvider`.* Rejected as out of scope — it broadens behavior (env vars, IMDS) beyond what was requested and changes the explicit, predictable credential selection the tool relies on. The existing `ProfileCredentialsProvider` path already handles SSO once the modules are present.
+
+**Decision: No code change to credential selection.**
+The profile branch already routes SSO profiles correctly. Keeping logic untouched minimizes risk and keeps the change to a dependency edit plus docs.
+
+## Risks / Trade-offs
+
+- **Risk: larger dependency footprint / transitive conflicts.** → Both modules are first-party AWS SDK v2 artifacts on the same version as the rest of the bundle; conflict risk is minimal. `./gradlew build` and the existing test suite verify the classpath resolves.
+- **Risk: SSO token expiry produces confusing runtime errors mid-run.** → Out of scope to auto-refresh; documented in setup docs that users must have an active `aws sso login` session. The SDK error message names the remedy.
+- **Trade-off: no automated test can fully exercise live SSO** (requires a real IdP + browser login). → Coverage is limited to verifying the modules are present/resolvable and that the profile path is selected; the SSO round-trip is validated manually.
+
+## Migration Plan
+
+Not applicable — clusters are ephemeral and there is no persisted state tied to credentials. The change is additive (new classpath entries); rollback is reverting the `libs.versions.toml` edit.

--- a/openspec/changes/add-aws-sso-support/proposal.md
+++ b/openspec/changes/add-aws-sso-support/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+Users whose AWS access is provisioned through AWS SSO (IAM Identity Center) cannot use easy-db-lab today. When a named profile backed by an SSO session (`sso_session` / `sso_start_url`) is configured, credential resolution fails at runtime because the AWS SDK v2 `sso` and `ssooidc` modules are not on the classpath. SSO is increasingly the only credential mechanism available in managed AWS organizations, so the tool is unusable for those users without out-of-band workarounds to obtain static keys.
+
+## What Changes
+
+- Add the AWS SDK v2 `sso` and `ssooidc` modules as dependencies and include them in the `awssdk` bundle so `ProfileCredentialsProvider` can resolve SSO sessions from the local token cache.
+- No change to credential-selection logic for runtime AWS SDK clients: the existing profile path in `AWSModule.kt` already routes a configured profile name through `ProfileCredentialsProvider`. With the modules present, SSO profiles flow through unchanged.
+- **Fix AMI building under SSO.** AMI builds shell out to Packer in a Docker container, which resolves AWS credentials independently of the JVM SDK. Today `AWSCredentialsManager` writes a static-key-only credentials file (`aws_access_key_id` / `aws_secret_access_key`) that is blank under SSO. Change it to resolve credentials through the SDK `AwsCredentialsProvider` (which now handles SSO) and write the resolved `aws_access_key_id`, `aws_secret_access_key`, and — when present — `aws_session_token`, so Packer authenticates with the same credentials as the rest of the tool.
+- Document the SSO setup flow (configure an SSO profile, run `aws sso login --profile <name>`, set that profile name in `setup-profile`) in the getting-started docs.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `setup`: adds a requirement that a configured AWS profile backed by an SSO session resolves credentials successfully, not only profiles holding static keys.
+
+## Impact
+
+- **Dependencies**: `gradle/libs.versions.toml` — two new library entries (`awssdk-sso`, `awssdk-ssooidc`) added to the `awssdk` bundle. These pull additional AWS SDK v2 artifacts onto the runtime classpath.
+- **Code**: No change to `providers/aws/AWSModule.kt` credential logic. The classpath addition alone enables SSO resolution via the existing `ProfileCredentialsProvider` path for runtime SDK clients. `providers/aws/AWSCredentialsManager.kt` is changed to resolve credentials through the SDK provider (instead of reading static keys off `User`) and emit a session token when one is present; `containers/Packer.kt` passes the provider into it.
+- **Docs**: `docs/getting-started/setup.md` gains an AWS SSO section.
+- **Out of scope**: No support for env-var/instance-profile credential chains, no `DefaultCredentialsProvider` migration, no `aws sso login` orchestration from within the tool — users authenticate their SSO session externally.

--- a/openspec/changes/add-aws-sso-support/specs/setup/spec.md
+++ b/openspec/changes/add-aws-sso-support/specs/setup/spec.md
@@ -1,0 +1,49 @@
+## ADDED Requirements
+
+### Requirement: AWS SSO credential resolution
+
+When a user profile is configured with the name of an AWS profile backed by an SSO session (IAM Identity Center), the system MUST resolve AWS credentials through that profile. The system MUST NOT require static access keys when a valid SSO-backed profile is configured and an active SSO login exists.
+
+#### Scenario: SSO-backed profile resolves credentials
+- **WHEN** a user configures their profile with the name of an AWS profile backed by an SSO session and has an active SSO login
+- **THEN** AWS operations authenticate using the SSO-derived credentials without requiring static access keys
+
+#### Scenario: SSO session not logged in
+- **WHEN** a user configures an SSO-backed profile but has no active SSO login (no cached token)
+- **THEN** the tool surfaces the AWS SDK authentication error directing the user to log in (e.g. `aws sso login --profile <name>`)
+
+### Requirement: AMI building uses resolved credentials
+
+AMI building (which runs Packer in a container with its own credential resolution) MUST authenticate using credentials resolved through the same AWS credential provider as the rest of the tool, not static access keys read directly from saved configuration. When the resolved credentials are temporary (carry a session token), the credentials supplied to the Packer container MUST include that session token.
+
+#### Scenario: Build under SSO supplies session token
+- **WHEN** AMI building runs while the active profile resolves to temporary SSO credentials
+- **THEN** the credentials file provided to Packer contains the access key, secret, and session token, allowing the build to authenticate
+
+#### Scenario: Build under static keys omits session token
+- **WHEN** AMI building runs while the active profile resolves to long-lived static credentials
+- **THEN** the credentials file provided to Packer contains the access key and secret with no session token line
+
+### Requirement: Setup tolerates IAM propagation delay
+
+Applying the S3 bucket policy (whose principals are the just-created IAM roles) MUST be resilient to IAM eventual consistency. When S3 rejects the policy because a role is not yet visible ("Invalid principal in policy"), the operation MUST retry with backoff rather than failing immediately. Permission errors (403) MUST NOT be retried. If the operation ultimately fails for the propagation reason, the surfaced error MUST explain the cause and direct the user to re-run setup, not expose a raw SDK exception.
+
+#### Scenario: Transient invalid-principal error is retried
+- **WHEN** the S3 bucket policy is applied while the referenced IAM role has not yet propagated
+- **THEN** the application retries with backoff and succeeds once the role becomes visible
+
+#### Scenario: Permission error is not retried
+- **WHEN** applying the S3 bucket policy fails with a 403 permission error
+- **THEN** the operation fails immediately without retrying
+
+#### Scenario: Persistent propagation failure gives clear guidance
+- **WHEN** the bucket policy still cannot be applied after retries because the role is not visible
+- **THEN** the user sees a message explaining the IAM propagation delay and advising a re-run, not a raw S3 exception
+
+### Requirement: Packer SSH access is scoped to the developer's IP
+
+The Packer AMI-build security group MUST allow SSH only from the developer's own public IP (a `/32`), not from `0.0.0.0/0`. This matches the cluster path and avoids managed-account governance tools (which revoke world-open SSH rules) stripping the rule out from under a build. The developer's public IP MUST be resolved through a single shared service used by both the cluster and Packer paths.
+
+#### Scenario: Packer security group restricts SSH to the developer IP
+- **WHEN** AMI-build infrastructure is created or ensured
+- **THEN** the security group's SSH ingress rule allows only the developer's public IP `/32`, not `0.0.0.0/0`

--- a/openspec/changes/add-aws-sso-support/tasks.md
+++ b/openspec/changes/add-aws-sso-support/tasks.md
@@ -1,0 +1,77 @@
+## 1. Dependencies
+
+- [x] 1.1 Add `awssdk-sso = { module = "software.amazon.awssdk:sso", version.ref = "awssdk" }` to the `[libraries]` section of `gradle/libs.versions.toml` (alongside the other `awssdk-*` entries).
+- [x] 1.2 Add `awssdk-ssooidc = { module = "software.amazon.awssdk:ssooidc", version.ref = "awssdk" }` to the same section.
+- [x] 1.3 Append `"awssdk-sso"` and `"awssdk-ssooidc"` to the `awssdk` bundle list in `[bundles]`.
+
+## 2. Packer / AMI build credential resolution
+
+- [x] 2a.1 Change `providers/aws/AWSCredentialsManager.kt` to resolve credentials via the injected `AwsCredentialsProvider` and write the resolved access key, secret, and (when the credentials are `AwsSessionCredentials`) a `aws_session_token` line. Always (re)write the file so expired/temporary credentials are refreshed each build.
+- [x] 2a.2 Update `containers/Packer.kt` to inject `AwsCredentialsProvider` and pass it into `AWSCredentialsManager` (dropped the now-unused `User` injection).
+- [x] 2a.3 Add a unit test verifying the written credentials file includes `aws_session_token` for session credentials and omits it for basic credentials (use real `StaticCredentialsProvider` with `AwsSessionCredentials` / `AwsBasicCredentials`; no mock-echo). — Both cases pass.
+- [x] 2a.4 Run `./gradlew ktlintFormat` then `ktlintCheck`/`detekt` on the changed Kotlin. — Clean, no regressions in the changed files.
+
+## 2b. Setup robustness (bugs surfaced during SSO setup)
+
+- [x] 2b.1 Add `RetryUtil.createS3BucketPolicyRetryConfig()` + `withS3BucketPolicyRetry()` that retry on the S3 "Invalid principal"/`MalformedPolicy` error and 5xx, but not on 403.
+- [x] 2b.2 Wrap `AWS.putS3BucketPolicy`'s `putBucketPolicy` call in the retry, and replace the raw `S3Exception` on terminal propagation failure with a clear message advising a re-run.
+- [x] 2b.3 Add `RetryUtilTest` verifying the predicate retries the invalid-principal case and does not retry 403.
+- [x] 2b.4 Reword the setup IAM-policy prompt so it explains when it is useful (requesting access from an admin) and notes `show-iam-policies` is available anytime.
+
+## 2c. Packer SSH scoped to developer IP (CloudCustodian revokes 0.0.0.0/0)
+
+- [x] 2c.1 Add a shared `ExternalIpService` (ipify) interface + default impl; register in `ServicesModule`; add a network-free fake to `TestModules`.
+- [x] 2c.2 Change `InfrastructureConfig.forPacker` to take an `sshCidr` instead of hardcoding `0.0.0.0/0`.
+- [x] 2c.3 Thread the CIDR through `AwsInfrastructureService.ensurePackerInfrastructure(sshPort, sshCidr)` and its callers (`BuildBaseImage`, `BuildCassandraImage`, `SetupProfile.ensurePackerVpc`), passing the developer's `/32`.
+- [x] 2c.4 Refactor `Up` to resolve its external IP via the shared `ExternalIpService` (remove its private duplicate).
+- [x] 2c.5 Update `InfrastructureConfigTest` (forPacker takes a CIDR) and `SetupProfileTest` (verify the two-arg call). Compile + targeted tests + ktlint/detekt clean.
+
+## 2d. AMI build resilience and S3 caching (base + cassandra)
+
+- [x] 2d.1 Bump the base image root volume 16→40 GiB (4 JDKs + their -dbg symbols overflow 16 GiB) and bump cassandra image 16→40 GiB (base + multiple staged C* versions).
+- [x] 2d.2 Give both Packer build instances `iam_instance_profile = EasyDBLabEC2Role` (bucket policy already grants it s3:*), and pass `-var s3_bucket=<User.s3Bucket>` from `Packer.kt`; declare the `s3_bucket` variable in both HCLs.
+- [x] 2d.3 Add a shared cache library (`edl-cache-lib.sh`) providing `cached_fetch` + apt-archive restore/save; restore the apt cache early (after AWS CLI) and save it at the end of the base build. Cassandra reuses the lib baked into the base AMI and restores/saves via inline steps.
+- [x] 2d.4 Route the large/pinned direct downloads through `cached_fetch` (S3 download cache, version-keyed): base — async-profiler, k3s binary + airgap images, k9s, cilium CLI, OTel agent; cassandra — versioned C* dist tarballs, MAAC, pyroscope. Each falls back to a direct download when the cache lib/bucket is absent (keeps the local packer Docker tests working). Floating "latest"/nightly artifacts (cassandra-easy-stress, C* nightly/trunk) intentionally left uncached.
+- [x] 2d.5 Replace the inline OpenJDK apt block with `install_jdks.sh` (served from the restored apt cache). Syntax-check all scripts; `:compileKotlin` clean.
+- [x] 2d.6 Build AMI instances with the user's own AWS keypair (mount `secret.pem`, pass `ssh_keypair_name`/`ssh_private_key_file`) so a kept instance is SSH-able with their key.
+- [x] 2d.7 Add `build-image --keep-on-error` (packer `-on-error=abort`) to leave a failed instance running, and print debug guidance on failure (how to SSH in if kept, or to use `--keep-on-error` if not).
+
+## 2. Verification
+
+- [x] 2.1 Run `./gradlew dependencies --configuration runtimeClasspath` (or `./gradlew build`) and confirm `software.amazon.awssdk:sso` and `software.amazon.awssdk:ssooidc` resolve onto the runtime classpath with no version conflicts. — Verified: both resolve to 2.42.33, no conflicts.
+- [x] 2.2 Confirm the existing test suite still passes (`./gradlew check`), since no credential code changed. — Root project check (compile + test + ktlint + detekt) passed. `:spark:bulk-writer-*` modules skipped due to the local cassandra-analytics/JDK 17 precondition (unrelated to this change; those modules don't consume the awssdk bundle).
+- [ ] 2.3 Manual SSO smoke test: configure an SSO-backed profile, run `aws sso login --profile <name>`, set that profile name via `setup-profile`, and confirm an AWS-touching command (e.g. listing key pairs / `up`) authenticates without static keys. Record the result in the change. — **Left for the user** (requires a real IdP browser login).
+
+## 3. Documentation
+
+- [x] 3.1 Add an "AWS SSO (IAM Identity Center)" section to `docs/getting-started/setup.md` describing: configuring an SSO profile in `~/.aws/config`, running `aws sso login --profile <name>`, entering that profile name during `setup-profile`, and that an active SSO session is required before running commands. Also corrected the prompt-order table (profile asked first; keys only if blank).
+- [x] 3.2 Verify no other setup docs (e.g. credential prerequisites) contradict the new SSO flow; update cross-references if needed. — Updated `installation.md` AWS Requirements to list profile/SSO as a credential option; `commands.md` is generic and fine.
+
+## Build resilience & optimization (implemented + verified in this change)
+
+- [x] F.1 Capture-then-teardown for failed AMI builds: instead of relying on the manual
+  `--keep-on-error` flag / `EASY_DB_LAB_BUILD_KEEP_ON_FAILURE` env var, default packer to
+  `-on-error=abort` and have easy-db-lab itself, on build failure, SSH into the kept instance,
+  pull the relevant diagnostic logs (`/tmp/jdk-install.log`, `/var/log/apt/term.log`, `dmesg`,
+  `df -h`), surface them to the user, and then terminate the instance. This gives the user
+  insight into every failure automatically and guarantees cleanup, removing the manual flag.
+- [x] F.2 Quiet provisioner output across **every** packer step (base + cassandra), not just the
+  JDK step. Heavy SSH output flood is what disrupts packer's connection and produces the spurious
+  123; quieting the JDK step fixed it there, so make it the standard everywhere. Concretely:
+  redirect each script's verbose output (apt, `tar` — drop `v`, downloads, builds, `ant`, etc.)
+  to a per-step log file on the instance, print only brief progress lines to stdout, and surface
+  the log tail on failure (via an `ERR` trap). Known-noisy steps to cover first: `install_cassandra.sh`
+  (`tar zxvf` of multiple C* dists + ant builds), `install_bcc.sh`, `install_python.sh`, and the
+  base inline blocks. Prefer a shared helper (e.g. a `run_quiet` wrapper in `edl-cache-lib.sh`) so
+  every script quiets output consistently rather than each reinventing it.
+- [x] F.3 Self-healing account S3 bucket (migrate without re-running setup-profile): have the
+  build path (and `up`) idempotently ensure the account bucket exists and is saved to the user
+  config — create + persist it if `s3Bucket` is empty — instead of only creating it in
+  setup-profile. This lets existing profiles (empty `s3Bucket`, e.g. when setup-profile failed
+  before saving it) activate the S3 cache automatically. Note: `Up.execute()` already calls
+  `configureAccountS3Bucket()` / `reapplyS3Policy()`; factor out that ensure-or-create logic and
+  reuse it from the AMI build path so `build-image` also benefits.
+- [x] F.4 Route the remaining base direct downloads through `cached_fetch` and quiet them: yq and
+  sjk.jar (currently inline `wget` in base.pkr.hcl, no `-q`, not cached) and async-profiler's
+  `tar zxvf` (verbose). Consider helm (`get-helm-3` pipe) and uv (astral.sh pipe) — harder to
+  cache, at least quiet them. (awscli is the cache bootstrap and can't cache itself.)

--- a/packer/base/base.pkr.hcl
+++ b/packer/base/base.pkr.hcl
@@ -31,11 +31,13 @@ variable "s3_bucket" {
 # The user's AWS keypair and local private key, so the build instance is reachable via SSH with
 # their own key (e.g. when left up by --keep-on-error / -on-error=abort).
 variable "ssh_keypair_name" {
-  type = string
+  type    = string
+  default = ""
 }
 
 variable "ssh_private_key_file" {
-  type = string
+  type    = string
+  default = ""
 }
 
 locals {

--- a/packer/base/base.pkr.hcl
+++ b/packer/base/base.pkr.hcl
@@ -22,6 +22,22 @@ variable "release_version" {
   default = ""
 }
 
+# Account S3 bucket used as an apt package cache for the JDK install (empty disables caching)
+variable "s3_bucket" {
+  type    = string
+  default = ""
+}
+
+# The user's AWS keypair and local private key, so the build instance is reachable via SSH with
+# their own key (e.g. when left up by --keep-on-error / -on-error=abort).
+variable "ssh_keypair_name" {
+  type = string
+}
+
+variable "ssh_private_key_file" {
+  type = string
+}
+
 locals {
   timestamp = regex_replace(timestamp(), "[- TZ:]", "")
   version = var.release_version != "" ? var.release_version : local.timestamp
@@ -33,6 +49,9 @@ source "amazon-ebs" "ubuntu" {
   ami_name      = "rustyrazorblade/images/easy-db-lab-base-${var.arch}-${local.version}"
   instance_type = local.instance_type
   region        = "${var.region}"
+  # Instance profile so the build can read/write the account S3 apt cache.
+  # The bucket policy already grants this role s3:* on the account bucket.
+  iam_instance_profile = "EasyDBLabEC2Role"
   source_ami_filter {
     filters = {
       name                = "ubuntu/images/*ubuntu-resolute-26.04-${var.arch}-server-*"
@@ -42,7 +61,9 @@ source "amazon-ebs" "ubuntu" {
     most_recent = true
     owners      = ["099720109477"]
   }
-  ssh_username = "ubuntu"
+  ssh_username         = "ubuntu"
+  ssh_keypair_name     = var.ssh_keypair_name
+  ssh_private_key_file = var.ssh_private_key_file
 
   # Use permanent VPC infrastructure created by PackerInfrastructureService
   vpc_filter {
@@ -73,8 +94,8 @@ source "amazon-ebs" "ubuntu" {
   }
   launch_block_device_mappings {
     device_name = "/dev/sda1"
-    volume_size = 16
-    volume_type = "gp2"
+    volume_size = 40
+    volume_type = "gp3"
     delete_on_termination = true
   }
 }
@@ -89,15 +110,30 @@ build {
     script = "install/prepare_instance.sh"
   }
 
+  # Upload the shared S3 cache library used by the install scripts below
+  provisioner "file" {
+    source      = "install/edl-cache-lib.sh"
+    destination = "/tmp/edl-cache-lib.sh"
+  }
+
+  # install AWS CLI v2 early so the S3 cache is usable by everything that follows
   provisioner "shell" {
-    inline = [
-      # bpftrace was removed b/c it breaks bcc tools, need to build latest from source
-      "echo '=== Downloading yq v4.41.1 ==='",
-      "sudo wget https://github.com/mikefarah/yq/releases/download/v4.41.1/yq_linux_${var.arch} -O /usr/local/bin/yq || { echo 'ERROR: yq download failed' >&2; exit 1; }",
-      "[ -f /usr/local/bin/yq ] || { echo 'ERROR: yq file not found after download' >&2; exit 1; }",
-      "sudo chmod +x /usr/local/bin/yq",
-      "echo '✓ yq installed successfully'",
+    script = "install/install_awscli.sh"
+  }
+
+  # install the cache library and restore the apt archive cache from S3
+  provisioner "shell" {
+    environment_vars = [
+      "EDL_ARCH=${var.arch}",
+      "EDL_S3_BUCKET=${var.s3_bucket}",
     ]
+    script = "install/setup_s3_cache.sh"
+  }
+
+  # install yq (via the S3 download cache)
+  provisioner "shell" {
+    environment_vars = ["ARCH=${var.arch}"]
+    script           = "install/install_yq.sh"
   }
 
   # install python via deadsnakes PPA
@@ -117,11 +153,6 @@ build {
 
   provisioner "shell" {
     script = "install/install_bcc.sh"
-  }
-
-  # install AWS CLI v2
-  provisioner "shell" {
-    script = "install/install_awscli.sh"
   }
 
   # install k3s (disabled, not auto-started)
@@ -157,12 +188,13 @@ build {
     script = "install/install_otel_agent.sh"
   }
 
+  # Installs all supported JDKs (8/11/17/21 + debug symbols) for the Cassandra versions we
+  # support. The hundreds of MB of -dbg packages come from the apt archive cache restored above.
   provisioner "shell" {
-    inline = [
-      "sudo DEBIAN_FRONTEND=noninteractive apt install -y openjdk-8-jdk openjdk-8-dbg openjdk-11-jdk openjdk-11-dbg openjdk-17-jdk openjdk-17-dbg openjdk-21-jdk openjdk-21-dbg",
-      "sudo update-java-alternatives -s /usr/lib/jvm/java-1.11.0-openjdk-${var.arch}",
-      "sudo sed -i '/hl jexec.*/d' /usr/lib/jvm/.java-1.8.0-openjdk-${var.arch}.jinfo"
+    environment_vars = [
+      "ARCH=${var.arch}",
     ]
+    script = "install/install_jdks.sh"
   }
 
   # install my extra nice tools, exa, bat, fd, ripgrep
@@ -181,15 +213,14 @@ build {
     ]
   }
 
+  # install sjk.jar (via the S3 download cache)
   provisioner "shell" {
-    inline = [
-      "echo '=== Downloading sjk.jar v0.21 from Maven Central ==='",
-      "wget https://repo1.maven.org/maven2/org/gridkit/jvmtool/sjk/0.21/sjk-0.21.jar -O /tmp/sjk.jar || { echo 'ERROR: sjk.jar download failed' >&2; exit 1; }",
-      "[ -f /tmp/sjk.jar ] || { echo 'ERROR: sjk.jar file not found after download' >&2; exit 1; }",
-      "sudo mv /tmp/sjk.jar /usr/local/lib/sjk.jar",
-      "echo '✓ sjk.jar v0.21 installed successfully'",
-      ""
-    ]
+    script = "install/install_sjk.sh"
+  }
+
+  # Save the warm apt archive cache back to S3 for the next build
+  provisioner "shell" {
+    script = "install/save_s3_cache.sh"
   }
 }
 

--- a/packer/base/install/edl-cache-lib.sh
+++ b/packer/base/install/edl-cache-lib.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# Shared S3-backed cache helpers for Packer provisioning, sourced by install scripts.
+#
+# Two caches, both stored under the account S3 bucket:
+#   - apt archives:   s3://$EDL_S3_BUCKET/apt-cache/$EDL_ARCH/      (all .deb downloads)
+#   - direct fetches: s3://$EDL_S3_BUCKET/download-cache/<key>      (pinned binaries/jars/tarballs)
+#
+# Config (EDL_S3_BUCKET, EDL_ARCH) is read from /etc/edl-cache.env, written once by
+# setup_s3_cache.sh. Every function degrades gracefully: with no bucket configured, or on any
+# cache error, it falls back to fetching from the origin so a build is never blocked by the cache.
+
+# shellcheck disable=SC1091
+[ -f /etc/edl-cache.env ] && . /etc/edl-cache.env
+EDL_S3_BUCKET="${EDL_S3_BUCKET:-}"
+EDL_ARCH="${EDL_ARCH:-amd64}"
+
+# cached_fetch <url> <cache_key> <dest>
+# Fetch <url> to <dest>, using s3://$EDL_S3_BUCKET/download-cache/<cache_key> as a cache.
+# Cache key should encode the version so a new version is a cache miss (e.g. "k9s/v0.50.18/...").
+cached_fetch() {
+    local url="$1" key="$2" dest="$3"
+    local s3="s3://${EDL_S3_BUCKET}/download-cache/${key}"
+
+    # Note: no sudo on the aws calls. Instance-profile creds come from IMDS and work as any user,
+    # and running as the build user keeps the downloaded file user-owned so callers can rm it
+    # (a sudo-downloaded file in a sticky dir like /tmp can't be removed by the non-root user).
+    if [ -n "$EDL_S3_BUCKET" ] && aws s3 cp "$s3" "$dest" --no-progress 2>/dev/null; then
+        echo "cache hit:  $key"
+        return 0
+    fi
+
+    echo "cache miss: $key (downloading $url)"
+    curl -fsSL --retry 3 "$url" -o "$dest"
+
+    if [ -n "$EDL_S3_BUCKET" ]; then
+        aws s3 cp "$dest" "$s3" --no-progress 2>/dev/null || echo "WARN: failed to populate cache for $key"
+    fi
+}
+
+# Restore the apt archive cache from S3 into /var/cache/apt/archives so subsequent apt installs
+# reuse previously-downloaded .debs instead of hitting the mirrors.
+apt_cache_restore() {
+    [ -n "$EDL_S3_BUCKET" ] || return 0
+    echo "=== Restoring apt cache from s3://${EDL_S3_BUCKET}/apt-cache/${EDL_ARCH}/ ==="
+    sudo aws s3 sync "s3://${EDL_S3_BUCKET}/apt-cache/${EDL_ARCH}/" /var/cache/apt/archives/ --no-progress \
+        || echo "WARN: apt cache restore failed (cold cache?); continuing"
+}
+
+# Save the (now warm) apt archive cache back to S3 for the next build.
+apt_cache_save() {
+    [ -n "$EDL_S3_BUCKET" ] || return 0
+    echo "=== Saving apt cache to s3://${EDL_S3_BUCKET}/apt-cache/${EDL_ARCH}/ ==="
+    sudo aws s3 sync /var/cache/apt/archives/ "s3://${EDL_S3_BUCKET}/apt-cache/${EDL_ARCH}/" \
+        --exclude '*' --include '*.deb' --no-progress \
+        || echo "WARN: apt cache save failed; continuing"
+}

--- a/packer/base/install/install_async_profiler.sh
+++ b/packer/base/install/install_async_profiler.sh
@@ -23,8 +23,20 @@ ARCHIVE="${RELEASE}.tar.gz"
 
 sudo sysctl kernel.perf_event_paranoid=1
 sudo sysctl kernel.kptr_restrict=0
-wget "https://github.com/async-profiler/async-profiler/releases/download/v${RELEASE_VERSION}/${ARCHIVE}"
-tar zxvf $ARCHIVE
-sudo mv $RELEASE /usr/local/async-profiler
+
+# Use the shared S3 download cache when present; otherwise download directly (local script
+# tests, or no cache configured).
+if [ -f /usr/local/lib/edl-cache.sh ]; then
+    # shellcheck disable=SC1091
+    source /usr/local/lib/edl-cache.sh
+else
+    cached_fetch() { echo "no S3 cache; downloading $1"; curl -fsSL --retry 3 "$1" -o "$3"; }
+fi
+cached_fetch \
+    "https://github.com/async-profiler/async-profiler/releases/download/v${RELEASE_VERSION}/${ARCHIVE}" \
+    "async-profiler/v${RELEASE_VERSION}/${ARCHIVE}" \
+    "${ARCHIVE}"
+tar zxf "$ARCHIVE"
+sudo mv "$RELEASE" /usr/local/async-profiler
 
 echo "✓ install_async_profiler.sh completed successfully"

--- a/packer/base/install/install_cilium_cli.sh
+++ b/packer/base/install/install_cilium_cli.sh
@@ -19,10 +19,20 @@ fi
 TARBALL="cilium-linux-${ARCH}.tar.gz"
 
 echo "Downloading cilium CLI ${CILIUM_CLI_VERSION} for ${ARCH}..."
-curl -fsSL --retry 3 \
+# Use the shared S3 download cache when present; otherwise download directly (local script
+# tests, or no cache configured).
+if [ -f /usr/local/lib/edl-cache.sh ]; then
+    # shellcheck disable=SC1091
+    source /usr/local/lib/edl-cache.sh
+else
+    cached_fetch() { echo "no S3 cache; downloading $1"; curl -fsSL --retry 3 "$1" -o "$3"; }
+fi
+cached_fetch \
     "https://github.com/cilium/cilium-cli/releases/download/${CILIUM_CLI_VERSION}/${TARBALL}" \
-    -o "${TARBALL}"
+    "cilium-cli/${CILIUM_CLI_VERSION}/${TARBALL}" \
+    "${TARBALL}"
 
+# Always fetch the checksum from origin and verify (validates cache integrity too)
 curl -fsSL --retry 3 \
     "https://github.com/cilium/cilium-cli/releases/download/${CILIUM_CLI_VERSION}/${TARBALL}.sha256sum" \
     -o "${TARBALL}.sha256sum"

--- a/packer/base/install/install_helm.sh
+++ b/packer/base/install/install_helm.sh
@@ -7,7 +7,7 @@ echo "=== Running: install_helm.sh ==="
 HELM_VERSION="v3.17.3"
 
 echo "Installing helm ${HELM_VERSION}..."
-curl -fsSL "https://raw.githubusercontent.com/helm/helm/${HELM_VERSION}/scripts/get-helm-3" | DESIRED_VERSION="${HELM_VERSION}" bash
+curl -fsSL "https://raw.githubusercontent.com/helm/helm/${HELM_VERSION}/scripts/get-helm-3" | DESIRED_VERSION="${HELM_VERSION}" bash >/tmp/helm-install.log 2>&1
 
 helm version || { echo "ERROR: helm installation verification failed" >&2; exit 1; }
 

--- a/packer/base/install/install_jdks.sh
+++ b/packer/base/install/install_jdks.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# Installs every JDK required by the Cassandra versions we support (8, 11, 17, 21) plus their
+# debug-symbol packages.
+#
+# apt's verbose output is redirected to a log file rather than streamed over SSH. This is the
+# longest step and floods hundreds of unpack lines; that heavy output disrupts packer's SSH
+# connection (especially through restrictive corporate networks), causing packer to abort with a
+# spurious non-zero status even though the install succeeds on the instance. Keeping the stream
+# quiet lets packer's keepalive hold the connection for the duration.
+#
+# Env vars (set by the Packer provisioner):
+#   ARCH  dpkg architecture suffix used in the JVM paths (e.g. amd64, arm64)
+set -euo pipefail
+
+ARCH="${ARCH:?ARCH must be set}"
+LOG=/tmp/jdk-install.log
+
+# On failure, surface the tail of the captured log (since it isn't streamed live).
+trap 'echo "=== JDK install FAILED — tail of ${LOG} ==="; tail -50 "${LOG}" 2>/dev/null || true' ERR
+
+PACKAGES="openjdk-8-jdk openjdk-8-dbg \
+          openjdk-11-jdk openjdk-11-dbg \
+          openjdk-17-jdk openjdk-17-dbg \
+          openjdk-21-jdk openjdk-21-dbg"
+
+echo "Installing JDKs (verbose output -> ${LOG} to keep the packer SSH stream quiet)..."
+sudo apt-get update >>"${LOG}" 2>&1
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y $PACKAGES >>"${LOG}" 2>&1
+echo "JDK packages installed."
+
+# Default to Java 11; tolerate update-java-alternatives's known non-zero exit when some
+# components are absent, matching the previous behavior. Output also goes to the log (it is noisy).
+sudo update-java-alternatives -s "/usr/lib/jvm/java-1.11.0-openjdk-${ARCH}" >>"${LOG}" 2>&1 || true
+sudo sed -i '/hl jexec.*/d' "/usr/lib/jvm/.java-1.8.0-openjdk-${ARCH}.jinfo" || true
+echo "JDK setup complete (Java 11 default)."

--- a/packer/base/install/install_k3s.sh
+++ b/packer/base/install/install_k3s.sh
@@ -12,19 +12,35 @@ echo "=== Running: install_k3s.sh ==="
 K3S_VERSION="v1.35.1+k3s1"
 ARCH="amd64"
 
+# Use the shared S3 download cache when present; otherwise download directly (local script
+# tests, or no cache configured).
+if [ -f /usr/local/lib/edl-cache.sh ]; then
+    # shellcheck disable=SC1091
+    source /usr/local/lib/edl-cache.sh
+else
+    cached_fetch() { echo "no S3 cache; downloading $1"; curl -fsSL --retry 3 "$1" -o "$3"; }
+fi
+
 echo "Downloading k3s ${K3S_VERSION} for airgap installation..."
 
-# Download k3s binary
+# Download k3s binary (via S3 cache)
 echo "Downloading k3s binary..."
-sudo curl -sfL -o /usr/local/bin/k3s \
-  "https://github.com/k3s-io/k3s/releases/download/${K3S_VERSION}/k3s"
-sudo chmod +x /usr/local/bin/k3s
+cached_fetch \
+  "https://github.com/k3s-io/k3s/releases/download/${K3S_VERSION}/k3s" \
+  "k3s/${K3S_VERSION}/k3s-${ARCH}" \
+  /tmp/k3s
+sudo install -m 0755 /tmp/k3s /usr/local/bin/k3s
+rm -f /tmp/k3s
 
-# Download airgap images
+# Download airgap images (large; via S3 cache)
 echo "Downloading k3s airgap images..."
 sudo mkdir -p /var/lib/rancher/k3s/agent/images
-sudo curl -sfL -o /var/lib/rancher/k3s/agent/images/k3s-airgap-images-${ARCH}.tar.zst \
-  "https://github.com/k3s-io/k3s/releases/download/${K3S_VERSION}/k3s-airgap-images-${ARCH}.tar.zst"
+cached_fetch \
+  "https://github.com/k3s-io/k3s/releases/download/${K3S_VERSION}/k3s-airgap-images-${ARCH}.tar.zst" \
+  "k3s/${K3S_VERSION}/k3s-airgap-images-${ARCH}.tar.zst" \
+  /tmp/k3s-airgap-images-${ARCH}.tar.zst
+sudo mv /tmp/k3s-airgap-images-${ARCH}.tar.zst \
+  /var/lib/rancher/k3s/agent/images/k3s-airgap-images-${ARCH}.tar.zst
 
 # Download install script
 echo "Downloading k3s install script..."

--- a/packer/base/install/install_k9s.sh
+++ b/packer/base/install/install_k9s.sh
@@ -23,9 +23,20 @@ K9S_VERSION="v0.50.18"
 RELEASE="k9s_Linux_${ARCH}.tar.gz"
 
 echo "Downloading k9s ${K9S_VERSION} for ${ARCH}..."
-wget "https://github.com/derailed/k9s/releases/download/${K9S_VERSION}/${RELEASE}" || { echo "ERROR: k9s download failed" >&2; exit 1; }
+# Use the shared S3 download cache when present; otherwise download directly (local script
+# tests, or no cache configured).
+if [ -f /usr/local/lib/edl-cache.sh ]; then
+    # shellcheck disable=SC1091
+    source /usr/local/lib/edl-cache.sh
+else
+    cached_fetch() { echo "no S3 cache; downloading $1"; curl -fsSL --retry 3 "$1" -o "$3"; }
+fi
+cached_fetch \
+    "https://github.com/derailed/k9s/releases/download/${K9S_VERSION}/${RELEASE}" \
+    "k9s/${K9S_VERSION}/${RELEASE}" \
+    "${RELEASE}"
 
-tar -xzvf "${RELEASE}"
+tar -xzf "${RELEASE}"
 sudo mv k9s /usr/local/bin/
 rm -f "${RELEASE}" LICENSE README.md
 

--- a/packer/base/install/install_otel_agent.sh
+++ b/packer/base/install/install_otel_agent.sh
@@ -11,10 +11,21 @@ sudo mkdir -p /usr/local/otel
 # SHA-256 for each version: gh api repos/open-telemetry/opentelemetry-java-instrumentation/releases/tags/v${OTEL_VERSION} | jq -r '.assets[] | select(.name=="opentelemetry-javaagent.jar") | .digest'
 OTEL_SHA256="d6e809824176cf88792db359a9d928281ba2102fa8755453c1940f6c0289e396"
 
-# Download the OpenTelemetry Java agent
-wget -q "https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v${OTEL_VERSION}/${OTEL_JAR}" \
-    -O "/tmp/${OTEL_JAR}"
+# Download the OpenTelemetry Java agent (via S3 cache)
+# Use the shared S3 download cache when present; otherwise download directly (local script
+# tests, or no cache configured).
+if [ -f /usr/local/lib/edl-cache.sh ]; then
+    # shellcheck disable=SC1091
+    source /usr/local/lib/edl-cache.sh
+else
+    cached_fetch() { echo "no S3 cache; downloading $1"; curl -fsSL --retry 3 "$1" -o "$3"; }
+fi
+cached_fetch \
+    "https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v${OTEL_VERSION}/${OTEL_JAR}" \
+    "otel-agent/v${OTEL_VERSION}/${OTEL_JAR}" \
+    "/tmp/${OTEL_JAR}"
 
+# Verify the checksum (validates cache integrity too)
 echo "${OTEL_SHA256}  /tmp/${OTEL_JAR}" | sha256sum -c -
 
 sudo mv "/tmp/${OTEL_JAR}" "/usr/local/otel/${OTEL_JAR}"

--- a/packer/base/install/install_python.sh
+++ b/packer/base/install/install_python.sh
@@ -42,7 +42,7 @@ sudo update-alternatives --set python /usr/bin/python3.11
 
 # Install uv (fast Python package installer) via official installer
 echo "Installing uv to /usr/local/bin..."
-curl -LsSf https://astral.sh/uv/install.sh | sudo env INSTALLER_NO_MODIFY_PATH=1 UV_INSTALL_DIR=/usr/local/bin sh
+curl -LsSf https://astral.sh/uv/install.sh | sudo env INSTALLER_NO_MODIFY_PATH=1 UV_INSTALL_DIR=/usr/local/bin sh >/tmp/uv-install.log 2>&1
 
 # Verify installation
 uv --version

--- a/packer/base/install/install_sjk.sh
+++ b/packer/base/install/install_sjk.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+#
+# Installs sjk.jar via the S3 download cache (falls back to a direct download when absent).
+set -euo pipefail
+
+echo "=== Running: install_sjk.sh ==="
+
+SJK_VERSION="0.21"
+
+if [ -f /usr/local/lib/edl-cache.sh ]; then
+    # shellcheck disable=SC1091
+    source /usr/local/lib/edl-cache.sh
+else
+    cached_fetch() { echo "no S3 cache; downloading $1"; curl -fsSL --retry 3 "$1" -o "$3"; }
+fi
+
+cached_fetch \
+    "https://repo1.maven.org/maven2/org/gridkit/jvmtool/sjk/${SJK_VERSION}/sjk-${SJK_VERSION}.jar" \
+    "sjk/${SJK_VERSION}/sjk-${SJK_VERSION}.jar" \
+    /tmp/sjk.jar
+sudo mv /tmp/sjk.jar /usr/local/lib/sjk.jar
+
+echo "✓ install_sjk.sh completed successfully"

--- a/packer/base/install/install_yq.sh
+++ b/packer/base/install/install_yq.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+# Installs yq via the S3 download cache (falls back to a direct download when the cache is absent).
+#
+# Env vars (set by the Packer provisioner):
+#   ARCH  dpkg architecture (amd64 / arm64)
+set -euo pipefail
+
+echo "=== Running: install_yq.sh ==="
+
+ARCH="${ARCH:?ARCH must be set}"
+YQ_VERSION="v4.41.1"
+
+if [ -f /usr/local/lib/edl-cache.sh ]; then
+    # shellcheck disable=SC1091
+    source /usr/local/lib/edl-cache.sh
+else
+    cached_fetch() { echo "no S3 cache; downloading $1"; curl -fsSL --retry 3 "$1" -o "$3"; }
+fi
+
+cached_fetch \
+    "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_${ARCH}" \
+    "yq/${YQ_VERSION}/yq_linux_${ARCH}" \
+    /tmp/yq
+sudo install -m 0755 /tmp/yq /usr/local/bin/yq
+rm -f /tmp/yq
+
+echo "✓ install_yq.sh completed successfully"

--- a/packer/base/install/save_s3_cache.sh
+++ b/packer/base/install/save_s3_cache.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+#
+# Saves the warm apt archive cache back to S3 at the end of the build so the next build reuses it.
+# Direct downloads are cached inline by cached_fetch as they happen, so only the apt cache needs a
+# final save here.
+set -euo pipefail
+
+echo "=== Running: save_s3_cache.sh ==="
+
+# shellcheck disable=SC1091
+. /usr/local/lib/edl-cache.sh
+apt_cache_save
+
+echo "✓ save_s3_cache.sh completed successfully"

--- a/packer/base/install/setup_s3_cache.sh
+++ b/packer/base/install/setup_s3_cache.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+#
+# Installs the shared S3 cache library and restores the apt archive cache. Runs early in the build,
+# right after the AWS CLI is available. Persists the cache config so every later install script can
+# source /usr/local/lib/edl-cache.sh without needing the env vars passed again.
+#
+# Env vars (set by the Packer provisioner):
+#   EDL_S3_BUCKET  account bucket name (empty disables all caching)
+#   EDL_ARCH       dpkg architecture (amd64 / arm64)
+set -euo pipefail
+
+echo "=== Running: setup_s3_cache.sh ==="
+
+EDL_S3_BUCKET="${EDL_S3_BUCKET:-}"
+EDL_ARCH="${EDL_ARCH:-amd64}"
+
+# Persist config for later scripts that source the library
+sudo tee /etc/edl-cache.env >/dev/null <<EOF
+EDL_S3_BUCKET=${EDL_S3_BUCKET}
+EDL_ARCH=${EDL_ARCH}
+EOF
+
+# Install the cache library (uploaded to /tmp by a file provisioner)
+sudo mkdir -p /usr/local/lib
+sudo mv /tmp/edl-cache-lib.sh /usr/local/lib/edl-cache.sh
+
+# shellcheck disable=SC1091
+. /usr/local/lib/edl-cache.sh
+apt_cache_restore
+
+if [ -n "$EDL_S3_BUCKET" ]; then
+    echo "✓ S3 cache enabled (bucket: ${EDL_S3_BUCKET}, arch: ${EDL_ARCH})"
+else
+    echo "✓ No S3 bucket configured; caching disabled (downloads go straight to origin)"
+fi

--- a/packer/cassandra/cassandra.pkr.hcl
+++ b/packer/cassandra/cassandra.pkr.hcl
@@ -22,6 +22,23 @@ variable "release_version" {
    default = ""
 }
 
+# Declared because the build harness passes -var s3_bucket to every build. The cassandra image
+# builds on top of the base AMI (which already has the JDKs), so it is currently unused here.
+variable "s3_bucket" {
+  type    = string
+  default = ""
+}
+
+# The user's AWS keypair and local private key, so the build instance is reachable via SSH with
+# their own key (e.g. when left up by --keep-on-error / -on-error=abort).
+variable "ssh_keypair_name" {
+  type = string
+}
+
+variable "ssh_private_key_file" {
+  type = string
+}
+
 
 locals {
   timestamp = regex_replace(timestamp(), "[- TZ:]", "")
@@ -38,6 +55,8 @@ source "amazon-ebs" "ubuntu" {
   ami_groups    = local.ami_groups
   instance_type = local.instance_type
   region        = "${var.region}"
+  # Instance profile so the build can read/write the account S3 download/apt cache.
+  iam_instance_profile = "EasyDBLabEC2Role"
   source_ami_filter {
     filters = {
       name                = "rustyrazorblade/images/easy-db-lab-base-${var.arch}-${local.base_version}"
@@ -47,7 +66,9 @@ source "amazon-ebs" "ubuntu" {
     most_recent = true
     owners      = ["self"]
   }
-  ssh_username = "ubuntu"
+  ssh_username         = "ubuntu"
+  ssh_keypair_name     = var.ssh_keypair_name
+  ssh_private_key_file = var.ssh_private_key_file
 
   # Use permanent VPC infrastructure created by PackerInfrastructureService
   vpc_filter {
@@ -78,8 +99,9 @@ source "amazon-ebs" "ubuntu" {
   }
   launch_block_device_mappings {
     device_name = "/dev/sda1"
-    volume_size = 16
-    volume_type = "gp2"
+    # Larger than 16 GiB to hold the base image plus multiple staged Cassandra versions.
+    volume_size = 40
+    volume_type = "gp3"
     delete_on_termination = true
   }
 }
@@ -89,6 +111,16 @@ build {
   sources = [
     "source.amazon-ebs.ubuntu"
   ]
+
+  # The cache library and AWS CLI are baked into the base AMI. Refresh the cache config for this
+  # build and restore the apt archive cache from S3 before any apt installs run.
+  provisioner "shell" {
+    inline = [
+      "echo 'EDL_S3_BUCKET=${var.s3_bucket}' | sudo tee /etc/edl-cache.env >/dev/null",
+      "echo 'EDL_ARCH=${var.arch}' | sudo tee -a /etc/edl-cache.env >/dev/null",
+      ". /usr/local/lib/edl-cache.sh && apt_cache_restore",
+    ]
+  }
 
   provisioner "shell" {
     script = "install/prepare_instance.sh"
@@ -222,6 +254,13 @@ build {
   provisioner "file" {
     source = "htoprc"
     destination = "/home/ubuntu/.config/htop/htoprc"
+  }
+
+  # Save the warm apt archive cache back to S3 for the next build
+  provisioner "shell" {
+    inline = [
+      ". /usr/local/lib/edl-cache.sh && apt_cache_save",
+    ]
   }
 }
 

--- a/packer/cassandra/cassandra.pkr.hcl
+++ b/packer/cassandra/cassandra.pkr.hcl
@@ -32,11 +32,13 @@ variable "s3_bucket" {
 # The user's AWS keypair and local private key, so the build instance is reachable via SSH with
 # their own key (e.g. when left up by --keep-on-error / -on-error=abort).
 variable "ssh_keypair_name" {
-  type = string
+  type    = string
+  default = ""
 }
 
 variable "ssh_private_key_file" {
-  type = string
+  type    = string
+  default = ""
 }
 
 

--- a/packer/cassandra/install/install_cassandra.sh
+++ b/packer/cassandra/install/install_cassandra.sh
@@ -34,9 +34,9 @@ download_cassandra_version() {
     archive="apache-cassandra-$full_version-bin.tar.gz"
     download_url="https://dlcdn.apache.org/cassandra/$full_version/$archive"
 
-    # Download the file
+    # Download the file (via S3 cache, keyed by the resolved patch version)
     echo "Downloading Cassandra version $full_version from $download_url..."
-    curl -O "$download_url" || {
+    cached_fetch "$download_url" "cassandra-dist/$full_version/$archive" "$archive" || {
         echo "ERROR: Failed to download Cassandra version $full_version from $download_url"
         return 1
     }
@@ -49,8 +49,8 @@ download_cassandra_version() {
 
     echo "Download completed successfully."
 
-    # Extract the archive
-    tar zxvf "$archive" || {
+    # Extract the archive (quiet: verbose file listing floods packer's SSH stream and drops it)
+    tar zxf "$archive" || {
         echo "ERROR: Failed to extract $archive for version $full_version"
         return 1
     }
@@ -87,6 +87,15 @@ fi
 set -euo pipefail
 set -x
 
+# Shared S3 download cache (provides cached_fetch, used by download_cassandra_version above).
+# Falls back to a direct download when the cache lib is absent (local script tests / no cache).
+if [ -f /usr/local/lib/edl-cache.sh ]; then
+    # shellcheck disable=SC1091
+    source /usr/local/lib/edl-cache.sh
+else
+    cached_fetch() { echo "no S3 cache; downloading $1"; curl -fsSL --retry 3 "$1" -o "$3"; }
+fi
+
 # Trap errors and report line number
 trap 'echo "ERROR: Installation failed at line $LINENO with exit code $?" >&2; exit 1' ERR
 
@@ -104,7 +113,7 @@ uv tool install cqlsh
 
 # used to skip the expensive checkstyle checks
 
-sudo update-java-alternatives -s java-1.11.0-openjdk-amd64
+sudo update-java-alternatives -s java-1.11.0-openjdk-amd64 >/tmp/cassandra-setup.log 2>&1
 
 lsblk
 
@@ -150,7 +159,7 @@ do
   elif [[ $URL == *.tar.gz ]]; then
     echo "Downloading $URL for version $version"
 
-    wget "$URL" || {
+    wget -q "$URL" || {
         echo "ERROR: wget failed for version $version from $URL"
         exit 1
     }
@@ -164,7 +173,7 @@ do
     fi
 
     echo "Extracting $archive_file"
-    tar zxvf "$archive_file" || {
+    tar zxf "$archive_file" || {
         echo "ERROR: Failed to extract $archive_file for version $version"
         exit 1
     }
@@ -214,7 +223,8 @@ do
     echo "Building version $version with ant"
     (
       cd "$version" || exit 1
-      ant realclean && ant -Dno-checkstyle=true $ANT_FLAGS || exit 1
+      # Quiet: ant output is voluminous and floods packer's SSH stream
+      ant realclean >/tmp/ant-build.log 2>&1 && ant -Dno-checkstyle=true $ANT_FLAGS >>/tmp/ant-build.log 2>&1 || exit 1
       rm -rf .git
     ) || {
         echo "ERROR: Ant build failed for version $version"

--- a/packer/cassandra/install/install_cassandra_easy_stress.sh
+++ b/packer/cassandra/install/install_cassandra_easy_stress.sh
@@ -9,7 +9,7 @@ TEMP_DIR=$(mktemp -d)
 
 echo "Downloading cassandra-easy-stress from ${TARBALL_URL}..."
 cd "${TEMP_DIR}"
-curl -L -o cassandra-easy-stress-latest.tar.gz "${TARBALL_URL}"
+curl -fsSL -o cassandra-easy-stress-latest.tar.gz "${TARBALL_URL}"
 
 echo "Extracting tarball..."
 tar -xzf cassandra-easy-stress-latest.tar.gz

--- a/packer/cassandra/install/install_maac.sh
+++ b/packer/cassandra/install/install_maac.sh
@@ -9,7 +9,15 @@ MAAC_BASE="/opt/management-api"
 TEMP_DIR=$(mktemp -d)
 
 echo "Downloading MAAC agent v${MAAC_VERSION}..."
-curl -fsSL -o "${TEMP_DIR}/jars.zip" "${MAAC_URL}"
+# Use the shared S3 download cache when present; otherwise download directly (local script
+# tests, or no cache configured).
+if [ -f /usr/local/lib/edl-cache.sh ]; then
+    # shellcheck disable=SC1091
+    source /usr/local/lib/edl-cache.sh
+else
+    cached_fetch() { echo "no S3 cache; downloading $1"; curl -fsSL --retry 3 "$1" -o "$3"; }
+fi
+cached_fetch "${MAAC_URL}" "maac/v${MAAC_VERSION}/jars.zip" "${TEMP_DIR}/jars.zip"
 
 echo "Extracting MAAC JARs..."
 cd "${TEMP_DIR}"

--- a/packer/cassandra/install/install_pyroscope_agent.sh
+++ b/packer/cassandra/install/install_pyroscope_agent.sh
@@ -22,9 +22,19 @@ PYROSCOPE_JAR="pyroscope.jar"
 
 sudo mkdir -p /usr/local/pyroscope
 
-# Download the Pyroscope Java agent
-wget -q "https://github.com/grafana/pyroscope-java/releases/download/v${PYROSCOPE_VERSION}/${PYROSCOPE_JAR}" \
-    -O "/tmp/${PYROSCOPE_JAR}"
+# Download the Pyroscope Java agent (via S3 cache)
+# Use the shared S3 download cache when present; otherwise download directly (local script
+# tests, or no cache configured).
+if [ -f /usr/local/lib/edl-cache.sh ]; then
+    # shellcheck disable=SC1091
+    source /usr/local/lib/edl-cache.sh
+else
+    cached_fetch() { echo "no S3 cache; downloading $1"; curl -fsSL --retry 3 "$1" -o "$3"; }
+fi
+cached_fetch \
+    "https://github.com/grafana/pyroscope-java/releases/download/v${PYROSCOPE_VERSION}/${PYROSCOPE_JAR}" \
+    "pyroscope/v${PYROSCOPE_VERSION}/${PYROSCOPE_JAR}" \
+    "/tmp/${PYROSCOPE_JAR}"
 
 sudo mv "/tmp/${PYROSCOPE_JAR}" "/usr/local/pyroscope/${PYROSCOPE_JAR}"
 sudo chmod 644 "/usr/local/pyroscope/${PYROSCOPE_JAR}"

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/Constants.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/Constants.kt
@@ -8,6 +8,7 @@ object Constants {
     object Paths {
         const val LOCAL_MOUNT = "/local"
         const val CREDENTIALS_MOUNT = "/credentials"
+        const val SSH_KEY_MOUNT = "/secret.pem"
     }
 
     // Server types
@@ -138,6 +139,10 @@ object Constants {
     object Environment {
         const val USER_DIR = "EASY_DB_LAB_USER_DIR"
         const val S3_BUCKET = "EASY_DB_LAB_S3_BUCKET"
+
+        // When truthy, AMI builds leave the instance running on failure (packer -on-error=abort),
+        // regardless of how the build was invoked (e.g. via setup-profile, which has no flag).
+        const val BUILD_KEEP_ON_FAILURE = "EASY_DB_LAB_BUILD_KEEP_ON_FAILURE"
     }
 
     // AWS configuration

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/BuildBaseImage.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/BuildBaseImage.kt
@@ -6,8 +6,10 @@ import com.rustyrazorblade.easydblab.annotations.RequireProfileSetup
 import com.rustyrazorblade.easydblab.commands.mixins.BuildArgsMixin
 import com.rustyrazorblade.easydblab.configuration.User
 import com.rustyrazorblade.easydblab.containers.Packer
+import com.rustyrazorblade.easydblab.services.ExternalIpService
 import com.rustyrazorblade.easydblab.services.aws.AWSResourceSetupService
 import com.rustyrazorblade.easydblab.services.aws.AwsInfrastructureService
+import com.rustyrazorblade.easydblab.services.aws.AwsS3BucketService
 import org.koin.core.component.inject
 import picocli.CommandLine.Command
 import picocli.CommandLine.Mixin
@@ -27,6 +29,8 @@ class BuildBaseImage : PicoBaseCommand() {
 
     private val awsInfrastructure: AwsInfrastructureService by inject()
     private val awsResourceSetupService: AWSResourceSetupService by inject()
+    private val s3BucketService: AwsS3BucketService by inject()
+    private val externalIpService: ExternalIpService by inject()
     private val userConfig: User by inject()
 
     override fun execute() {
@@ -37,9 +41,11 @@ class BuildBaseImage : PicoBaseCommand() {
 
         // Ensure AWS infrastructure (IAM roles, S3) exists first
         awsResourceSetupService.ensureAWSResources(userConfig)
+        // Ensure the account bucket exists so the S3 build cache is active (migrates old profiles)
+        s3BucketService.ensureAccountBucket(userConfig)
 
-        // Ensure Packer VPC infrastructure exists before building
-        awsInfrastructure.ensurePackerInfrastructure(Constants.Network.SSH_PORT)
+        // Ensure Packer VPC infrastructure exists before building, scoping SSH to this machine's IP
+        awsInfrastructure.ensurePackerInfrastructure(Constants.Network.SSH_PORT, externalIpService.getExternalCidr())
 
         val packer = Packer(context, "base")
         packer.build("base.pkr.hcl", buildArgs)

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/BuildCassandraImage.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/BuildCassandraImage.kt
@@ -6,8 +6,10 @@ import com.rustyrazorblade.easydblab.annotations.RequireProfileSetup
 import com.rustyrazorblade.easydblab.commands.mixins.BuildArgsMixin
 import com.rustyrazorblade.easydblab.configuration.User
 import com.rustyrazorblade.easydblab.containers.Packer
+import com.rustyrazorblade.easydblab.services.ExternalIpService
 import com.rustyrazorblade.easydblab.services.aws.AWSResourceSetupService
 import com.rustyrazorblade.easydblab.services.aws.AwsInfrastructureService
+import com.rustyrazorblade.easydblab.services.aws.AwsS3BucketService
 import org.koin.core.component.inject
 import picocli.CommandLine.Command
 import picocli.CommandLine.Mixin
@@ -27,6 +29,8 @@ class BuildCassandraImage : PicoBaseCommand() {
 
     private val awsInfrastructure: AwsInfrastructureService by inject()
     private val awsResourceSetupService: AWSResourceSetupService by inject()
+    private val s3BucketService: AwsS3BucketService by inject()
+    private val externalIpService: ExternalIpService by inject()
     private val userConfig: User by inject()
 
     override fun execute() {
@@ -37,9 +41,11 @@ class BuildCassandraImage : PicoBaseCommand() {
 
         // Ensure AWS infrastructure (IAM roles, S3) exists first
         awsResourceSetupService.ensureAWSResources(userConfig)
+        // Ensure the account bucket exists so the S3 build cache is active (migrates old profiles)
+        s3BucketService.ensureAccountBucket(userConfig)
 
-        // Ensure Packer VPC infrastructure exists before building
-        awsInfrastructure.ensurePackerInfrastructure(Constants.Network.SSH_PORT)
+        // Ensure Packer VPC infrastructure exists before building, scoping SSH to this machine's IP
+        awsInfrastructure.ensurePackerInfrastructure(Constants.Network.SSH_PORT, externalIpService.getExternalCidr())
 
         val packer = Packer(context, "cassandra")
         packer.build("cassandra.pkr.hcl", buildArgs)

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/SetupProfile.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/SetupProfile.kt
@@ -10,6 +10,7 @@ import com.rustyrazorblade.easydblab.events.Event
 import com.rustyrazorblade.easydblab.providers.aws.AWS
 import com.rustyrazorblade.easydblab.providers.aws.AWSClientFactory
 import com.rustyrazorblade.easydblab.services.CommandExecutor
+import com.rustyrazorblade.easydblab.services.ExternalIpService
 import com.rustyrazorblade.easydblab.services.aws.AMIValidationException
 import com.rustyrazorblade.easydblab.services.aws.AMIValidator
 import com.rustyrazorblade.easydblab.services.aws.AWSResourceSetupService
@@ -41,6 +42,7 @@ class SetupProfile : PicoBaseCommand() {
     private val commandExecutor: CommandExecutor by inject()
     private val prompter: Prompter by inject()
     private val awsClientFactory: AWSClientFactory by inject()
+    private val externalIpService: ExternalIpService by inject()
 
     override fun execute() {
         val existingConfig = userConfigProvider.loadExistingConfig()
@@ -213,7 +215,8 @@ class SetupProfile : PicoBaseCommand() {
     private fun offerIamPolicyDisplay(aws: AWS) {
         val showPolicies =
             prompter.prompt(
-                "Do you want to see the IAM policies with your account ID populated?",
+                "Print the IAM policies easy-db-lab needs (to request access from an AWS admin)? " +
+                    "Not required if setup completes — view anytime with 'show-iam-policies'",
                 "N",
             )
         if (showPolicies.equals("y", true)) {
@@ -452,7 +455,7 @@ class SetupProfile : PicoBaseCommand() {
      */
     private fun ensurePackerVpc() {
         eventBus.emit(Event.Setup.PackerVpcCreating)
-        awsInfra.ensurePackerInfrastructure(Constants.Network.SSH_PORT)
+        awsInfra.ensurePackerInfrastructure(Constants.Network.SSH_PORT, externalIpService.getExternalCidr())
         eventBus.emit(Event.Setup.PackerVpcReady)
     }
 

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Up.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Up.kt
@@ -25,6 +25,7 @@ import com.rustyrazorblade.easydblab.services.CiliumService
 import com.rustyrazorblade.easydblab.services.ClusterConfigurationService
 import com.rustyrazorblade.easydblab.services.ClusterProvisioningService
 import com.rustyrazorblade.easydblab.services.CommandExecutor
+import com.rustyrazorblade.easydblab.services.ExternalIpService
 import com.rustyrazorblade.easydblab.services.HostOperationsService
 import com.rustyrazorblade.easydblab.services.InstanceProvisioningConfig
 import com.rustyrazorblade.easydblab.services.K3sClusterConfig
@@ -45,7 +46,6 @@ import io.github.resilience4j.retry.Retry
 import org.koin.core.component.inject
 import picocli.CommandLine
 import java.io.File
-import java.net.URL
 import java.time.Duration
 
 /**
@@ -87,6 +87,7 @@ class Up : PicoBaseCommand() {
     private val registryService: RegistryService by inject()
     private val socksProxyService: SocksProxyService by inject()
     private val commandExecutor: CommandExecutor by inject()
+    private val externalIpService: ExternalIpService by inject()
 
     // Working copy loaded during execute() - modified and saved
     private lateinit var workingState: ClusterState
@@ -94,12 +95,6 @@ class Up : PicoBaseCommand() {
     companion object {
         private val log = KotlinLogging.logger {}
         private val SSH_STARTUP_DELAY = Duration.ofSeconds(5)
-
-        /**
-         * Gets the external IP address of the machine running easy-db-lab.
-         * Used to restrict SSH access to the security group.
-         */
-        private fun getExternalIpAddress(): String = URL("https://api.ipify.org/").readText()
     }
 
     // Lock for synchronizing access to workingState from parallel threads
@@ -154,10 +149,8 @@ class Up : PicoBaseCommand() {
             return
         }
 
-        val accountBucket = userConfig.s3Bucket
-        require(accountBucket.isNotBlank()) {
-            "No S3 bucket configured in profile. Run 'easy-db-lab setup-profile' first."
-        }
+        // Ensure-or-create the account bucket (migrates profiles that never had one saved)
+        val accountBucket = s3BucketService.ensureAccountBucket(userConfig)
 
         // Configure account-level bucket
         eventBus.emit(Event.S3.BucketUsing(accountBucket))
@@ -322,7 +315,7 @@ class Up : PicoBaseCommand() {
             tags = initConfig.tags,
             vpcCidr = resolvedCidr,
         ),
-    ) { getExternalIpAddress() }
+    ) { externalIpService.getExternalIpAddress() }
 
     private fun discoverExistingHosts(): Map<ServerType, List<ClusterHost>> {
         val existingInstances = ec2InstanceService.findInstancesByClusterId(workingState.clusterId)

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/mixins/BuildArgsMixin.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/mixins/BuildArgsMixin.kt
@@ -29,4 +29,13 @@ class BuildArgsMixin {
         converter = [PicoArchConverter::class],
     )
     var arch: Arch = Arch.AMD64
+
+    @Option(
+        names = ["--keep-on-error"],
+        description = [
+            "On build failure, leave the instance and temporary SSH key running for debugging " +
+                "(packer -on-error=abort) instead of terminating it",
+        ],
+    )
+    var keepOnError: Boolean = false
 }

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/containers/Packer.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/containers/Packer.kt
@@ -9,15 +9,20 @@ import com.rustyrazorblade.easydblab.VolumeMapping
 import com.rustyrazorblade.easydblab.commands.mixins.BuildArgsMixin
 import com.rustyrazorblade.easydblab.configuration.Arch
 import com.rustyrazorblade.easydblab.configuration.CassandraVersion
+import com.rustyrazorblade.easydblab.configuration.Host
 import com.rustyrazorblade.easydblab.configuration.User
 import com.rustyrazorblade.easydblab.events.Event
 import com.rustyrazorblade.easydblab.events.EventBus
 import com.rustyrazorblade.easydblab.providers.aws.AWSCredentialsManager
+import com.rustyrazorblade.easydblab.providers.aws.VpcService
+import com.rustyrazorblade.easydblab.providers.ssh.RemoteOperationsService
+import com.rustyrazorblade.easydblab.services.aws.EC2InstanceService
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.apache.commons.io.FileUtils
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import org.koin.core.parameter.parametersOf
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
 import java.io.File
 import java.nio.file.Path
 import java.time.Duration
@@ -30,8 +35,16 @@ class Packer(
 ) : KoinComponent {
     private val docker: Docker by inject { parametersOf(context) }
     private val eventBus: EventBus by inject()
+    private val credentialsProvider: AwsCredentialsProvider by inject()
     private val user: User by inject()
-    private val awsCredentialsManager by lazy { AWSCredentialsManager(context.profileDir, user) }
+
+    // Used on build failure to capture diagnostics from, and tear down, the kept instance.
+    private val vpcService: VpcService by inject()
+    private val ec2InstanceService: EC2InstanceService by inject()
+    private val remoteOps: RemoteOperationsService by inject()
+
+    private val awsCredentialsManager by lazy { AWSCredentialsManager(context.profileDir, credentialsProvider) }
+    private val secretKeyFile by lazy { File(context.profileDir, "secret.pem") }
 
     private val containerWorkingDir = Constants.Paths.LOCAL_MOUNT
     private val logger = KotlinLogging.logger {}
@@ -46,7 +59,7 @@ class Packer(
         name: String,
         buildArgs: BuildArgsMixin,
     ) {
-        buildInternal(name, buildArgs.region, buildArgs.arch, buildArgs.release)
+        buildInternal(name, buildArgs.region, buildArgs.arch, buildArgs.release, buildArgs.keepOnError)
     }
 
     private fun buildInternal(
@@ -54,18 +67,41 @@ class Packer(
         region: String,
         arch: Arch,
         isRelease: Boolean,
+        keepOnError: Boolean,
     ) {
         require(name.isNotBlank()) { "Build name cannot be blank" }
         require(region.isNotBlank()) { "Build region cannot be blank" }
 
+        val keepUp = keepOnError || keepOnErrorFromEnv()
+
         val command =
             mutableListOf(
                 "build",
+                // Always keep the instance on failure so we can capture diagnostics from it
+                // before deciding whether to tear it down (see handleBuildFailure).
+                "-on-error=abort",
+            )
+
+        require(user.keyName.isNotEmpty() && secretKeyFile.exists()) {
+            "AWS keypair not configured (key: '${user.keyName}', file: ${secretKeyFile.absolutePath}). Run setup-profile first."
+        }
+
+        command.addAll(
+            listOf(
                 "-var",
                 "region=$region",
                 "-var",
                 "arch=${arch.type}",
-            )
+                "-var",
+                "s3_bucket=${user.s3Bucket}",
+                // Build with the user's own AWS keypair so an instance left up via --keep-on-error
+                // can be SSH'd into with ${profileDir}/secret.pem.
+                "-var",
+                "ssh_keypair_name=${user.keyName}",
+                "-var",
+                "ssh_private_key_file=${Constants.Paths.SSH_KEY_MOUNT}",
+            ),
+        )
 
         if (isRelease) {
             // When passing the release flag,
@@ -86,11 +122,83 @@ class Packer(
         when {
             result.isFailure -> {
                 logger.error { "Packer build failed: ${result.exceptionOrNull()}" }
+                handleBuildFailure(keepUp)
                 exitProcess(1)
             }
             result.isSuccess -> {
                 logger.info { "Packer build succeeded" }
             }
+        }
+    }
+
+    /**
+     * Whether the EASY_DB_LAB_BUILD_KEEP_ON_FAILURE env var is set to a truthy value. Lets builds
+     * triggered indirectly (e.g. by setup-profile) keep the instance up on failure without a flag.
+     */
+    private fun keepOnErrorFromEnv(): Boolean =
+        System.getenv(Constants.Environment.BUILD_KEEP_ON_FAILURE)?.lowercase() in setOf("1", "true", "yes", "on")
+
+    /**
+     * On build failure, capture diagnostics from the kept instance (packer ran with
+     * -on-error=abort) and surface them, then tear the instance down — unless [keepUp] is set
+     * (--keep-on-error / env), in which case it is left running for manual debugging.
+     *
+     * Best-effort: any failure resolving/SSHing/terminating the instance degrades gracefully to
+     * printing manual SSH instructions, so a build failure is never made worse.
+     */
+    private fun handleBuildFailure(keepUp: Boolean) {
+        val instanceId =
+            runCatching {
+                val vpcId = vpcService.findVpcByName(Constants.Vpc.PACKER_VPC_NAME) ?: return@runCatching null
+                // The packer VPC only ever holds the in-flight build instance.
+                vpcService.findInstancesInVpc(vpcId).firstOrNull()
+            }.getOrNull()
+
+        if (instanceId == null) {
+            println("Build failed. Could not locate the build instance to capture/clean up.")
+            return
+        }
+
+        val ip = runCatching { ec2InstanceService.describeInstances(listOf(instanceId)).firstOrNull()?.publicIp }.getOrNull()
+        if (!ip.isNullOrBlank()) {
+            captureAndPrintDiagnostics(ip)
+        }
+
+        if (keepUp) {
+            println(
+                """
+
+                Build instance $instanceId left running (--keep-on-error / EASY_DB_LAB_BUILD_KEEP_ON_FAILURE).
+                SSH in:  ssh -i ${secretKeyFile.absolutePath} ubuntu@${ip ?: "<instance-ip>"}
+                Terminate when done: aws ec2 terminate-instances --instance-ids $instanceId
+                """.trimIndent(),
+            )
+        } else {
+            runCatching { vpcService.terminateInstances(listOf(instanceId)) }
+                .onSuccess { println("Build instance $instanceId terminated (set --keep-on-error to keep it for debugging).") }
+                .onFailure { println("WARNING: failed to terminate build instance $instanceId: ${it.message}") }
+        }
+    }
+
+    /**
+     * SSHes into the kept build instance and prints the most useful failure diagnostics.
+     * Best-effort: if the instance is unreachable, prints manual SSH instructions instead.
+     */
+    private fun captureAndPrintDiagnostics(ip: String) {
+        val cmd =
+            "echo '--- df / ---'; df -h /; " +
+                "echo '--- /tmp/jdk-install.log (tail) ---'; tail -60 /tmp/jdk-install.log 2>/dev/null; " +
+                "echo '--- /var/log/apt/term.log (tail) ---'; sudo tail -100 /var/log/apt/term.log 2>/dev/null; " +
+                "echo '--- dmesg (tail) ---'; sudo dmesg 2>/dev/null | tail -40"
+        runCatching {
+            val host = Host(public = ip, private = "", alias = "packer-build", availabilityZone = "")
+            val response = remoteOps.executeRemotely(host, cmd, output = false)
+            println("==== build instance diagnostics ($ip) ====")
+            println(response.text)
+            println("==========================================")
+        }.onFailure {
+            println("Could not auto-capture diagnostics from $ip (${it.message}).")
+            println("SSH in manually: ssh -i ${secretKeyFile.absolutePath} ubuntu@$ip")
         }
     }
 
@@ -140,6 +248,10 @@ class Packer(
             .addVolume(packerDir)
             .addVolume(
                 VolumeMapping(awsCredentialsManager.credentialsPath, creds, AccessMode.ro),
+            )
+            // Mount the user's private key so packer authenticates with their keypair
+            .addVolume(
+                VolumeMapping(secretKeyFile.absolutePath, Constants.Paths.SSH_KEY_MOUNT, AccessMode.ro),
             ).addEnv("${Constants.Packer.AWS_CREDENTIALS_ENV}=$creds")
             .runContainer(Containers.PACKER, args, containerWorkingDir, packerTimeout)
     }

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/providers/aws/AWS.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/providers/aws/AWS.kt
@@ -242,9 +242,25 @@ class AWS(
                     .policy(bucketPolicy)
                     .build()
 
-            s3Client.putBucketPolicy(request)
+            // The policy references the just-created IAM roles as principals. IAM is eventually
+            // consistent, so S3 may briefly reject the policy with "Invalid principal in policy"
+            // until the roles propagate. Retry with backoff so this resolves itself.
+            RetryUtil.withS3BucketPolicyRetry("put-bucket-policy") {
+                s3Client.putBucketPolicy(request)
+            }
             log.info { "✓ Applied S3 bucket policy granting access to all 3 IAM roles: $bucketName" }
         } catch (e: software.amazon.awssdk.services.s3.model.S3Exception) {
+            val isPrincipalPropagation =
+                e.awsErrorDetails()?.errorCode() == "MalformedPolicy" ||
+                    e.message?.contains("Invalid principal") == true
+            if (isPrincipalPropagation) {
+                log.error(e) { "Failed to apply S3 bucket policy: $bucketName - ${e.message}" }
+                throw IllegalStateException(
+                    "Could not apply the S3 bucket policy because the easy-db-lab IAM roles are not yet " +
+                        "visible to S3 (IAM propagation delay). Wait a moment and re-run setup-profile.",
+                    e,
+                )
+            }
             log.error(e) { "Failed to apply S3 bucket policy: $bucketName - ${e.message}" }
             throw e
         }

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/providers/aws/AWSCredentialsManager.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/providers/aws/AWSCredentialsManager.kt
@@ -1,17 +1,23 @@
 package com.rustyrazorblade.easydblab.providers.aws
 
 import com.rustyrazorblade.easydblab.Constants
-import com.rustyrazorblade.easydblab.configuration.User
 import io.github.oshai.kotlinlogging.KotlinLogging
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials
 import java.io.File
 
 /**
- * Manages AWS credentials file creation and access.
- * This was previously handled by the awsConfig lazy property in Context.
+ * Manages the AWS credentials file handed to the Packer container during AMI builds.
+ *
+ * Packer resolves AWS credentials independently of the JVM SDK, so the tool writes a
+ * shared-credentials file and mounts it into the container. Credentials are resolved through the
+ * same [AwsCredentialsProvider] the rest of the tool uses — static keys or an SSO-backed profile —
+ * so AMI builds authenticate identically to every other AWS operation. When the resolved
+ * credentials are temporary (e.g. SSO), the session token is written so Packer can authenticate.
  */
 class AWSCredentialsManager(
     private val profileDir: File,
-    private val user: User,
+    private val credentialsProvider: AwsCredentialsProvider,
 ) {
     private val logger = KotlinLogging.logger {}
 
@@ -21,20 +27,26 @@ class AWSCredentialsManager(
     val credentialsFileName: String = Constants.AWS.DEFAULT_CREDENTIALS_NAME
 
     /**
-     * Get or create the AWS credentials file.
-     * If the file doesn't exist, it will be created with the user's AWS credentials.
+     * The AWS credentials file, written from the currently-resolved credentials.
+     *
+     * The file is always (re)written rather than reused, so temporary credentials (e.g. SSO) are
+     * refreshed on each build instead of leaving a stale, expired file on disk.
      */
     val credentialsFile: File by lazy {
         val file = File(profileDir, credentialsFileName)
-        if (!file.exists()) {
-            logger.debug { "Creating AWS credentials file at ${file.absolutePath}" }
-            file.writeText(
-                """[default]
-                |aws_access_key_id=${user.awsAccessKey}
-                |aws_secret_access_key=${user.awsSecret}
-            """.trimMargin("|"),
-            )
-        }
+        val credentials = credentialsProvider.resolveCredentials()
+        logger.debug { "Writing AWS credentials file at ${file.absolutePath}" }
+
+        val contents =
+            buildString {
+                appendLine("[default]")
+                appendLine("aws_access_key_id=${credentials.accessKeyId()}")
+                appendLine("aws_secret_access_key=${credentials.secretAccessKey()}")
+                if (credentials is AwsSessionCredentials) {
+                    appendLine("aws_session_token=${credentials.sessionToken()}")
+                }
+            }
+        file.writeText(contents)
         file
     }
 

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/providers/aws/InfrastructureConfig.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/providers/aws/InfrastructureConfig.kt
@@ -101,9 +101,16 @@ data class InfrastructureConfig(
          *
          * Packer needs:
          * - Single subnet in any AZ
-         * - SSH access from anywhere (0.0.0.0/0)
+         * - SSH access from the given CIDR (the developer's public IP /32, not 0.0.0.0/0 —
+         *   managed-account governance tools revoke world-open SSH rules)
+         *
+         * @param sshPort SSH port to allow
+         * @param sshCidr CIDR allowed to SSH in (e.g. "203.0.113.10/32")
          */
-        fun forPacker(sshPort: Int): InfrastructureConfig =
+        fun forPacker(
+            sshPort: Int,
+            sshCidr: String,
+        ): InfrastructureConfig =
             InfrastructureConfig(
                 vpcName = PACKER_VPC_NAME,
                 vpcCidr = Constants.Vpc.DEFAULT_CIDR,
@@ -118,7 +125,7 @@ data class InfrastructureConfig(
                 securityGroupDescription = "Security group for Packer AMI builds",
                 securityGroupRules =
                     listOf(
-                        SecurityGroupRule.singlePort(sshPort, "0.0.0.0/0"),
+                        SecurityGroupRule.singlePort(sshPort, sshCidr),
                     ),
                 internetGatewayName = "easy-db-lab-packer-igw",
                 tags = mapOf(Constants.Vpc.TAG_KEY to Constants.Vpc.TAG_VALUE),

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/providers/aws/RetryUtil.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/providers/aws/RetryUtil.kt
@@ -313,6 +313,50 @@ object RetryUtil {
                 }
             }.build()
 
+    /**
+     * Creates retry configuration for applying an S3 bucket policy whose principals are
+     * IAM roles that were just created.
+     *
+     * IAM is eventually consistent, so a freshly created role may not yet be visible to S3's
+     * policy validator. S3 rejects the policy with a 400 `MalformedPolicy` ("Invalid principal
+     * in policy") until the role propagates. Retrying with backoff lets propagation catch up.
+     *
+     * - 5 attempts to cover propagation delay
+     * - Retries on `MalformedPolicy` / "Invalid principal" S3 errors and on 5xx server errors
+     * - Does NOT retry on 403 (forbidden) — that is a real permission error
+     *
+     * Exponential backoff: 1s, 2s, 4s, 8s, 16s
+     *
+     * @return RetryConfig configured for S3 bucket policy application
+     */
+    fun <T> createS3BucketPolicyRetryConfig(): RetryConfig =
+        RetryConfig
+            .custom<T>()
+            .maxAttempts(Constants.Retry.MAX_INSTANCE_PROFILE_RETRIES)
+            .intervalFunction { attemptCount ->
+                // Exponential backoff: 1s, 2s, 4s, 8s, 16s
+                Constants.Retry.EXPONENTIAL_BACKOFF_BASE_MS * (1L shl (attemptCount - 1))
+            }.retryOnException { throwable ->
+                when {
+                    throwable !is S3Exception -> false
+                    throwable.statusCode() == Constants.HttpStatus.FORBIDDEN -> {
+                        log.warn { "Permission denied applying S3 bucket policy - will not retry" }
+                        false
+                    }
+                    throwable.awsErrorDetails()?.errorCode() == "MalformedPolicy" ||
+                        throwable.message?.contains("Invalid principal") == true -> {
+                        log.warn { "IAM role not yet visible to S3 (eventual consistency) - will retry bucket policy" }
+                        true
+                    }
+                    throwable.statusCode() in
+                        Constants.HttpStatus.SERVER_ERROR_MIN..Constants.HttpStatus.SERVER_ERROR_MAX -> {
+                        log.warn { "S3 server error ${throwable.statusCode()} applying bucket policy - will retry" }
+                        true
+                    }
+                    else -> false
+                }
+            }.build()
+
     // ==================== Helper Functions ====================
 
     /**
@@ -364,6 +408,22 @@ object RetryUtil {
         operation: () -> T,
     ): T {
         val retryConfig = createVpcTeardownRetryConfig<T>()
+        val retry = Retry.of(operationName, retryConfig)
+        return Retry.decorateSupplier(retry, operation).get()
+    }
+
+    /**
+     * Executes an operation with S3 bucket policy retry logic (handles IAM eventual consistency).
+     *
+     * @param operationName Name of the operation for logging and metrics
+     * @param operation The operation to execute with retry logic
+     * @return The result of the operation
+     */
+    fun <T> withS3BucketPolicyRetry(
+        operationName: String,
+        operation: () -> T,
+    ): T {
+        val retryConfig = createS3BucketPolicyRetryConfig<T>()
         val retry = Retry.of(operationName, retryConfig)
         return Retry.decorateSupplier(retry, operation).get()
     }

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/ExternalIpService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/ExternalIpService.kt
@@ -1,0 +1,27 @@
+package com.rustyrazorblade.easydblab.services
+
+import java.net.URI
+
+/**
+ * Resolves the public IP address of the machine running easy-db-lab.
+ *
+ * Used to scope security-group SSH ingress to the developer's own address (a `/32`) rather than
+ * opening it to the world. This keeps managed-account governance tools (e.g. CloudCustodian, which
+ * auto-revokes `0.0.0.0/0` SSH rules) from stripping the rule out from under a Packer build, and is
+ * more secure regardless. Both the cluster (`Up`) and Packer build paths resolve their IP here so
+ * there is a single implementation.
+ */
+interface ExternalIpService {
+    /** Returns the public IP address as seen from the internet (e.g. "203.0.113.10"). */
+    fun getExternalIpAddress(): String
+
+    /** Returns the public IP as a single-host CIDR suitable for a security-group rule (e.g. "203.0.113.10/32"). */
+    fun getExternalCidr(): String = "${getExternalIpAddress()}/32"
+}
+
+/**
+ * Default [ExternalIpService] that resolves the public IP via api.ipify.org.
+ */
+class DefaultExternalIpService : ExternalIpService {
+    override fun getExternalIpAddress(): String = URI("https://api.ipify.org/").toURL().readText()
+}

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/ServicesModule.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/ServicesModule.kt
@@ -147,6 +147,9 @@ val servicesModule =
             )
         }
 
+        // Resolves the developer's public IP for scoping security-group SSH ingress to a /32
+        single<ExternalIpService> { DefaultExternalIpService() }
+
         // Command executor for scheduling and executing commands with full lifecycle
         // Note: BackupRestoreService is lazily injected in DefaultCommandExecutor to avoid
         // triggering the AWS dependency chain during setup-profile (when settings.yaml doesn't exist yet)

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/aws/AwsInfrastructureService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/aws/AwsInfrastructureService.kt
@@ -130,10 +130,14 @@ class AwsInfrastructureService(
      * created on repeated Packer builds.
      *
      * @param sshPort SSH port to allow access on
+     * @param sshCidr CIDR allowed to SSH in (the developer's public IP /32)
      * @return VpcInfrastructure containing the IDs of all created/found resources
      */
-    fun ensurePackerInfrastructure(sshPort: Int): VpcInfrastructure {
-        val config = InfrastructureConfig.forPacker(sshPort)
+    fun ensurePackerInfrastructure(
+        sshPort: Int,
+        sshCidr: String,
+    ): VpcInfrastructure {
+        val config = InfrastructureConfig.forPacker(sshPort, sshCidr)
 
         // Check for existing packer VPC first
         val existingVpcId = vpcService.findVpcByName(config.vpcName)

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/aws/AwsS3BucketService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/aws/AwsS3BucketService.kt
@@ -1,11 +1,15 @@
 package com.rustyrazorblade.easydblab.services.aws
 
 import com.rustyrazorblade.easydblab.Constants
+import com.rustyrazorblade.easydblab.Context
+import com.rustyrazorblade.easydblab.configuration.User
+import com.rustyrazorblade.easydblab.configuration.UserConfigProvider
 import com.rustyrazorblade.easydblab.events.Event
 import com.rustyrazorblade.easydblab.events.EventBus
 import com.rustyrazorblade.easydblab.providers.aws.AWS
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
+import java.util.UUID
 
 /**
  * Return value from [AwsS3BucketService.configureDataBucket].
@@ -26,6 +30,38 @@ class AwsS3BucketService(
     private val aws: AWS,
 ) : KoinComponent {
     private val eventBus: EventBus by inject()
+    private val userConfigProvider: UserConfigProvider by inject()
+    private val context: Context by inject()
+
+    /**
+     * Ensures the account-level S3 bucket exists and is recorded in the user config, creating it
+     * if [User.s3Bucket] is blank. Idempotent: returns the existing bucket name if already set.
+     *
+     * This lets profiles that predate (or never completed) bucket setup migrate automatically —
+     * `up` and the AMI build path call this so the bucket (and the S3 build cache it backs) come
+     * online without re-running `setup-profile`.
+     */
+    fun ensureAccountBucket(user: User): String {
+        if (user.s3Bucket.isNotBlank()) {
+            return user.s3Bucket
+        }
+        eventBus.emit(Event.Setup.S3BucketCreating)
+        val bucketName = "easy-db-lab-${UUID.randomUUID()}"
+        aws.createS3Bucket(bucketName)
+        aws.putS3BucketPolicy(bucketName)
+        aws.tagS3Bucket(
+            bucketName,
+            mapOf(
+                "Profile" to context.profile,
+                "Owner" to user.email,
+                "easy_cass_lab" to "1",
+            ),
+        )
+        user.s3Bucket = bucketName
+        userConfigProvider.saveUserConfig(user)
+        eventBus.emit(Event.Setup.S3BucketCreated(bucketName))
+        return bucketName
+    }
 
     /**
      * Creates an S3 bucket with the specified name.

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-    <property name="LOG_DIR" value="${EASY_DB_LAB_USER_DIR:-${user.home}/.easy-db-lab}/logs" />
+    <property name="LOG_DIR" value="${EASY_DB_LAB_LOG_DIR:-${EASY_DB_LAB_USER_DIR:-${user.home}/.easy-db-lab}/logs}" />
 
     <appender name="INFO_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${LOG_DIR}/info.log</file>

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/TestModules.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/TestModules.kt
@@ -18,6 +18,7 @@ import com.rustyrazorblade.easydblab.providers.ssh.RemoteOperationsService
 import com.rustyrazorblade.easydblab.providers.ssh.SSHConfiguration
 import com.rustyrazorblade.easydblab.providers.ssh.SSHConnectionProvider
 import com.rustyrazorblade.easydblab.services.CommandExecutor
+import com.rustyrazorblade.easydblab.services.ExternalIpService
 import com.rustyrazorblade.easydblab.services.aws.AMIValidator
 import com.rustyrazorblade.easydblab.services.aws.AwsS3BucketService
 import com.rustyrazorblade.easydblab.ssh.ISSHClient
@@ -178,6 +179,13 @@ object TestModules {
 
             // AwsS3BucketService using mocked AWS
             single { AwsS3BucketService(get<AWS>()) }
+
+            // Fake external IP resolver so tests never make a network call
+            single<ExternalIpService> {
+                object : ExternalIpService {
+                    override fun getExternalIpAddress(): String = "203.0.113.10"
+                }
+            }
         }
 
     /**

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/commands/SetupProfileTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/commands/SetupProfileTest.kt
@@ -297,8 +297,8 @@ class SetupProfileTest : BaseKoinTest() {
             // Should setup IAM resources
             verify(mockAwsResourceSetup).ensureAWSResources(any())
 
-            // Should create Packer infrastructure
-            verify(mockAwsInfra).ensurePackerInfrastructure(any())
+            // Should create Packer infrastructure, scoping SSH to the developer's IP
+            verify(mockAwsInfra).ensurePackerInfrastructure(any(), any())
         }
 
         @Test

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/providers/aws/AWSCredentialsManagerTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/providers/aws/AWSCredentialsManagerTest.kt
@@ -1,0 +1,53 @@
+package com.rustyrazorblade.easydblab.providers.aws
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
+import java.io.File
+
+/**
+ * Verifies that the credentials file written for the Packer container reflects the credentials
+ * resolved from the AWS provider, including a session token when the credentials are temporary
+ * (the SSO case) and omitting it for long-lived static keys.
+ */
+class AWSCredentialsManagerTest {
+    @Test
+    fun `writes session token when resolved credentials are temporary`(
+        @TempDir tempDir: File,
+    ) {
+        val provider =
+            StaticCredentialsProvider.create(
+                AwsSessionCredentials.create("AKIASSO", "sso-secret", "session-token-123"),
+            )
+        val manager = AWSCredentialsManager(tempDir, provider)
+
+        val contents = manager.credentialsFile.readText()
+
+        assertThat(contents)
+            .contains("[default]")
+            .contains("aws_access_key_id=AKIASSO")
+            .contains("aws_secret_access_key=sso-secret")
+            .contains("aws_session_token=session-token-123")
+    }
+
+    @Test
+    fun `omits session token for static credentials`(
+        @TempDir tempDir: File,
+    ) {
+        val provider =
+            StaticCredentialsProvider.create(
+                AwsBasicCredentials.create("AKIASTATIC", "static-secret"),
+            )
+        val manager = AWSCredentialsManager(tempDir, provider)
+
+        val contents = manager.credentialsFile.readText()
+
+        assertThat(contents)
+            .contains("aws_access_key_id=AKIASTATIC")
+            .contains("aws_secret_access_key=static-secret")
+        assertThat(contents).doesNotContain("aws_session_token")
+    }
+}

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/providers/aws/InfrastructureConfigTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/providers/aws/InfrastructureConfigTest.kt
@@ -185,30 +185,30 @@ class InfrastructureConfigTest {
     inner class ForPacker {
         @Test
         fun `should create single subnet`() {
-            val config = InfrastructureConfig.forPacker(sshPort = 22)
+            val config = InfrastructureConfig.forPacker(sshPort = 22, sshCidr = "203.0.113.10/32")
 
             assertThat(config.subnets).hasSize(1)
             assertThat(config.subnets[0].name).isEqualTo("easy-db-lab-packer-subnet")
         }
 
         @Test
-        fun `should allow SSH from anywhere`() {
-            val config = InfrastructureConfig.forPacker(sshPort = 22)
+        fun `should scope SSH to the provided cidr`() {
+            val config = InfrastructureConfig.forPacker(sshPort = 22, sshCidr = "203.0.113.10/32")
 
             val sshRule = config.securityGroupRules.find { it.fromPort == 22 }
-            assertThat(sshRule?.cidr).isEqualTo("0.0.0.0/0")
+            assertThat(sshRule?.cidr).isEqualTo("203.0.113.10/32")
         }
 
         @Test
         fun `should use correct packer VPC name`() {
-            val config = InfrastructureConfig.forPacker(sshPort = 22)
+            val config = InfrastructureConfig.forPacker(sshPort = 22, sshCidr = "203.0.113.10/32")
 
             assertThat(config.vpcName).isEqualTo(Constants.Vpc.PACKER_VPC_NAME)
         }
 
         @Test
         fun `should use correct naming for packer resources`() {
-            val config = InfrastructureConfig.forPacker(sshPort = 22)
+            val config = InfrastructureConfig.forPacker(sshPort = 22, sshCidr = "203.0.113.10/32")
 
             assertThat(config.securityGroupName).isEqualTo("easy-db-lab-packer-sg")
             assertThat(config.internetGatewayName).isEqualTo("easy-db-lab-packer-igw")
@@ -216,7 +216,7 @@ class InfrastructureConfigTest {
 
         @Test
         fun `should use custom SSH port`() {
-            val config = InfrastructureConfig.forPacker(sshPort = 2222)
+            val config = InfrastructureConfig.forPacker(sshPort = 2222, sshCidr = "203.0.113.10/32")
 
             val sshRule = config.securityGroupRules.first()
             assertThat(sshRule.fromPort).isEqualTo(2222)

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/providers/aws/RetryUtilTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/providers/aws/RetryUtilTest.kt
@@ -1,0 +1,73 @@
+package com.rustyrazorblade.easydblab.providers.aws
+
+import io.github.resilience4j.retry.Retry
+import io.github.resilience4j.retry.RetryConfig
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import software.amazon.awssdk.awscore.exception.AwsErrorDetails
+import software.amazon.awssdk.services.s3.model.S3Exception
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Verifies the retry decision logic for applying an S3 bucket policy: transient IAM-propagation
+ * failures ("Invalid principal" / MalformedPolicy) are retried, while real permission errors are
+ * not. Uses a config with no backoff delay so the test runs instantly.
+ */
+class RetryUtilTest {
+    private fun s3Exception(
+        errorCode: String,
+        statusCode: Int,
+        message: String,
+    ): S3Exception =
+        S3Exception
+            .builder()
+            .awsErrorDetails(AwsErrorDetails.builder().errorCode(errorCode).build())
+            .statusCode(statusCode)
+            .message(message)
+            .build() as S3Exception
+
+    private fun retryNoDelay() =
+        Retry.of(
+            "test",
+            RetryConfig
+                .from<Any>(RetryUtil.createS3BucketPolicyRetryConfig<Unit>())
+                .intervalFunction { 1L }
+                .build(),
+        )
+
+    @Test
+    fun `retries invalid-principal errors until the role propagates`() {
+        val attempts = AtomicInteger(0)
+        val retry = retryNoDelay()
+
+        val result =
+            Retry
+                .decorateSupplier(retry) {
+                    // Fail the first two attempts as if the IAM role is not yet visible, then succeed.
+                    if (attempts.incrementAndGet() < 3) {
+                        throw s3Exception("MalformedPolicy", 400, "Invalid principal in policy")
+                    }
+                    "ok"
+                }.get()
+
+        assertThat(result).isEqualTo("ok")
+        assertThat(attempts.get()).isEqualTo(3)
+    }
+
+    @Test
+    fun `does not retry permission errors`() {
+        val attempts = AtomicInteger(0)
+        val retry = retryNoDelay()
+
+        assertThatThrownBy {
+            Retry
+                .decorateSupplier(retry) {
+                    attempts.incrementAndGet()
+                    throw s3Exception("AccessDenied", 403, "Access Denied")
+                }.get()
+        }.isInstanceOf(S3Exception::class.java)
+
+        assertThat(attempts.get()).isEqualTo(1)
+    }
+}


### PR DESCRIPTION
## Summary

Adds AWS SSO (IAM Identity Center) authentication and makes AMI builds reliable in managed/governed accounts, with an S3-backed build cache for speed.

## Features

- **AWS SSO auth** — authenticate via an SSO profile (set after `aws sso login`), not just static keys. Credentials are resolved live and never stored; the session token is passed to Packer so AMI builds work under SSO.
- **Managed-account AMI builds**:
  - Packer SG allows SSH only from the developer's public `/32` (via the new `ExternalIpService`/ipify), so tools that revoke world-open SSH rules don't break the build.
  - Account S3 bucket policy is applied resiliently (retries IAM eventual consistency via the new `RetryUtil`); terminal failures explain the cause.
  - Build instances use the developer's keypair so they're SSH-able.
- **Fast, reliable builds**:
  - S3-backed build cache (apt archives + pinned downloads: JDK -dbg, k3s airgap, Cassandra dists, MAAC, pyroscope, yq, sjk). The account bucket self-heals on demand.
  - Provisioner output quieted (logs to file) to avoid disrupting Packer's SSH connection.
  - gp3 root volumes; larger base/cassandra volumes.
- **Build diagnostics** — on failure, capture diagnostics over SSH (df, jdk/apt logs, dmesg), print them, and tear down — or keep the instance with `--keep-on-error` / `EASY_DB_LAB_BUILD_KEEP_ON_FAILURE`.
- **Docs** — documented the SSO setup flow in getting-started.

## Architecture

- Add AWS SDK v2 `sso` and `ssooidc` modules so `ProfileCredentialsProvider` resolves SSO sessions.
- `AWSCredentialsManager` resolves credentials through the injected `AwsCredentialsProvider` and writes a session token when present.
- Shared `ExternalIpService` used by both the cluster (`Up`) and Packer paths.
- OpenSpec change `add-aws-sso-support`.