### PR TITLE
test: isolate Koin tests via JVM forks instead of in-JVM parallelism

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -200,10 +200,13 @@ tasks.test {
         html.required.set(true)
     }
 
-    // Single JVM so @Isolated / @ResourceLock can serialise TestContainers tests across classes.
-    // Within-JVM class-level parallelism is configured via junit-platform.properties.
-    maxParallelForks = 1
+    // Parallelism comes from forked JVMs, not in-JVM threads. Each fork has its own Koin
+    // GlobalContext, so isolated tests can never collide on shared global state — which is
+    // why in-JVM parallel execution is disabled in junit-platform.properties. forkEvery
+    // reuses each JVM across many classes to amortise JVM startup cost.
     val processors = Runtime.getRuntime().availableProcessors()
+    maxParallelForks = (processors / 2).coerceAtLeast(1)
+    forkEvery = 100
 
     doFirst {
         environment("EASY_DB_LAB_PROFILE", "default")

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/BaseKoinTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/BaseKoinTest.kt
@@ -2,14 +2,12 @@ package com.rustyrazorblade.easydblab
 
 import org.junit.jupiter.api.extension.RegisterExtension
 import org.junit.jupiter.api.io.TempDir
-import org.junit.jupiter.api.parallel.ResourceLock
 import org.koin.core.module.Module
 import org.koin.test.KoinTest
 import org.koin.test.get
 import org.koin.test.junit5.KoinTestExtension
 import java.io.File
 
-@ResourceLock("koin")
 abstract class BaseKoinTest : KoinTest {
     @TempDir
     lateinit var tempDir: File

--- a/src/test/resources/junit-platform.properties
+++ b/src/test/resources/junit-platform.properties
@@ -1,9 +1,6 @@
-# Single JVM (maxParallelForks=1 in build.gradle.kts) means all tests share one
-# Koin context and one Docker daemon. Parallel class execution is enabled so unit tests
-# run fast; @Isolated on container-using classes gives each one exclusive access to
-# Docker, preventing LocalStack/Redis races.
-junit.jupiter.execution.parallel.enabled=true
-junit.jupiter.execution.parallel.mode.default=same_thread
-junit.jupiter.execution.parallel.mode.classes.default=concurrent
-junit.jupiter.execution.parallel.config.strategy=fixed
-junit.jupiter.execution.parallel.config.fixed.parallelism=4
+# Parallelism comes from forked JVMs (maxParallelForks in build.gradle.kts), each with its
+# own Koin GlobalContext, so isolated tests never share global state. In-JVM parallel
+# execution is disabled on purpose: running multiple tests concurrently in a single JVM
+# would collide on Koin's single global context (which is why the old setup needed a
+# @ResourceLock around BaseKoinTest).
+junit.jupiter.execution.parallel.enabled=false


### PR DESCRIPTION
## Summary

Class-level in-JVM parallelism (`parallel.mode.classes.default=concurrent`) forced a `@ResourceLock("koin")` on `BaseKoinTest`, because every test resolves through Koin's single global context (`GlobalContext._koin`) and concurrent classes in one JVM collide on it. The lock then serialized all DI tests against each other, so the in-JVM parallelism bought little.

This switches parallelism to **forked JVMs**: each fork gets its own `GlobalContext`, so isolated tests can't share global state — process isolation instead of in-JVM thread isolation.

## Changes

- **Remove `@ResourceLock("koin")`** from `BaseKoinTest` (and its unused import).
- **Disable in-JVM parallel execution** — `junit-platform.properties` is now just `parallel.enabled=false`.
- **Parallelize via forks** — `maxParallelForks = (processors/2).coerceAtLeast(1)`, with `forkEvery = 100` to amortize JVM startup.

## Why this is the supported shape

Koin's documented testing model is single-global-context with start/stop per test — it never positions itself for parallel in-JVM isolated tests. Forked JVMs are isolated by construction, so no production change, no lock, and the documented Koin test pattern stays intact. Testcontainers tests are fork-safe here (random ports, shared host daemon, no fixed port bindings).