### PR TITLE
fix: `up` must fail fast; SOCKS tunnel must not die silently (#734)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,7 @@
 - Do not add logging frameworks to command classes unless there is a specific internal debugging need separate from user output.
 - When logging is needed, use: `import io.github.oshai.kotlinlogging.KotlinLogging` and create a logger with `private val log = KotlinLogging.logger {}`
 - **Never use Python for JSON parsing in shell scripts.** Use `jq` instead.
+- **ABSOLUTE RULE: NEVER set, clear, or otherwise touch the `socksProxyHost` / `socksProxyPort` JVM system properties.** Not even temporarily with save/restore. These are JVM-global and capture **every** socket in the process — including the AWS SDK — routing it through the SOCKS tunnel. This caused a major incident and was deliberately removed in #725 (see the commit message and the `Socks5ProxySelector` KDoc). The proxy publishes **only** its port under `Constants.Proxy.PORT_PROPERTY`; cluster clients opt into the tunnel **explicitly and per-client** — Fabric8 via `config.httpsProxy = "socks5://127.0.0.1:{port}"` (`KubernetesClientFactory`), cluster HTTP via `Socks5ProxySelector` installed on that client only (`ProxiedHttpClientFactory`), the CQL driver via `SocksProxyNettyOptions`. To route a **new** client type (e.g. JDBC) through the tunnel, give **that connection** an explicit `java.net.Proxy(SOCKS, ...)` / driver-native SOCKS option — never a global property. This invariant is also encoded in `openspec/specs/networking/spec.md` REQ-NET-005.
 
 ## Project Organization
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -107,6 +107,12 @@ easy-db-lab up [options]
 
 Creates: VPC, EC2 instances, K3s cluster. Configures the account S3 bucket for this cluster.
 
+`up` fails fast. If any provisioning step fails — EC2 setup, K3s, node labeling, the
+`local-storage`/`local-storage-wfc` StorageClasses, the observability stack, Tailscale, and so
+on — the command exits non-zero and stops rather than continuing with a partially-provisioned
+cluster. EC2 instances that were already launched are left running; there is no automatic
+rollback. Reclaim them with `easy-db-lab down`, fix the underlying issue, and re-run `up`.
+
 ### down
 
 Shut down AWS infrastructure.
@@ -148,6 +154,15 @@ Display full environment status.
 ```bash
 easy-db-lab status
 ```
+
+`status` is the one command that degrades instead of failing outright when the SOCKS proxy
+tunnel can't be established. It still reports EC2, VPC, security groups, Spark/EMR, OpenSearch,
+S3, kits, observability URLs, and database versions — the last read directly over SSH, which
+never uses the tunnel. Only the sections that require the private Kubernetes API (stress jobs,
+ClickHouse) are marked unavailable, each stating the proxy failure as the reason. `status` still
+exits non-zero when degraded, so a partial report is never mistaken for a healthy cluster by a
+script. See [Network Connectivity](../user-guide/network-connectivity.md) for how to diagnose a
+tunnel that won't come up.
 
 ---
 

--- a/docs/user-guide/network-connectivity.md
+++ b/docs/user-guide/network-connectivity.md
@@ -170,6 +170,38 @@ socks5-status         # Check status
 stop-socks5           # Stop proxy
 ```
 
+### Host Key Verification
+
+The `sshConfig` generated for your cluster sets `UserKnownHostsFile=/dev/null` alongside
+`StrictHostKeyChecking=no`. `ssh` — and therefore the SOCKS tunnel, which is launched with
+`ssh -N -D` against that config — never reads or writes your `~/.ssh/known_hosts` for cluster
+nodes.
+
+This matters because AWS recycles public IPs across ephemeral cluster lifetimes. Without this
+setting, a recycled IP that previously belonged to a different cluster (with a different host
+key) would make `ssh` hard-fail with `REMOTE HOST IDENTIFICATION HAS CHANGED` — `StrictHostKeyChecking=no`
+only auto-adds *unknown* hosts, it doesn't override a *changed* key for a host already recorded.
+Every cluster is short-lived and gets fresh host keys on every provision, so there is nothing to
+verify against across runs.
+
+If you connected to easy-db-lab clusters before this change, their host keys may still be in
+your `~/.ssh/known_hosts`. They're no longer read by the tool, so you can prune them any time —
+look for entries matching your cluster's `Hostname` lines in the generated `sshConfig`.
+
+### Tunnel Failures
+
+If the SOCKS tunnel can't be established, the command that needed it fails immediately with a
+non-zero exit code rather than silently continuing against a proxy port nothing is listening on.
+The error names the SOCKS proxy as the failing component and points at `socks5-proxy.log` in
+your cluster workspace directory — that file holds the `ssh -v` transcript from the tunnel
+attempt and is the fastest way to find the real cause (a host-key mismatch, a security group
+blocking port 22, the control node not yet accepting SSH, and so on).
+
+`easy-db-lab status` is the one exception: it still reports everything it can reach over SSH and
+the AWS SDK even when the tunnel is down, marking only the sections that require the private
+Kubernetes API (stress jobs, ClickHouse) as unavailable. See the
+[`status` command reference](../reference/commands.md#status) for details.
+
 ### Troubleshooting SOCKS Proxy
 
 **"Connection refused" errors:**
@@ -195,6 +227,14 @@ start-socks5 1081     # Use different port
 1. Check cluster status: `easy-db-lab status`
 2. Verify SSH works: `ssh control0 hostname`
 3. Restart proxy: `stop-socks5 && start-socks5`
+
+**`easy-db-lab` command fails with a SOCKS proxy error:**
+As of this change, `easy-db-lab` commands that need the tunnel (`up`, kit commands, Grafana
+config updates, etc.) abort immediately if the tunnel can't be established, instead of silently
+running against a dead proxy port. Check `socks5-proxy.log` in your cluster workspace directory
+for the `ssh -v` transcript — it shows the actual reason the tunnel failed. See
+[Host Key Verification](#host-key-verification) above for the most common cause on a
+newly-provisioned cluster.
 
 ## Comparison
 

--- a/docs/user-guide/tutorial.md
+++ b/docs/user-guide/tutorial.md
@@ -101,6 +101,14 @@ This command creates:
 5. Configures K3s cluster on all nodes
 6. Writes SSH config and environment files
 
+```admonish warning title="up fails fast"
+If any step fails — EC2 setup, K3s, node labeling, StorageClasses, the observability stack,
+Tailscale — `up` aborts with a non-zero exit code instead of continuing with a
+partially-provisioned cluster. EC2 instances already launched are left running; clusters are
+ephemeral and there's no automatic rollback. Reclaim them with `easy-db-lab down`, fix the
+underlying issue, and re-run `up`.
+```
+
 ### Up Options
 
 | Option | Description |

--- a/openspec/changes/up-fail-fast/.openspec.yaml
+++ b/openspec/changes/up-fail-fast/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-09

--- a/openspec/changes/up-fail-fast/design.md
+++ b/openspec/changes/up-fail-fast/design.md
@@ -1,0 +1,179 @@
+## Context
+
+`init --up` exits 0 having provisioned a cluster with no observability stack, no `local-storage` StorageClasses, and no node labels (GitHub issue #734).
+
+The failure chain:
+
+```
+sshConfig sets StrictHostKeyChecking=no, no UserKnownHostsFile
+        │  ssh -N -D reads ~/.ssh/known_hosts; MINA SSHD (everything else) reads nothing
+        │  AWS recycles public IPs → changed host key → ssh exits immediately
+        ▼
+verifyProxyAcceptingConnections() logs "proceeding anyway", returns Unit
+        │
+        ▼
+applySystemProperties(1080) publishes a port nothing is listening on
+        │
+        ▼
+Fabric8 calls → Connection refused: localhost:1080
+        │  labelNode, ensureLocalStorageClass, ensureLocalStorageWfcClass,
+        │  GrafanaUpdateConfig — all proxied, all failed
+        ▼
+14 swallow sites in Up.kt turn each exception into a log line
+        │
+        ▼
+printProvisioningSuccessMessage(); exit 0
+```
+
+Two asymmetries make this invisible. First, only the `ssh` CLI consults `~/.ssh/known_hosts` — `DefaultSSHConnectionProvider` uses Apache MINA SSHD, and nothing in the repo calls `setServerKeyVerifier`, so it runs the default `AcceptAllServerKeyVerifier`. `SetupInstance` and the K3s install therefore connect to the control node successfully moments before the tunnel to that same node dies. Second, `ProcessSocksProxyService.startNewProxy()` carries a comment stating *"The new port is republished by applySystemProperties() only after the proxy is verified"* directly above code that republishes it unconditionally. The contract was written and never implemented.
+
+The blast radius is wider than the reported symptom: `labelNode`, `ensureLocalStorageClass`, and `ensureLocalStorageWfcClass` are Fabric8 calls through the same dead tunnel. A cluster provisioned this way is missing its `type=control` label, all db/app node ordinals (breaking StatefulSet pod-to-node pinning for every kit), and both StorageClasses (PVCs never bind).
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Establish and enforce the invariant: **if `up` reports success, every provisioning step succeeded.**
+- Fix the root cause — the `ssh` CLI must not consult the developer's `~/.ssh/known_hosts`.
+- Make the proxy fail loudly rather than publishing a port nothing listens on.
+- Make the proxy pre-flight opt-in, so no command starts a tunnel it does not need.
+- Move the two cluster shape invariants (control node exists, S3 bucket configured) ahead of EC2 provisioning.
+- Confirm control-node SSH readiness before anything depends on connecting to it.
+
+**Non-Goals:**
+
+- Fixing MINA SSHD's `AcceptAllServerKeyVerifier`. The library SSH path verifies no host keys at all. This change makes the CLI path *match* that behavior rather than diverge from it; making both verify properly is a separate, larger change.
+- `grafana update-config` dropping kit-installed dashboards (noted in #734).
+- `Down.cleanupSocks5Proxy()` resolving its state file against cwd instead of `context.workingDirectory` (issue #738).
+- Rolling back partially-provisioned infrastructure on failure. `up` aborts; the user runs `down`. Clusters are ephemeral.
+- Retrying a proxy that fails to establish. Fail fast, surface `socks5-proxy.log`.
+
+## Decisions
+
+### D1: `UserKnownHostsFile=/dev/null` rather than a per-workspace `known_hosts`
+
+`ClusterConfigWriter.writeSshConfig()` emits `UserKnownHostsFile=/dev/null` alongside the existing `StrictHostKeyChecking=no`.
+
+`StrictHostKeyChecking=no` only auto-adds *unknown* hosts; a host already present under a different key still hard-fails with `REMOTE HOST IDENTIFICATION HAS CHANGED`. Since `sshConfig` writes `Hostname <publicIp>` and AWS recycles public IPs, entries collide across cluster lifetimes.
+
+*Alternative considered:* a per-workspace `known_hosts` file (`UserKnownHostsFile <workdir>/known_hosts`), which dies with the cluster and would catch a host key changing *within* a single cluster's lifetime. Rejected: it costs the same one line but only *appears* to add safety, because MINA SSHD accepts any key on the very same hosts. Real host-key verification means fixing both paths, which is out of scope. `/dev/null` is the honest expression of what the system actually does today, and it stops writing to the developer's file.
+
+### D2: Fail-fast is expressed by letting exceptions propagate, not by collecting errors
+
+Every swallow site in `Up.kt` becomes a propagating failure. `installCilium()`'s existing `.getOrThrow()` is the precedent.
+
+- `Result`-returning calls: `.getOrThrow()`.
+- Nested `commandExecutor.execute { }` calls: check the returned `Int`; non-zero throws.
+- `k3sClusterService.setupCluster()`: `if (!result.isSuccessful)` throws after logging each operation error.
+
+*Alternative considered:* accumulate failures and report them all at the end of `up`. Rejected: provisioning steps are sequential and dependent — K3s setup failing makes every subsequent K8s call fail too, so an accumulated report is mostly noise derived from the first failure. Aborting at the first failure names the actual cause. It also matches the owner's stated rule: *"If something fails, it should fail fast."*
+
+`DefaultCommandExecutor.executeWithLifecycle()` already catches, logs the cause chain, emits `Event.Command.ExecutionError`, and returns a non-zero exit code. `Up` calling nested commands must therefore inspect the return value rather than rely on an exception escaping — the executor has already absorbed it.
+
+### D3: A new `Up`-local helper for nested command exit codes
+
+Four call sites (`WriteConfig`, `SetupInstance`, `ConfigureAxonOps`, `GrafanaUpdateConfig`) discard `commandExecutor.execute { }`'s `Int`. Rather than repeat the check, `Up` gains a private helper that runs a nested command and throws when the exit code is non-zero, naming the command in the error.
+
+This keeps the fix in one place and makes a future discarded exit code visibly anomalous.
+
+### D4: Cluster shape invariants validate before provisioning, and the downstream guards are deleted
+
+`up` today discovers a missing control node at `startK3sOnAllNodes()`, emits `NoControlNodes`, returns, and skips K3s, Cilium, node labeling, both StorageClasses, and observability — then exits 0. `configureRegistryTls()` and `installCilium()` carry their own `controlHosts.isEmpty()` guards.
+
+A control node and an S3 bucket are required. Validation moves ahead of EC2 provisioning, so an unsatisfiable configuration fails before instances are launched. The three downstream `isEmpty()` guards are then unreachable and are **removed** rather than left as dead defensive code — a guard that silently does nothing is how this class of bug survives.
+
+*Alternative considered:* keep the guards and make them throw. Rejected: three places asserting the same invariant is three places for it to drift, and the failure would still arrive after paying for EC2 instances.
+
+### D5: Zero db nodes is legal; the warning is the bug
+
+`up` with zero db nodes is a supported configuration (Trino + OpenSearch). The skip at db-node labeling stays; `log.warn { "No db nodes found..." }` drops to `log.debug`.
+
+Once warnings in `up` reliably mean "something is off," a warning on a normal configuration trains the user to ignore them. This is the same disease as the swallow, in the logging layer.
+
+### D6: `NodeLabelingComplete` is emitted only on success
+
+`Event.Provision.NodeLabelingComplete` is currently emitted unconditionally after `labelNode(...).getOrElse { log.warn }`. It is the line users read as the last-good checkpoint before the failure in #734 — and it asserts an outcome it never checked.
+
+Once labeling propagates failure (D2), reaching the emit implies success. This is a consequence of D2, not a separate mechanism, but it is called out because the misleading event is what made the issue hard to diagnose.
+
+### D7: `@RequiresProxy` opt-in over `@NoProxy` opt-out
+
+`DefaultCommandExecutor.ensureProxyRunning()` fires for **every** command, gated only on cluster state, and catches → `log.warn "proceeding without proxy"`. Its KDoc justifies the catch on the grounds that *"the proxy may not be reachable during teardown"* — but `Down.kt:93-102` unpublishes the proxy port and kills the ssh process as its **first two actions**. The pre-flight starts a tunnel that `Down` exists to tear down. The swallow existed to make that contradiction survivable.
+
+A new `@RequiresProxy` class annotation, checked in `checkRequirements()` alongside `@RequireDocker` / `@RequireSSHKey` / `@RequireProfileSetup`, declares the dependency. `ensureProxyRunning()` runs only for annotated commands and stops catching — safe precisely because the annotation *is* the assertion that the proxy is required.
+
+*Alternative considered:* `@NoProxy` opt-out on `Down`. Rejected on failure-mode asymmetry: a missed `@NoProxy` makes a working command start failing (a regression), while a missed `@RequiresProxy` makes a command fail exactly the way it does today (no worse than status quo). Opt-in also matches the three existing `@Require*` annotations.
+
+**Commands requiring the annotation** — those whose execution path reaches Fabric8 (`K8sClientProvider`) or `ProxiedHttpClientFactory`:
+
+`Up`, `Status`, `GrafanaInstall`, `GrafanaUpdateConfig`, `PlatformCreatePvs`, `KitInstallCommand`, `KitRunnerCommand`, `KitStatusCommand`, `LogsBackup`, `MetricsBackup`, `cassandra/Start`, `cassandra/Stop`, `cassandra/Restart`, and the `cassandra/stress/*` family (`StressStart`, `StressStop`, `StressStatus`, `StressList`, `StressLogs`, `StressInfo`, `StressFields`).
+
+`Down` is **not** annotated. The annotation must be applied by verified execution path, not by guessing from the command name — the task list treats this as an audit with a mechanical criterion, since a missed annotation degrades to today's behavior rather than a new failure.
+
+Note that commands driving remote tooling through `RemoteOperationsService` (helm, kubectl, cilium run *on* the control node over SSH) do **not** need the proxy — only local Fabric8 and local HTTP to private cluster IPs do.
+
+Implementation widened the set from the ~20 identified by grep to **25**: `LogsQuery`, `LogsImport`, `MetricsImport`, `SparkLogs`, and `Server` also qualify. `Server` reaches Fabric8 only transitively (`Server` → `McpServer` → `StatusCache` → `K8sService`).
+
+**No test enforces that the annotation is applied.** A guard test was written and deleted. Every form it can take is a list masquerading as a check: reflecting over injected properties requires a hand-maintained set of "proxy-reaching" service types, and bytecode reachability over-approximates, requiring a hand-maintained suppression list for its false positives. Both pass indefinitely while covering less and less as the codebase moves. The annotation is applied by reading the execution path, and D7's opt-in choice is what makes that safe: a missed annotation reproduces today's behaviour (a confusing Fabric8 error) rather than breaking a working command. That benign failure mode is the reason opt-in was chosen, so buying insurance against it with a decaying test is a bad trade.
+
+### D8: The proxy verifies before it publishes, and verifies before it reuses
+
+`ProcessSocksProxyService`:
+
+- `verifyProxyAcceptingConnections()` throws when the port never opens, so `applySystemProperties(port)` is unreachable on failure. The existing `System.clearProperty()` at the top of `startNewProxy()` already ensures no stale port survives, so clients fall back to no-proxy rather than a dead one. This makes the code honor the comment already above it.
+- The thrown error names the proxy as the failing component and points at `socks5-proxy.log`, which holds `ssh -v` stderr — the transcript that would have identified the host-key failure immediately.
+- `isValidProxy()` currently checks PID-alive, `controlIP`, and `sshConfig` path, but never the port. `isRunning()` *does* check the port. A zombie `ssh` — process alive, tunnel dead — is therefore reused and its dead port republished, which is a second door to the same silent failure. `isValidProxy()` gains an `isPortAccepting()` check.
+- `startNewProxy()`'s `ProcessBuilder` dials the string literal `"control0"` while holding a `gatewayHost` it uses only for logging. It uses `gatewayHost.alias`.
+
+Two consequences surfaced during implementation, both inside this decision:
+
+- **The in-memory fast path is a third door.** `ensureRunning()` short-circuits on `if (current != null && isAlive(pid))` *before* `isValidProxy()` is consulted. Fixing only `isValidProxy()` would still let a long-lived `Server` or `Repl` session reuse a zombie tunnel. The fast path must check `isPortAccepting()` too. PID-alive is never sufficient evidence that a tunnel is alive, at any of the three sites that ask.
+- **Throwing before the state-file write leaks the ssh process.** The state file records the PID that `Down` uses for cleanup. Once `verifyProxyAcceptingConnections()` throws, that write is skipped, so a spawned-but-unverified `ssh` would survive untracked. `startNewProxy()` must `destroyForcibly()` the process before rethrowing. Failing fast must not fail dirty.
+
+### D9: `Status` degrades rather than failing — the one permitted exception
+
+`Status` reaches Fabric8 and therefore carries `@RequiresProxy`. Under D7 + D8 a proxy failure would abort it. But `status` is the command a user reaches for *when the cluster is misbehaving*, so failing fast removes the diagnostic exactly when it is needed.
+
+`Status` catches proxy establishment failure, reports every section it can still observe, and marks only the genuinely unreachable ones unavailable with the reason. It exits non-zero, so a partial report is never mistaken by a script for a healthy cluster.
+
+Unavailability follows the **transport**, not a hand-picked section list. `Status`'s sections split cleanly:
+
+```
+cluster / nodes / networking   cluster state + AWS SDK            no tunnel
+database version               remoteOperationsService (SSH)      no tunnel
+kubernetes / workloads         Fabric8 via K8sClientProvider      TUNNEL
+```
+
+SSH never traverses the SOCKS tunnel — the tunnel exists to reach the private *Kubernetes API*, not the nodes' sshd. So only the Kubernetes and workload sections may be marked unavailable; database versions still render over SSH.
+
+This also dictates the structure: there is **no separate degraded rendering routine**. A second path listing which sections to render would drift — a new SSH-backed section added to the healthy report would silently go missing from the degraded one, and nothing would catch it. Instead the single rendering path guards only the Kubernetes-API-backed sections, emitting `Event.Status.SectionUnavailable` in their place when the proxy failed.
+
+This is a swallow. It is narrow, deliberate, specified, and confined to a **read-only** command that mutates nothing — reporting partial state cannot leave the cluster in an unexpected condition. It is recorded here rather than left implicit precisely because unrecorded exceptions of exactly this shape are how the fourteen swallow sites accumulated. No state-mutating command may take it.
+
+*Alternative considered:* fail fast like every other `@RequiresProxy` command, letting the proxy error message (which names `socks5-proxy.log`) serve as the diagnosis. Rejected: it is a coherent position, but it costs the user all visibility into EC2 and VPC state in the situation where they most need it, and the proxy error alone cannot distinguish "tunnel broken" from "instances gone."
+
+### D10: Control node joins the SSH readiness wait; the version download does not
+
+`waitForSshAndDownloadVersions()` retries SSH against `ServerType.Cassandra` hosts only, and within the same block downloads `/etc/cassandra_versions.yaml`. The control node — which the tunnel dials — is never checked.
+
+The two concerns separate: the control node needs a **readiness check**, not the version download, which is meaningful only for db hosts. The readiness wait covers control and db hosts; the download stays scoped to db hosts.
+
+This is an independent real bug. It is **not** the cause of #734 — control's `sshd` was demonstrably accepting connections, since `SetupInstance` (which SSHes to control as its final step) and the K3s install both succeeded immediately beforehand. It is fixed here because it is a genuine gap on the same path, not because it explains the incident.
+
+## Risks / Trade-offs
+
+**`Status`'s permitted swallow could be cited as precedent for reintroducing others** → D9 is a real exception to the invariant, and exceptions grow. Mitigation: the spec states the exception's boundary normatively — read-only commands only, no state-mutating command may take it — and `Status` still exits non-zero, so it cannot be mistaken for success. The exception is specified rather than implied, which is the difference between D9 and the fourteen sites this change removes.
+
+**Previously "successful" provisions will start failing** → Intended. Any `up` that now fails was already producing a degraded cluster; the change makes existing breakage visible rather than introducing it. Because clusters are ephemeral, there is no migration burden — the remedy is `down` and re-provision.
+
+**`UserKnownHostsFile=/dev/null` removes all host-key verification from the `ssh` CLI path** → A MITM on the path to a public EC2 IP becomes undetectable. Mitigation: this is already true of every other SSH in the system via MINA's `AcceptAllServerKeyVerifier`, so the change closes a divergence rather than opening a hole. Fixing verification properly is scoped as a separate issue.
+
+**A missed `@RequiresProxy` annotation leaves a command without a tunnel** → Degrades to today's behavior: a confusing Fabric8 error rather than a clear one. Mitigation: the audit uses a mechanical criterion (does the execution path reach `K8sClientProvider` or `ProxiedHttpClientFactory`), and a test asserts that every command reaching those services carries the annotation.
+
+**Aborting mid-`up` leaves EC2 instances running** → Accepted, and preferable to a silently degraded cluster. Instances are ephemeral and `down` reclaims them. Moving the shape invariants ahead of provisioning (D4) means the two most likely configuration failures now cost nothing.
+
+**Tailscale startup failure now aborts `up`** → Previously it warned and printed manual-setup instructions. Under the invariant, a requested networking path that fails to come up is a failed provision. The manual-setup instruction is preserved in the error message rather than dropped.
+
+## Open Questions
+
+None outstanding. `Status`'s behavior on proxy failure is resolved in D9: it degrades rather than failing, as the single specified exception, confined to read-only commands.

--- a/openspec/changes/up-fail-fast/proposal.md
+++ b/openspec/changes/up-fail-fast/proposal.md
@@ -1,0 +1,80 @@
+# Proposal: `up` fails fast; the SOCKS tunnel never dies silently
+
+## Why
+
+`init --up` can exit 0 having provisioned a cluster with **no observability stack, no `local-storage` StorageClasses, and no node labels**. The user is told the cluster is ready. It is not.
+
+Three defects compound (GitHub issue #734):
+
+1. The generated `sshConfig` sets `StrictHostKeyChecking=no` but never sets `UserKnownHostsFile`, so the `ssh -N -D` SOCKS tunnel consults the developer's `~/.ssh/known_hosts`. Every *other* SSH in the codebase goes through Apache MINA SSHD, which uses the default `AcceptAllServerKeyVerifier` and reads no known-hosts file. `StrictHostKeyChecking=no` auto-adds *unknown* hosts; it does **not** bypass a *changed* key for a known host. AWS recycles public EC2 IPs and `sshConfig` keys `Hostname` by `publicIp`, so on a recycled IP `ssh` hard-fails with `REMOTE HOST IDENTIFICATION HAS CHANGED` and exits. The tunnel never opens.
+2. `ProcessSocksProxyService` publishes the proxy port anyway — despite a comment promising it would not — so every Fabric8 call gets `Connection refused: localhost:1080`.
+3. `Up.kt` swallows those failures at fourteen separate sites, each turning an exception into a log line, and then reports success.
+
+The governing invariant this change establishes:
+
+> **If `up` reports success, every provisioning step succeeded.** There is never a valid case for a step to fail during `up` and for provisioning to continue.
+
+Silent partial success is the worst possible outcome for a provisioning tool: the cluster looks healthy, the missing StorageClasses and node labels surface hours later as unrelated-looking failures, and the absent observability stack reads as "observability is broken in the product" rather than "observability was never deployed."
+
+## What Changes
+
+**Host-key verification (root cause).** The generated `sshConfig` gains `UserKnownHostsFile=/dev/null` alongside the existing `StrictHostKeyChecking=no`. The `ssh` CLI stops consulting — and stops writing to — the developer's `~/.ssh/known_hosts`, matching the accept-all behavior the MINA SSHD path has always had. Clusters are ephemeral and get fresh host keys on every provision.
+
+**`up` fails fast.** All fourteen swallow sites in `Up.kt` propagate failure. `installCilium()`'s existing `.getOrThrow()` is the precedent every other site follows. Specifically:
+
+- Discarded `commandExecutor.execute { }` exit codes (`WriteConfig`, `SetupInstance`, `ConfigureAxonOps`, `GrafanaUpdateConfig`) are checked and abort on non-zero.
+- `writeConfigurationFiles()`, `k3sClusterService.setupCluster()`, `ensureLocalStorageClass()`, `ensureLocalStorageWfcClass()`, `labelNode()` (×3), `reapplyS3Policy()`, and `TailscaleStart()` abort on failure instead of logging and continuing.
+- `Event.Provision.NodeLabelingComplete` is emitted only when labeling actually succeeded. Today it is emitted unconditionally — the log line users read as the last-good checkpoint asserts an outcome it never checked.
+
+**Two cluster invariants move before provisioning.** A cluster must have a control node, and an S3 bucket must be configured. Both are validated *before* EC2 instances are launched, rather than discovered mid-`up` and silently skipped. This removes the `controlHosts.isEmpty()` guards that currently cause `up` to skip all of K3s, Cilium, node labeling, StorageClasses, and observability while still exiting 0.
+
+A cluster with **zero db nodes remains legal** (a Trino + OpenSearch cluster has nothing to pin), so db-node labeling is still skipped — but silently. A normal configuration must not emit a warning.
+
+**The proxy fails fast.** `ProcessSocksProxyService.startNewProxy()` throws when the local port never opens, so the dead port is never published — honoring the contract its own comment already documents. `isValidProxy()` verifies the port is accepting before reusing a proxy, not merely that the PID is alive; a zombie `ssh` (process up, tunnel dead) is no longer reused. `startNewProxy()` dials `gatewayHost.alias` rather than the hardcoded string literal `"control0"`.
+
+**The proxy pre-flight becomes opt-in.** A new `@RequiresProxy` annotation, checked in `CommandExecutor.checkRequirements()` alongside the existing `@RequireDocker` / `@RequireSSHKey` / `@RequireProfileSetup`, declares which commands reach the private K8s API. `ensureProxyRunning()` stops catching and lets failure propagate — safe precisely because the annotation *is* the assertion that the proxy is required. `Down` does not declare it: its first two actions are to unpublish the proxy port and kill the ssh process, so the pre-flight was starting a tunnel that `Down` exists to tear down. That contradiction is what forced the swallow.
+
+**`status` degrades rather than failing.** `Status` reaches Fabric8 and so declares `@RequiresProxy`, but it is the command a user reaches for *when the cluster is misbehaving*. It catches proxy establishment failure, reports EC2 and VPC state, marks the Kubernetes, workload, and database-version sections unavailable with the reason, and exits non-zero. This is the single specified exception to the invariant, permitted because `Status` is read-only and mutates nothing. No state-mutating command may take it.
+
+**The SSH readiness wait covers control nodes.** `waitForSshAndDownloadVersions()` waits only on `ServerType.Cassandra` hosts today; the control node — which the tunnel dials — is never checked. This is an independent real bug. It is *not* the cause of issue #734 (control's `sshd` was demonstrably accepting connections, since `SetupInstance` and the K3s install both SSH to it successfully moments earlier), but it is a genuine gap.
+
+**BREAKING**: `up` now exits non-zero on failures it previously logged and ignored. Configurations that appeared to succeed while silently producing a degraded cluster will now fail loudly. This is the intent of the change.
+
+## Capabilities
+
+### New Capabilities
+
+None. The behavior belongs to two existing capabilities.
+
+### Modified Capabilities
+
+- `cluster-lifecycle`: Modifies `REQ-CL-004: Cluster Status` so `status` degrades rather than failing when the cluster API is unreachable, reporting what it can observe and marking the rest unavailable. Adds the governing invariant — `up` MUST exit non-zero when any provisioning step fails, and MUST NOT report success on partial provisioning. Adds the two pre-provisioning cluster invariants (a control node exists; an S3 bucket is configured) and codifies zero db nodes as a legal configuration.
+- `networking`: `REQ-NET-005: SOCKS Proxy` currently has five scenarios, all happy-path or reuse. None specify behavior when the proxy cannot be established. Adds failure scenarios: a proxy that cannot be verified fails the command and never publishes its port; a live PID with a dead port is not reused; commands that do not declare `@RequiresProxy` never start a proxy. Also specifies that generated SSH configuration must not depend on the developer's `~/.ssh/known_hosts`.
+
+## Impact
+
+**Code**
+
+- `commands/Up.kt` — fourteen swallow sites; `NodeLabelingComplete` emission; control node added to the SSH readiness wait.
+- `configuration/ClusterConfigWriter.kt` — `writeSshConfig()` emits `UserKnownHostsFile=/dev/null`.
+- `proxy/ProcessSocksProxyService.kt` — `verifyProxyAcceptingConnections()` throws; `isValidProxy()` checks the port; `startNewProxy()` uses `gatewayHost.alias`.
+- `services/CommandExecutor.kt` — `ensureProxyRunning()` gated on `@RequiresProxy`, stops catching.
+- `annotations/RequiresProxy.kt` — new annotation.
+- `commands/*` — audit of which commands reach the private K8s API (Fabric8 / kubectl) and must be annotated. `Down` is explicitly not annotated.
+- `events/Event.kt` — `Provision` events for the new pre-provisioning validation failures.
+
+**Behavior**
+
+- `up` exits non-zero where it previously exited 0 with a degraded cluster.
+- Commands not annotated `@RequiresProxy` no longer start a SOCKS tunnel. `Down` no longer starts a tunnel it immediately destroys.
+- `ssh` no longer writes host keys into the developer's `~/.ssh/known_hosts`, and no longer fails when an ephemeral cluster lands on a recycled public IP.
+
+**Docs**
+
+- User-facing documentation for `up` failure semantics and the `known_hosts` behavior change.
+
+**Explicitly out of scope**
+
+- `grafana update-config` dropping kit-installed dashboards (noted in #734, deferred).
+- MINA SSHD's `AcceptAllServerKeyVerifier` — the library SSH path verifies no host keys at all. Separate issue.
+- `Down.cleanupSocks5Proxy()` resolving its state file against cwd rather than `context.workingDirectory` — filed as issue #738.

--- a/openspec/changes/up-fail-fast/specs/cluster-lifecycle/spec.md
+++ b/openspec/changes/up-fail-fast/specs/cluster-lifecycle/spec.md
@@ -1,0 +1,123 @@
+## MODIFIED Requirements
+
+### REQ-CL-004: Cluster Status
+
+The system MUST provide comprehensive status of cluster resources including nodes, networking, Kubernetes pods, and running workloads.
+
+`status` is the command a user reaches for when the cluster is not behaving, so it MUST remain useful when parts of the cluster are unreachable. Unlike every other command, `status` MUST NOT fail when the SOCKS proxy cannot be established. It MUST instead report every section it can still observe, and mark each unavailable section with the reason it could not be read.
+
+A section is unavailable only when the transport it actually depends on is unavailable. Sections sourced from cluster state, the AWS APIs, or direct SSH to the nodes MUST still be reported when the SOCKS proxy is down — SSH never traverses the tunnel. Only sections sourced from the private Kubernetes API may be marked unavailable on a proxy failure.
+
+This is the single deliberate exception to the rule that an unreachable cluster API fails the command. It is permitted because `status` is read-only: it changes no state, and reporting partial state cannot leave the cluster in an unexpected condition. No command that mutates state may take this exception.
+
+#### Scenario: Full status on a healthy cluster
+- **GIVEN** a running cluster
+- **WHEN** the user checks status
+- **THEN** the state of EC2 instances, VPC networking, K8s pods, stress jobs, and database versions SHALL be displayed
+
+#### Scenario: Status degrades when the cluster API is unreachable
+- **GIVEN** a running cluster whose SOCKS proxy cannot be established
+- **WHEN** the user checks status
+- **THEN** `status` SHALL report EC2 instance state, VPC networking state, and database versions, none of which depend on the tunnel
+- **AND** only the Kubernetes and workload sections SHALL be marked unavailable
+- **AND** each unavailable section SHALL state why it could not be read, referencing the proxy failure
+- **AND** `status` SHALL NOT abort before reporting the sections it can observe
+
+#### Scenario: Degraded and healthy reports share one rendering path
+- **WHEN** `status` renders a report, degraded or not
+- **THEN** every section not sourced from the private Kubernetes API SHALL be rendered by the same code path in both cases
+- **AND** a section added to the healthy report SHALL appear in the degraded report without further change, unless it depends on the private Kubernetes API
+
+#### Scenario: Degraded status is still an unsuccessful command
+- **GIVEN** `status` could not read one or more sections
+- **WHEN** the command completes
+- **THEN** it SHALL exit non-zero, so scripts do not read a partial report as a healthy cluster
+
+## ADDED Requirements
+
+### Requirement: Provisioning reports success only when it fully succeeded
+
+The system MUST NOT report successful provisioning unless every provisioning step succeeded. When any provisioning step fails, `up` MUST abort at the point of failure and exit non-zero.
+
+There is no provisioning step whose failure may be logged and stepped over. A step that is skipped because there is nothing for it to do has not failed; a step that was attempted and threw has failed, and MUST abort provisioning.
+
+This applies to every step invoked during provisioning, including nested commands whose exit codes were previously discarded, and to operations whose results were previously reduced to a log line.
+
+#### Scenario: A failing provisioning step aborts `up`
+- **WHEN** any provisioning step fails during `up` — writing configuration files, node setup, K3s cluster setup, StorageClass creation, node labeling, Tailscale startup, IAM policy application, or observability deployment
+- **THEN** `up` SHALL abort at that step
+- **AND** `up` SHALL exit non-zero
+- **AND** the reported error SHALL identify the step that failed
+
+#### Scenario: A failing nested command aborts `up`
+- **WHEN** `up` invokes a nested command and that command returns a non-zero exit code
+- **THEN** `up` SHALL abort
+- **AND** `up` SHALL exit non-zero
+
+#### Scenario: Unreachable cluster API aborts `up`
+- **GIVEN** the cluster's Kubernetes API cannot be reached
+- **WHEN** `up` attempts to apply node labels, StorageClasses, or the observability stack
+- **THEN** `up` SHALL abort and exit non-zero
+- **AND** `up` SHALL NOT report a successfully provisioned cluster
+
+#### Scenario: Progress events assert only verified outcomes
+- **WHEN** a provisioning step emits an event announcing its completion
+- **THEN** that event SHALL be emitted only if the step actually succeeded
+
+#### Scenario: Explicit opt-out is not a failure
+- **WHEN** the user passes `--no-setup`
+- **THEN** node setup SHALL be skipped
+- **AND** `up` SHALL exit zero if all remaining steps succeeded
+
+### Requirement: Cluster shape invariants are validated before provisioning
+
+The system MUST validate the cluster's required shape before any AWS resource is provisioned, so that an unsatisfiable configuration fails before EC2 instances are launched rather than being discovered part-way through `up`.
+
+A cluster MUST have a control node. An S3 bucket MUST be configured. Neither may be treated as an optional condition that causes provisioning steps to be silently skipped.
+
+#### Scenario: Missing control node fails before provisioning
+- **GIVEN** a cluster configuration that would produce no control node
+- **WHEN** the user runs `up`
+- **THEN** the command SHALL fail before any EC2 instance is launched
+- **AND** the error SHALL state that a control node is required
+
+#### Scenario: Missing S3 bucket fails before provisioning
+- **GIVEN** no S3 bucket is configured
+- **WHEN** the user runs `up`
+- **THEN** the command SHALL fail before any EC2 instance is launched
+- **AND** the error SHALL state that an S3 bucket is required
+
+#### Scenario: Provisioning steps do not defend against missing invariants
+- **WHEN** provisioning proceeds past validation
+- **THEN** no provisioning step SHALL skip its work on the grounds that a control node or S3 bucket is absent
+
+### Requirement: A cluster with zero database nodes is a valid configuration
+
+The system MUST support provisioning a cluster with no database nodes. Workloads such as Trino with OpenSearch require a control node and application nodes but no database nodes.
+
+Work that exists solely to serve database nodes MUST be skipped without warning when there are none. A supported configuration MUST NOT produce warning output.
+
+#### Scenario: Zero database nodes provisions successfully
+- **GIVEN** a cluster configuration with a control node, application nodes, and zero database nodes
+- **WHEN** the user runs `up`
+- **THEN** provisioning SHALL complete successfully and exit zero
+
+#### Scenario: Database node labeling is skipped silently
+- **GIVEN** a cluster with zero database nodes
+- **WHEN** provisioning reaches database node labeling
+- **THEN** the step SHALL be skipped
+- **AND** no warning SHALL be emitted to the user
+
+### Requirement: Control node SSH readiness is confirmed before it is used
+
+The system MUST confirm that the control node is accepting SSH connections before any provisioning step depends on connecting to it.
+
+#### Scenario: Provisioning waits for control node SSH
+- **WHEN** `up` waits for instances to become reachable
+- **THEN** the wait SHALL include the control node, not only database nodes
+- **AND** provisioning SHALL NOT proceed to node setup or tunnel establishment until the control node accepts SSH connections
+
+#### Scenario: Control node that never accepts SSH aborts `up`
+- **GIVEN** the control node does not accept SSH connections within the retry window
+- **WHEN** `up` waits for SSH readiness
+- **THEN** `up` SHALL exit non-zero

--- a/openspec/changes/up-fail-fast/specs/networking/spec.md
+++ b/openspec/changes/up-fail-fast/specs/networking/spec.md
@@ -1,0 +1,79 @@
+## MODIFIED Requirements
+
+### REQ-NET-005: SOCKS Proxy
+
+The system MUST support a SOCKS5 proxy via SSH dynamic port forwarding as an alternative to Tailscale for routing traffic to internal cluster services.
+
+The proxy MUST be started only for commands that declare a dependency on it. A command that does not declare the dependency MUST NOT cause a proxy to be started.
+
+The system MUST NOT publish a proxy port that is not accepting connections. Establishing the proxy MUST be verified before the port is advertised to any client, and a proxy that cannot be verified MUST fail the invoking command rather than allowing it to proceed against a dead tunnel.
+
+#### Scenario: Proxy starts for commands that require it
+- **WHEN** a command declaring a proxy dependency is invoked against a provisioned cluster with infrastructure UP and Tailscale not enabled
+- **THEN** the SOCKS5 proxy SHALL be started, or reused if already running, before any command logic executes
+
+#### Scenario: Proxy is not started for commands that do not require it
+- **WHEN** a command that does not declare a proxy dependency is invoked
+- **THEN** no SOCKS5 proxy SHALL be started, regardless of cluster state
+- **AND** teardown SHALL NOT start a tunnel it then destroys
+
+#### Scenario: Killed proxy is restarted automatically
+- **WHEN** the SOCKS5 proxy OS process has been killed since the last invocation and a command requiring the proxy is invoked
+- **THEN** the proxy SHALL be restarted without user intervention
+
+#### Scenario: Proxy that cannot be established fails the command
+- **WHEN** the SOCKS5 proxy is started but its local port never begins accepting connections within the verification window
+- **THEN** the invoking command SHALL fail with a non-zero exit code
+- **AND** the proxy port SHALL NOT be published to any client
+- **AND** the error SHALL identify the proxy as the failing component and reference the SSH transcript log
+
+#### Scenario: A live process with a dead tunnel is not reused
+- **WHEN** a recorded proxy process is still alive but its local port is not accepting connections
+- **THEN** the proxy SHALL NOT be reused
+- **AND** its port SHALL NOT be published
+- **AND** a fresh proxy SHALL be started, or the command SHALL fail if one cannot be established
+- **AND** this SHALL hold for every path that may reuse a proxy, including an in-memory handle held by a long-lived REPL or server session
+
+#### Scenario: A proxy that fails verification leaves no orphaned process
+- **WHEN** a proxy process is spawned but its local port never begins accepting connections
+- **THEN** the spawned process SHALL be terminated before the failure is reported
+- **AND** no untracked SSH process SHALL survive the failed command
+
+#### Scenario: Proxy connects to the recorded gateway host
+- **WHEN** the SOCKS5 proxy is started for a given control host
+- **THEN** the SSH tunnel SHALL be established to that host's alias as recorded in cluster state, not to a hardcoded alias
+
+#### Scenario: Proxy persists for long-lived sessions
+- **WHEN** the REPL or server is running and the proxy is needed
+- **THEN** the proxy SHALL persist for the lifetime of the session rather than per-command
+
+#### Scenario: Tailscale bypasses the proxy
+- **WHEN** Tailscale is enabled for the cluster and any CLI command is invoked
+- **THEN** the SOCKS5 proxy SHALL NOT be started
+- **AND** connections SHALL use direct private IP access
+
+#### Scenario: Shell wrappers read the proxy port
+- **WHEN** the user sources `env.sh` for a running cluster
+- **THEN** `SOCKS5_PROXY_PORT` SHALL be populated from the state file written by the CLI so shell wrappers (kubectl, helm, curl) use the correct port
+
+## ADDED Requirements
+
+### Requirement: Generated SSH configuration is self-contained
+
+The SSH configuration the system generates for a cluster MUST fully determine how the `ssh` CLI verifies host keys, and MUST NOT depend on, read from, or write to the developer's personal `~/.ssh/known_hosts` file.
+
+Cluster instances are ephemeral and are assigned fresh host keys on every provision, while AWS recycles public IP addresses. Host-key state carried across cluster lifetimes therefore causes spurious verification failures. The generated configuration MUST behave consistently with the library SSH path used everywhere else in the system.
+
+#### Scenario: Generated config pins the known-hosts file
+- **WHEN** the system writes the cluster's SSH configuration
+- **THEN** the configuration SHALL set `UserKnownHostsFile` to `/dev/null` alongside `StrictHostKeyChecking=no`
+
+#### Scenario: Recycled public IP does not break the tunnel
+- **GIVEN** a cluster node is assigned a public IP previously recorded in the developer's `~/.ssh/known_hosts` under a different host key
+- **WHEN** the system establishes the SOCKS5 tunnel to that node using the generated SSH configuration
+- **THEN** the tunnel SHALL be established successfully
+- **AND** `ssh` SHALL NOT fail host-key verification
+
+#### Scenario: Developer known_hosts is not modified
+- **WHEN** the system connects to any cluster node using the generated SSH configuration
+- **THEN** no entry SHALL be added to the developer's `~/.ssh/known_hosts`

--- a/openspec/changes/up-fail-fast/tasks.md
+++ b/openspec/changes/up-fail-fast/tasks.md
@@ -1,0 +1,75 @@
+# Tasks
+
+Ordered by dependency. Groups 1–3 are independent of each other; group 4 depends on 3; group 5 depends on 1–4.
+
+Practice TDD throughout: write the failing test first. Use AssertJ, extend `BaseKoinTest`, use `@TempDir` for temporary directories. No mock-echo tests — every test must exercise a decision, transformation, or real failure mode. Never mock `TemplateService`. Prefer K3s TestContainers over mocks for anything applying real K8s state.
+
+## 1. Root cause: SSH host-key verification
+
+- [x] 1.1 Write a failing test asserting `ClusterConfigWriter.writeSshConfig()` emits `UserKnownHostsFile=/dev/null` alongside the existing `StrictHostKeyChecking=no`, and that both appear before any `Host` block.
+- [x] 1.2 Add `UserKnownHostsFile=/dev/null` to `ClusterConfigWriter.writeSshConfig()`.
+- [x] 1.3 Write a test asserting the generated config for a multi-node cluster still produces one `Host <alias>` / `Hostname <publicIp>` pair per host, so the new directive does not disturb the existing structure.
+
+## 2. Proxy verifies before it publishes
+
+- [x] 2.1 Write a failing test: when the local port never accepts connections, `ProcessSocksProxyService.startNewProxy()` throws, and `Constants.Proxy.PORT_PROPERTY` is left unset. Use a `@TempDir` working directory as `ProcessSocksProxyServiceTest` already does.
+- [x] 2.2 Change `verifyProxyAcceptingConnections()` to throw instead of logging `"proceeding anyway"`. The exception message must name the SOCKS proxy as the failing component and reference `socks5-proxy.log`.
+- [x] 2.3 Write a failing test: `isValidProxy()` rejects a recorded proxy whose PID is alive but whose port is not accepting connections (zombie tunnel), so it is not reused and its port is not republished.
+- [x] 2.4 Add an `isPortAccepting()` check to `isValidProxy()`, alongside the existing PID / `controlIP` / `sshConfig` checks.
+- [x] 2.5 Write a failing test asserting `startNewProxy()` invokes `ssh` with the gateway host's recorded alias, not the literal `"control0"`.
+- [x] 2.6 Replace the hardcoded `"control0"` argument in `startNewProxy()`'s `ProcessBuilder` with `gatewayHost.alias`.
+- [x] 2.7 Update the KDoc on `startNewProxy()` so the documented contract and the code agree — the comment currently promises verification-before-publish that the code did not perform.
+
+## 3. Proxy pre-flight becomes opt-in
+
+- [x] 3.1 Create `annotations/RequiresProxy.kt` — `@Target(AnnotationTarget.CLASS)`, `@Retention(AnnotationRetention.RUNTIME)`, with a class-level KDoc explaining that it declares a command reaches the private K8s API (Fabric8) or a private cluster HTTP endpoint, and therefore needs the SOCKS tunnel.
+- [x] 3.2 Write a failing test: `DefaultCommandExecutor` does not start a proxy for a command lacking `@RequiresProxy`, even when the cluster is provisioned, infrastructure is UP, and Tailscale is disabled.
+- [x] 3.3 Write a failing test: for a command carrying `@RequiresProxy`, a proxy failure propagates and the command exits non-zero — it is not swallowed into `log.warn "proceeding without proxy"`.
+- [x] 3.4 Gate `ensureProxyRunning()` on the `@RequiresProxy` annotation in `checkRequirements()`, alongside the existing `@RequireDocker` / `@RequireSSHKey` / `@RequireProfileSetup` checks. Remove the `try`/`catch` from `ensureProxyRunning()` and correct its now-false KDoc.
+- [x] 3.5 Audit the command surface with the mechanical criterion from design D7: does the execution path reach `K8sClientProvider` or `ProxiedHttpClientFactory`? Annotate `Up`, `Status`, `GrafanaInstall`, `GrafanaUpdateConfig`, `PlatformCreatePvs`, `KitInstallCommand`, `KitRunnerCommand`, `KitStatusCommand`, `LogsBackup`, `MetricsBackup`, `cassandra/Start`, `cassandra/Stop`, `cassandra/Restart`, and the `cassandra/stress/*` family. Verify each by execution path rather than by name.
+- [x] 3.6 Confirm `Down` is **not** annotated, and write a test asserting `Down` starts no proxy — it unpublishes the port and kills the ssh process as its first actions.
+- [x] 3.7 ~~Write a guard test that fails when a command reaching `K8sClientProvider` or `ProxiedHttpClientFactory` lacks `@RequiresProxy`.~~ **Dropped by owner decision.** Any such test hand-maintains either a list of proxy-reaching service types or a suppression list for bytecode-reachability false positives. Both are lists masquerading as checks — they pass while silently covering less. The annotation is applied by reading the execution path; the opt-in design (D7) makes a missed annotation benign. `RequiresProxyAuditTest.kt` was written, reviewed, and deleted.
+
+## 3a. `Status` degrades instead of failing (design D9)
+
+- [x] 3a.1 Write a failing test: with the SOCKS proxy unable to establish, `Status` still reports EC2 instance and VPC networking state rather than aborting.
+- [x] 3a.2 Write a failing test: under the same conditions, only the sections sourced from the private Kubernetes API (stress jobs, ClickHouse) are marked unavailable, each stating the proxy failure as the reason — while database versions still render over SSH, which never traverses the tunnel. Unavailability follows the transport, not a section list.
+- [x] 3a.3 Write a failing test: a degraded `Status` exits non-zero, so a partial report is never read by a script as a healthy cluster.
+- [x] 3a.4 Implement the degradation in `Status`: catch proxy establishment failure, render the observable sections, mark the rest unavailable with cause. Add typed `Event` fields for an unavailable section and its reason — do not use `Event.Message` or `Event.Error`.
+- [x] 3a.5 Add a KDoc note on `Status` recording that this is the single specified exception to the fail-fast invariant, permitted because `Status` is read-only, and that no state-mutating command may take it.
+
+## 4. Cluster shape invariants move before provisioning
+
+- [x] 4.1 Add `Event.Provision` typed events for the two pre-provisioning validation failures (missing control node, missing S3 bucket), with structured fields. Do not use `Event.Message` or `Event.Error`.
+- [x] 4.2 Write a failing test: `up` with a configuration producing no control node fails before any EC2 instance is launched, with an error stating a control node is required.
+- [x] 4.3 Write a failing test: `up` with no S3 bucket configured fails before any EC2 instance is launched, with an error stating an S3 bucket is required.
+- [x] 4.4 Implement both invariant checks ahead of EC2 provisioning in `Up`.
+- [x] 4.5 Remove the now-unreachable `controlHosts.isEmpty()` guards in `startK3sOnAllNodes()`, `installCilium()`, and `configureRegistryTls()`, and remove the `bucketName.isBlank()` guard in `configureRegistryTls()`. Delete `Event.Provision.NoControlNodes` if it has no remaining emitter.
+- [x] 4.6 Write a test: `up` with a control node, app nodes, and **zero db nodes** provisions successfully and emits no warning. Demote `log.warn { "No db nodes found..." }` to `log.debug`.
+
+## 5. `up` fails fast
+
+- [x] 5.1 Add a private helper in `Up` that runs a nested command via `commandExecutor.execute { }` and throws when the exit code is non-zero, naming the command in the message. Write a test covering both the zero and non-zero paths.
+- [x] 5.2 Write a failing test for each nested-command site — `WriteConfig`, `SetupInstance`, `ConfigureAxonOps`, `GrafanaUpdateConfig` — asserting a non-zero exit code aborts `up` with a non-zero exit code. Route all four through the helper from 5.1.
+- [x] 5.3 Write a failing test asserting `writeConfigurationFiles()` failure aborts `up`; replace `onFailure { log.error }` with propagation.
+- [x] 5.4 Write a failing test asserting a `k3sClusterService.setupCluster()` result with `isSuccessful == false` aborts `up`; log each operation error, then throw.
+- [x] 5.5 Write a failing test asserting `ensureLocalStorageClass()` and `ensureLocalStorageWfcClass()` failures abort `up`; replace `getOrElse { log.warn }` with `.getOrThrow()`, following `installCilium()`'s precedent.
+- [x] 5.6 Write a failing test asserting any `labelNode()` failure — control, db, or app — aborts `up`; replace all three `getOrElse { log.warn }` sites with `.getOrThrow()`.
+- [x] 5.7 Write a failing test asserting `Event.Provision.NodeLabelingComplete` is **not** emitted when labeling fails. Emit it only after labeling succeeds.
+- [x] 5.8 Write a failing test asserting `reapplyS3Policy()` failure aborts `up`; replace `runCatching { }.onFailure { log.warn }` with propagation.
+- [x] 5.9 Write a failing test asserting `TailscaleStart()` failure aborts `up`. Remove the `catch → warn` path; preserve the manual-setup instruction in the thrown error message rather than dropping it.
+- [x] 5.10 Write a test asserting `--no-setup` still exits zero when all remaining steps succeed — an explicit opt-out is not a failure.
+
+## 6. Control node SSH readiness
+
+- [x] 6.1 Write a failing test asserting the SSH readiness wait covers `ServerType.Control` hosts, not only `ServerType.Cassandra`. (Design D10.)
+- [x] 6.2 Separate the two concerns in `waitForSshAndDownloadVersions()`: the readiness check covers control and db hosts; the `/etc/cassandra_versions.yaml` download remains scoped to db hosts. Rename the method to reflect what it now does.
+- [x] 6.3 Write a test asserting `up` exits non-zero when the control node never accepts SSH within the retry window.
+
+## 7. Verification and documentation
+
+- [ ] 7.1 Run `./gradlew ktlintFormat`, then `./gradlew test`, then `./gradlew detekt` (JDK 21 — detekt 1.23.8 cannot run under JDK 25). All must pass with no new detekt findings.
+- [ ] 7.2 End-to-end check against a real cluster: provision with `init --up` and confirm the observability stack, both StorageClasses, and all node labels are present. Then simulate a dead tunnel and confirm `up` exits non-zero rather than reporting success.
+- [x] 7.3 Update user documentation in `docs/` for the changed `up` failure semantics and for the `known_hosts` behavior change — `ssh` no longer writes host keys to the developer's `~/.ssh/known_hosts`.
+- [x] 7.4 Update `commands/CLAUDE.md` to document `@RequiresProxy` alongside the other command annotations, and note that `RemoteOperationsService`-driven tooling (helm, kubectl, cilium on the control node) does not need it.
+- [x] 7.5 Confirm no scope creep: `grafana update-config` dashboard handling, MINA SSHD's `AcceptAllServerKeyVerifier`, and `Down.cleanupSocks5Proxy()`'s cwd-relative state path (issue #738) remain untouched.

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/Constants.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/Constants.kt
@@ -219,6 +219,12 @@ object Constants {
         // via the OTel Collector Jaeger receiver, since TiDB v8.5.x has no native OTel support.
         const val JAEGER_THRIFT_COMPACT_PORT = 6831
         const val CLEANUP_JOB_TTL_SECONDS = 300
+
+        // Max time `up` waits for every observability pod in the `default` namespace to reach Ready
+        // after the stack is applied. Generous because Grafana plugin installs and first-boot image
+        // pulls are slow; the wait is fail-fast on CrashLoopBackOff/ImagePullBackOff, so a broken
+        // stack aborts well before this ceiling.
+        const val OBSERVABILITY_READY_TIMEOUT_SECONDS = 300
         const val DB_MOUNT_PATH = "/mnt/db1"
 
         // Labels used by the metrics registry system.
@@ -340,6 +346,14 @@ object Constants {
          * explicitly while AWS and all other traffic stays direct.
          */
         const val PORT_PROPERTY = "easydblab.socks5Port"
+
+        /**
+         * Filename of the SOCKS5 proxy's `ssh -v` transcript. It lives under the workspace
+         * `logs/` directory (alongside `logs/info.log`), overwritten on each proxy start so the
+         * tail is always exactly the most recent attempt. Read back on verification failure to
+         * surface the real ssh error (e.g. a changed host key or refused connection).
+         */
+        const val SOCKS5_PROXY_LOG_FILE = "socks5-proxy.log"
     }
 
     // Tailscale VPN configuration

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/annotations/RequiresProxy.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/annotations/RequiresProxy.kt
@@ -1,0 +1,39 @@
+package com.rustyrazorblade.easydblab.annotations
+
+/**
+ * Marks a command whose execution path reaches the private Kubernetes API (Fabric8, via
+ * `K8sClientProvider` or the equivalent `KubernetesClientFactory` used by kit status checks)
+ * or a private cluster HTTP endpoint (via `ProxiedHttpClientFactory` / `HttpClientFactory`,
+ * e.g. Grafana, VictoriaMetrics, VictoriaLogs on the control node's private IP).
+ *
+ * `DefaultCommandExecutor.checkRequirements()` starts the SOCKS5 tunnel before executing any
+ * command carrying this annotation, when the cluster is provisioned, infrastructure is UP, and
+ * Tailscale is not active. Commands that never touch the private cluster network must NOT carry
+ * this annotation — doing so would start a tunnel nothing needs.
+ *
+ * This is opt-in by design. A command that omits the annotation but does reach the private
+ * cluster network degrades to a confusing connection error — the same behaviour it had before
+ * the annotation existed — rather than to a new failure mode. That benign failure mode is why
+ * opt-in was chosen over an opt-out annotation, where a missed annotation would instead break a
+ * working command.
+ *
+ * There is deliberately no test enforcing that this annotation is applied. Any such test would
+ * either hand-maintain a list of the services considered to reach the cluster network, or
+ * over-approximate reachability from bytecode and require a hand-maintained suppression list
+ * for its false positives. Both are lists masquerading as checks: they pass while silently
+ * covering less over time. Apply this annotation by reading the command's execution path.
+ *
+ * @property tolerateFailure When `true`, a proxy establishment failure is recorded on
+ * [com.rustyrazorblade.easydblab.proxy.ProxyAvailability] instead of aborting the command — the
+ * command must then query that holder itself to render a degraded result. This is the single,
+ * narrow mechanism for the one specified exception to the fail-fast invariant (see design
+ * decision D9 in `openspec/changes/up-fail-fast/design.md`): `status` is read-only and is the
+ * command reached for when the cluster is already broken, so it degrades rather than aborting.
+ * Defaults to `false` — every other command fails fast, and setting this to `true` must be a
+ * deliberate, visible choice at the annotation site. No command that mutates state may set it.
+ */
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class RequiresProxy(
+    val tolerateFailure: Boolean = false,
+)

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/CLAUDE.md
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/CLAUDE.md
@@ -158,6 +158,37 @@ automatically after a successful `start`.
 - `@McpCommand` — expose command as an MCP tool in the server (must also add to `McpToolRegistry`)
 - `@RequireProfileSetup` — require AWS profile configuration before execution
 - `@RequireSSHKey` — require SSH key to be available
+- `@RequireDocker` — require a Docker daemon to be reachable before execution
+- `@RequiresProxy` — command's execution path reaches the private K8s API (Fabric8, via
+  `K8sClientProvider`) or a private cluster HTTP endpoint (via `ProxiedHttpClientFactory`), and
+  therefore needs the SOCKS5 tunnel. `DefaultCommandExecutor.checkRequirements()` starts the
+  tunnel before the command runs, when the cluster is provisioned, infrastructure is UP, and
+  Tailscale is not active; a failure to establish it propagates and aborts the command. See
+  `annotations/RequiresProxy.kt` and design decision D7/D9 in
+  `openspec/changes/up-fail-fast/design.md`.
+
+  Commands driving remote tooling through `RemoteOperationsService` — helm, kubectl, cilium run
+  *on the control node* over SSH — do **not** need this annotation. There is no local client
+  making the call, and SSH never traverses the SOCKS tunnel (the tunnel exists only to reach the
+  private Kubernetes API from the developer's machine). `Down` is a concrete example: its first
+  actions unpublish the proxy port and kill the ssh process, so it must not carry `@RequiresProxy`
+  or it would start a tunnel it exists to tear down.
+
+  The annotation takes one parameter, `tolerateFailure: Boolean = false`. When `true`, a proxy
+  failure is recorded on `ProxyAvailability` instead of aborting the command, which must then
+  query that holder itself to render a degraded result. `Status` is the only command that sets
+  this — it is read-only, so reporting a partial view can never leave the cluster in an
+  unexpected state, and it is the command a user reaches for when the cluster is already broken.
+  **No state-mutating command may set `tolerateFailure = true`.**
+
+  There is deliberately no test enforcing that this annotation is applied to every command that
+  reaches the private cluster network. Any such test would have to hand-maintain either a list of
+  proxy-reaching service types or a suppression list for bytecode-reachability false positives —
+  both are lists masquerading as checks that pass while silently covering less as the codebase
+  moves. This is safe specifically because the annotation is opt-in (D7): a missed annotation
+  degrades to a confusing Fabric8/HTTP connection error, the same failure mode the codebase had
+  before the annotation existed, rather than breaking a previously-working command. Apply it by
+  reading the command's execution path, not by a mechanical check.
 - `@TriggerBackup` — trigger a cluster state backup after execution
 - `@PreExecute` / `@PostExecute` — lifecycle hooks around command execution
 

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Server.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Server.kt
@@ -2,6 +2,7 @@ package com.rustyrazorblade.easydblab.commands
 
 import com.rustyrazorblade.easydblab.Constants
 import com.rustyrazorblade.easydblab.annotations.RequireProfileSetup
+import com.rustyrazorblade.easydblab.annotations.RequiresProxy
 import com.rustyrazorblade.easydblab.events.Event
 import com.rustyrazorblade.easydblab.mcp.McpServer
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -13,8 +14,16 @@ import java.io.File
 
 /**
  * Starts the server for AI assistant integration, REST status endpoints, and live metrics.
+ *
+ * Carries [RequiresProxy]: [McpServer] unconditionally constructs a `StatusCache` whose
+ * background refresh loop calls `K3sService`/`K8sService` (Fabric8, via `K8sClientProvider`)
+ * on every refresh cycle, and conditionally a `MetricsCollector` that queries
+ * `VictoriaMetricsQueryService` (`HttpClientFactory`) when Redis is configured. Both run inside
+ * this command's own execution, not as separate `PicoCommand`s, so the tunnel must be
+ * established before [execute] starts the server.
  */
 @RequireProfileSetup
+@RequiresProxy
 @Command(
     name = "server",
     description = [

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Status.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Status.kt
@@ -4,6 +4,7 @@ import com.rustyrazorblade.easydblab.Constants
 import com.rustyrazorblade.easydblab.Context
 import com.rustyrazorblade.easydblab.annotations.McpCommand
 import com.rustyrazorblade.easydblab.annotations.RequireProfileSetup
+import com.rustyrazorblade.easydblab.annotations.RequiresProxy
 import com.rustyrazorblade.easydblab.configuration.ClusterHost
 import com.rustyrazorblade.easydblab.configuration.ClusterS3Path
 import com.rustyrazorblade.easydblab.configuration.ClusterStateManager
@@ -16,6 +17,7 @@ import com.rustyrazorblade.easydblab.kubernetes.getLocalKubeconfigPath
 import com.rustyrazorblade.easydblab.providers.aws.SecurityGroupRuleInfo
 import com.rustyrazorblade.easydblab.providers.aws.VpcService
 import com.rustyrazorblade.easydblab.providers.ssh.RemoteOperationsService
+import com.rustyrazorblade.easydblab.proxy.ProxyAvailability
 import com.rustyrazorblade.easydblab.services.K8sService
 import com.rustyrazorblade.easydblab.services.StressJobService
 import com.rustyrazorblade.easydblab.services.aws.EC2InstanceService
@@ -36,9 +38,34 @@ import java.time.format.DateTimeFormatter
  * - Security group rules (full ingress/egress)
  * - Kubernetes jobs running on K3s cluster
  * - Cassandra version (live via SSH, fallback to cached)
+ *
+ * ## The one permitted exception to fail-fast
+ *
+ * Every other `@RequiresProxy` command aborts when the SOCKS5 tunnel cannot be established.
+ * `Status` is the single, deliberate exception: it carries `@RequiresProxy(tolerateFailure =
+ * true)`, so a proxy failure is recorded on [ProxyAvailability] instead of aborting the command
+ * (see `DefaultCommandExecutor.checkRequirements()`).
+ *
+ * Unavailability follows the **transport** a section actually uses, not a hand-picked list.
+ * Sections sourced from cluster state, the AWS SDK, or direct SSH to the nodes still render when
+ * the proxy is down — SSH never traverses the tunnel, which exists only to reach the private
+ * Kubernetes API. Only the two sections sourced from that API (stress jobs and the ClickHouse
+ * namespace status) are marked unavailable, via [renderProxyDependentSection]. There is exactly
+ * one rendering path ([execute]) for both the healthy and degraded reports, so a section added
+ * to the healthy report cannot silently vanish from the degraded one unless it too depends on
+ * the Kubernetes API.
+ *
+ * This is permitted only because `Status` is read-only — it changes no cluster state, so
+ * reporting a partial view can never leave the cluster in an unexpected condition. It is why
+ * `status` is the command a user reaches for when the cluster is already broken. It still exits
+ * non-zero when degraded (see [StatusDegradedException]), so a partial report is never mistaken
+ * by a script for a healthy cluster. See design decision D9 in
+ * `openspec/changes/up-fail-fast/design.md`. **No command that mutates state may take this
+ * exception.**
  */
 @McpCommand
 @RequireProfileSetup
+@RequiresProxy(tolerateFailure = true)
 @Command(
     name = "status",
     description = ["Display full environment status"],
@@ -48,6 +75,7 @@ class Status :
     PicoCommand,
     KoinComponent {
     private val context: Context by inject()
+    private val proxyAvailability: ProxyAvailability by inject()
 
     companion object {
         private val log = KotlinLogging.logger {}
@@ -83,6 +111,11 @@ class Status :
             return
         }
 
+        // One rendering path for both the healthy and degraded reports. Every section renders by
+        // default; only the two sourced from the private Kubernetes API are wrapped in
+        // renderProxyDependentSection, so a proxy failure marks exactly those unavailable while
+        // every AWS-, cluster-state-, and SSH-backed section still renders. A section added here
+        // renders unless it is deliberately wrapped — it can never silently vanish when degraded.
         displayClusterSection()
         displayNodesSection()
         displayNetworkingSection()
@@ -91,11 +124,51 @@ class Status :
         displayOpenSearchSection()
         displayS3BucketSection()
         displayKitsSection()
-        displayStressJobsSection()
+        renderProxyDependentSection("Stress jobs") { displayStressJobsSection() }
         displayObservabilitySection()
-        displayClickHouseSection()
+        renderProxyDependentSection("ClickHouse") { displayClickHouseSection() }
         displayS3ManagerSection()
         displayCassandraVersionSection()
+
+        // A degraded report is still an unsuccessful command: fail after rendering so a script
+        // can never read a partial report as a healthy cluster. See StatusDegradedException.
+        val proxyFailure = proxyAvailability.failure()
+        if (proxyFailure != null) {
+            throw StatusDegradedException(proxyFailure)
+        }
+    }
+
+    /**
+     * Renders a status section whose data comes from the private Kubernetes API (Fabric8 via
+     * `K8sClientProvider`) and therefore depends on the SOCKS tunnel.
+     *
+     * When the proxy failed to establish (recorded on [ProxyAvailability]; see the class KDoc and
+     * design decision D9), the section is reported as [Event.Status.SectionUnavailable] with the
+     * proxy failure as its reason, instead of being read. Otherwise it renders normally via
+     * [render].
+     *
+     * This is the ONLY place a section is skipped on a proxy failure, and it is keyed on the
+     * transport — not on a hand-maintained list of section names. Sections sourced from cluster
+     * state, the AWS SDK, or direct SSH to the nodes are never wrapped here, because SSH never
+     * traverses the tunnel and neither the AWS APIs nor cluster state touch it; they always
+     * render, degraded or not. There is deliberately no second "degraded" rendering routine that
+     * could fall out of sync with this one.
+     */
+    private fun renderProxyDependentSection(
+        sectionName: String,
+        render: () -> Unit,
+    ) {
+        val proxyFailure = proxyAvailability.failure()
+        if (proxyFailure == null) {
+            render()
+            return
+        }
+        eventBus.emit(
+            Event.Status.SectionUnavailable(
+                sectionName,
+                "SOCKS proxy could not be established: ${proxyFailure.message}",
+            ),
+        )
     }
 
     /**
@@ -562,3 +635,16 @@ private fun ClusterHost.toHost(): Host =
         alias = this.alias,
         availabilityZone = this.availabilityZone,
     )
+
+/**
+ * Thrown by [Status] after it renders a degraded report, so the command still exits non-zero.
+ *
+ * Rendering happens before this is thrown — `Status.execute` renders every section, guarding
+ * only the tunnel-dependent ones via `renderProxyDependentSection`, and throws this only at the
+ * end — so a caller reading only the output still sees everything that could be observed, while a
+ * caller reading only the exit code can never mistake a partial report for a healthy cluster.
+ * The proxy failure that forced the degradation is carried as this exception's cause.
+ */
+class StatusDegradedException(
+    proxyFailure: Throwable,
+) : Exception("status degraded: SOCKS proxy could not be established", proxyFailure)

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Up.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Up.kt
@@ -3,6 +3,7 @@ package com.rustyrazorblade.easydblab.commands
 import com.rustyrazorblade.easydblab.Constants
 import com.rustyrazorblade.easydblab.annotations.McpCommand
 import com.rustyrazorblade.easydblab.annotations.RequireProfileSetup
+import com.rustyrazorblade.easydblab.annotations.RequiresProxy
 import com.rustyrazorblade.easydblab.annotations.TriggerBackup
 import com.rustyrazorblade.easydblab.commands.cassandra.WriteConfig
 import com.rustyrazorblade.easydblab.commands.grafana.GrafanaUpdateConfig
@@ -64,6 +65,7 @@ import java.time.Duration
  */
 @McpCommand
 @RequireProfileSetup
+@RequiresProxy
 @TriggerBackup
 @CommandLine.Command(
     name = "up",
@@ -112,13 +114,64 @@ class Up : PicoBaseCommand() {
             workingState.initConfig
                 ?: error("No init config found. Please run 'easy-db-lab init' first.")
 
+        validateControlNodeConfigured(initConfig)
+
         configureAccountS3Bucket()
+        validateS3BucketConfigured()
         reapplyS3Policy()
         provisionInfrastructure(initConfig)
         writeConfigurationFiles()
-        commandExecutor.execute { WriteConfig() }
-        waitForSshAndDownloadVersions()
+        runNestedCommand { WriteConfig() }
+        waitForSshReady()
+        downloadCassandraVersions()
         setupInstancesIfNeeded()
+    }
+
+    /**
+     * Validates that the configuration will produce a control node, before any AWS resource is
+     * provisioned. Every downstream step — K3s, node labeling, StorageClasses, observability —
+     * depends on a control node existing. Discovering that it doesn't mid-provisioning, after
+     * EC2 instances are already running, is the exact failure this check exists to prevent.
+     */
+    private fun validateControlNodeConfigured(initConfig: InitConfig) {
+        if (initConfig.controlInstances < 1) {
+            eventBus.emit(Event.Provision.ControlNodeRequired(initConfig.controlInstances))
+            error(
+                "A control node is required to provision a cluster " +
+                    "(configured control instances: ${initConfig.controlInstances}).",
+            )
+        }
+    }
+
+    /**
+     * Validates that an S3 bucket is actually configured after [configureAccountS3Bucket] runs.
+     * That method is responsible for ensuring one exists; this is the assertion that it did, so
+     * a bug there fails loudly here rather than silently skipping registry TLS configuration and
+     * kubeconfig backup later.
+     */
+    private fun validateS3BucketConfigured() {
+        if (workingState.s3Bucket.isNullOrBlank()) {
+            eventBus.emit(Event.Provision.S3BucketRequired(workingState.name))
+            error("An S3 bucket is required to provision a cluster.")
+        }
+    }
+
+    /**
+     * Runs a nested command through [commandExecutor] and aborts `up` if it fails.
+     *
+     * [CommandExecutor.execute] never lets a nested command's exception escape to its caller —
+     * [com.rustyrazorblade.easydblab.services.DefaultCommandExecutor.executeWithLifecycle]
+     * catches it, logs the cause chain, and converts it to a non-zero exit code. Callers must
+     * therefore inspect the returned exit code themselves; this helper does that once so every
+     * nested-command call site aborts provisioning identically instead of discarding the result.
+     */
+    private fun <T : PicoCommand> runNestedCommand(commandFactory: () -> T) {
+        val command = commandFactory()
+        val commandName = command::class.simpleName ?: "nested command"
+        val exitCode = commandExecutor.execute { command }
+        if (exitCode != 0) {
+            error("$commandName failed during provisioning (exit code $exitCode).")
+        }
     }
 
     /**
@@ -128,13 +181,8 @@ class Up : PicoBaseCommand() {
      */
     private fun reapplyS3Policy() {
         eventBus.emit(Event.Provision.IamUpdating)
-        runCatching {
-            s3BucketService.attachS3Policy(Constants.AWS.Roles.EC2_INSTANCE_ROLE)
-        }.onFailure { e ->
-            log.warn(e) { "Failed to re-apply S3 policy (cluster may still work if policy exists)" }
-        }.onSuccess {
-            log.debug { "S3 policy re-applied successfully" }
-        }
+        s3BucketService.attachS3Policy(Constants.AWS.Roles.EC2_INSTANCE_ROLE)
+        log.debug { "S3 policy re-applied successfully" }
     }
 
     /**
@@ -454,13 +502,17 @@ class Up : PicoBaseCommand() {
                 context.workingDirectory.toPath(),
                 workingState,
                 userConfig,
-            ).onFailure { error ->
-                log.error(error) { "Failed to write some configuration files" }
-            }
+            ).getOrThrow()
     }
 
-    /** Waits for SSH to become available on instances and downloads Cassandra version info. */
-    private fun waitForSshAndDownloadVersions() {
+    /**
+     * Waits for SSH to become available on the control node and Cassandra hosts.
+     *
+     * The control node is included because the SOCKS tunnel and K3s setup both dial it next;
+     * confirming it is reachable here, rather than discovering it isn't mid-tunnel-setup, is
+     * what [downloadCassandraVersions] alone never verified.
+     */
+    private fun waitForSshReady() {
         eventBus.emit(Event.Provision.SshWaiting)
         Thread.sleep(SSH_STARTUP_DELAY.toMillis())
 
@@ -474,23 +526,38 @@ class Up : PicoBaseCommand() {
 
         Retry
             .decorateRunnable(retry) {
-                hostOperationsService.withHosts(
-                    workingState.hosts,
-                    ServerType.Cassandra,
-                    hosts.hostList,
-                ) { clusterHost ->
-                    val host = clusterHost.toHost()
-                    remoteOps.executeRemotely(host, "echo 1").text
-                    val versionsFile = File(context.workingDirectory, "cassandra_versions.yaml")
-                    if (!versionsFile.exists()) {
-                        remoteOps.download(
-                            host,
-                            "/etc/cassandra_versions.yaml",
-                            versionsFile.toPath(),
-                        )
-                    }
-                }
+                checkSshReady(ServerType.Control)
+                checkSshReady(ServerType.Cassandra)
             }.run()
+    }
+
+    private fun checkSshReady(serverType: ServerType) {
+        hostOperationsService.withHosts(
+            workingState.hosts,
+            serverType,
+            hosts.hostList,
+        ) { clusterHost ->
+            remoteOps.executeRemotely(clusterHost.toHost(), "echo 1").text
+        }
+    }
+
+    /** Downloads Cassandra version metadata from db hosts. Meaningless for the control node. */
+    private fun downloadCassandraVersions() {
+        hostOperationsService.withHosts(
+            workingState.hosts,
+            ServerType.Cassandra,
+            hosts.hostList,
+        ) { clusterHost ->
+            val host = clusterHost.toHost()
+            val versionsFile = File(context.workingDirectory, "cassandra_versions.yaml")
+            if (!versionsFile.exists()) {
+                remoteOps.download(
+                    host,
+                    "/etc/cassandra_versions.yaml",
+                    versionsFile.toPath(),
+                )
+            }
+        }
     }
 
     /** Runs instance setup, K3s configuration, and optional AxonOps setup unless --no-setup. */
@@ -498,14 +565,14 @@ class Up : PicoBaseCommand() {
         if (noSetup) {
             eventBus.emit(Event.Provision.SkippingNodeSetup)
         } else {
-            commandExecutor.execute { SetupInstance() }
+            runNestedCommand { SetupInstance() }
             startTailscaleIfConfigured()
             startProxyIfNeeded()
             startK3sOnAllNodes()
 
             if (userConfig.axonOpsKey.isNotBlank() && userConfig.axonOpsOrg.isNotBlank()) {
                 eventBus.emit(Event.Provision.AxonOpsSetup(userConfig.axonOpsOrg))
-                commandExecutor.execute { ConfigureAxonOps() }
+                runNestedCommand { ConfigureAxonOps() }
             }
         }
     }
@@ -527,35 +594,34 @@ class Up : PicoBaseCommand() {
     /**
      * Starts Tailscale VPN on the control node if credentials are configured.
      *
-     * This enables secure remote access to the cluster through Tailscale's VPN.
-     * If Tailscale fails to start, a warning is logged but the up command continues.
+     * This enables secure remote access to the cluster through Tailscale's VPN. A requested
+     * networking path that fails to come up is a failed provision: this aborts `up` rather than
+     * warning and continuing, but preserves the manual-setup instruction in the thrown message
+     * so the user still knows how to recover.
      */
     private fun startTailscaleIfConfigured() {
         if (!workingState.isTailscaleEnabled()) return
         if (userConfig.tailscaleClientId.isNotBlank() && userConfig.tailscaleClientSecret.isNotBlank()) {
             eventBus.emit(Event.Provision.TailscaleStarting)
-            try {
-                commandExecutor.execute { TailscaleStart() }
-            } catch (e: Exception) {
-                eventBus.emit(Event.Provision.TailscaleWarning(e.message ?: "Unknown error"))
-                eventBus.emit(Event.Provision.TailscaleManualInstruction)
+            val exitCode = commandExecutor.execute { TailscaleStart() }
+            if (exitCode != 0) {
+                error(
+                    "Failed to start Tailscale VPN (exit code $exitCode). " +
+                        "You can manually start it later with: easy-db-lab tailscale start",
+                )
             }
         }
     }
 
-    /** Starts K3s server on control node and joins Cassandra/Stress nodes as agents. */
+    /** Installs Cilium as the K3s CNI on the control node. */
     private fun installCilium() {
         val controlHosts = workingState.hosts[ServerType.Control] ?: emptyList()
-        if (controlHosts.isEmpty()) return
         ciliumService.install(controlHosts.first().toHost()).getOrThrow()
     }
 
+    /** Starts K3s server on control node and joins Cassandra/Stress nodes as agents. */
     private fun startK3sOnAllNodes() {
         val controlHosts = workingState.hosts[ServerType.Control] ?: emptyList()
-        if (controlHosts.isEmpty()) {
-            eventBus.emit(Event.Provision.NoControlNodes)
-            return
-        }
 
         // Configure registry TLS before K3s starts so registries.yaml is in place
         configureRegistryTls()
@@ -582,24 +648,17 @@ class Up : PicoBaseCommand() {
             result.errors.forEach { (operation, error) ->
                 log.error(error) { "K3s setup failed: $operation" }
             }
+            error("K3s cluster setup failed: " + result.errors.keys.joinToString(", "))
         }
 
         // Label db and app nodes with ordinals for StatefulSet pod-to-node pinning
         labelNodesWithOrdinals(controlHosts.first())
 
         // Ensure StorageClasses exist for Local PVs
-        k8sService
-            .ensureLocalStorageClass(controlHosts.first())
-            .getOrElse { exception ->
-                log.warn(exception) { "Failed to create local-storage StorageClass" }
-            }
-        k8sService
-            .ensureLocalStorageWfcClass(controlHosts.first())
-            .getOrElse { exception ->
-                log.warn(exception) { "Failed to create local-storage-wfc StorageClass" }
-            }
+        k8sService.ensureLocalStorageClass(controlHosts.first()).getOrThrow()
+        k8sService.ensureLocalStorageWfcClass(controlHosts.first()).getOrThrow()
 
-        commandExecutor.execute { GrafanaUpdateConfig() }
+        runNestedCommand { GrafanaUpdateConfig() }
     }
 
     /**
@@ -611,23 +670,21 @@ class Up : PicoBaseCommand() {
      */
     private fun labelNodesWithOrdinals(controlHost: ClusterHost) {
         // Label control node with type=control (db and app nodes get this via K3s agent config)
-        k8sService.labelNode(controlHost, controlHost.alias, mapOf("type" to "control")).getOrElse { exception ->
-            log.warn(exception) { "Failed to label control node ${controlHost.alias} with type=control" }
-        }
+        k8sService.labelNode(controlHost, controlHost.alias, mapOf("type" to "control")).getOrThrow()
 
         val dbHosts = workingState.hosts[ServerType.Cassandra] ?: emptyList()
         val appHosts = workingState.hosts[ServerType.Stress] ?: emptyList()
 
+        // Zero db nodes is a legal configuration (e.g. Trino + OpenSearch) — this is a skip
+        // because there is nothing to do, not a failure, so it must never warn.
         if (dbHosts.isEmpty()) {
-            log.warn { "No db nodes found, skipping db node labeling" }
+            log.debug { "No db nodes found, skipping db node labeling" }
         } else {
             eventBus.emit(Event.Provision.NodeLabeling(dbHosts.size))
             dbHosts.forEachIndexed { index, host ->
                 k8sService
                     .labelNode(controlHost, host.alias, mapOf(Constants.NODE_ORDINAL_LABEL to index.toString()))
-                    .getOrElse { exception ->
-                        log.warn(exception) { "Failed to label db node ${host.alias} with ordinal $index" }
-                    }
+                    .getOrThrow()
             }
             eventBus.emit(Event.Provision.NodeLabelingComplete)
         }
@@ -637,9 +694,7 @@ class Up : PicoBaseCommand() {
             appHosts.forEachIndexed { index, host ->
                 k8sService
                     .labelNode(controlHost, host.alias, mapOf(Constants.NODE_ORDINAL_LABEL to index.toString()))
-                    .getOrElse { exception ->
-                        log.warn(exception) { "Failed to label app node ${host.alias} with ordinal $index" }
-                    }
+                    .getOrThrow()
             }
             eventBus.emit(Event.Provision.NodeLabelingComplete)
         }
@@ -654,16 +709,7 @@ class Up : PicoBaseCommand() {
      */
     private fun configureRegistryTls() {
         val controlHosts = workingState.hosts[ServerType.Control] ?: emptyList()
-        if (controlHosts.isEmpty()) {
-            log.warn { "No control nodes found, skipping registry TLS configuration" }
-            return
-        }
-
-        val s3Bucket = workingState.s3Bucket
-        if (s3Bucket.isNullOrBlank()) {
-            log.warn { "S3 bucket not configured, skipping registry TLS configuration" }
-            return
-        }
+        val s3Bucket = checkNotNull(workingState.s3Bucket) { "S3 bucket must be configured before registry TLS setup" }
 
         val controlHost = controlHosts.first().toHost()
         val registryHost = controlHost.private

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/Restart.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/Restart.kt
@@ -2,6 +2,7 @@ package com.rustyrazorblade.easydblab.commands.cassandra
 
 import com.rustyrazorblade.easydblab.annotations.McpCommand
 import com.rustyrazorblade.easydblab.annotations.RequireProfileSetup
+import com.rustyrazorblade.easydblab.annotations.RequiresProxy
 import com.rustyrazorblade.easydblab.commands.PicoBaseCommand
 import com.rustyrazorblade.easydblab.commands.mixins.HostsMixin
 import com.rustyrazorblade.easydblab.configuration.ServerType
@@ -18,6 +19,7 @@ import picocli.CommandLine.Mixin
  */
 @McpCommand
 @RequireProfileSetup
+@RequiresProxy
 @Command(
     name = "restart",
     description = ["Restart cassandra"],

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/Start.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/Start.kt
@@ -3,6 +3,7 @@ package com.rustyrazorblade.easydblab.commands.cassandra
 import com.rustyrazorblade.easydblab.annotations.McpCommand
 import com.rustyrazorblade.easydblab.annotations.RequireProfileSetup
 import com.rustyrazorblade.easydblab.annotations.RequireSSHKey
+import com.rustyrazorblade.easydblab.annotations.RequiresProxy
 import com.rustyrazorblade.easydblab.commands.PicoBaseCommand
 import com.rustyrazorblade.easydblab.commands.mixins.HostsMixin
 import com.rustyrazorblade.easydblab.configuration.ServerType
@@ -24,6 +25,7 @@ import java.io.File
 @McpCommand
 @RequireProfileSetup
 @RequireSSHKey
+@RequiresProxy
 @Command(
     name = "start",
     description = ["Start cassandra on all nodes via service command"],

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/Stop.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/Stop.kt
@@ -2,6 +2,7 @@ package com.rustyrazorblade.easydblab.commands.cassandra
 
 import com.rustyrazorblade.easydblab.annotations.RequireProfileSetup
 import com.rustyrazorblade.easydblab.annotations.RequireSSHKey
+import com.rustyrazorblade.easydblab.annotations.RequiresProxy
 import com.rustyrazorblade.easydblab.commands.PicoBaseCommand
 import com.rustyrazorblade.easydblab.commands.mixins.HostsMixin
 import com.rustyrazorblade.easydblab.configuration.ServerType
@@ -21,6 +22,7 @@ import picocli.CommandLine.Mixin
  */
 @RequireProfileSetup
 @RequireSSHKey
+@RequiresProxy
 @Command(
     name = "stop",
     description = ["Stop cassandra on all nodes via service command"],

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/stress/StressFields.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/stress/StressFields.kt
@@ -3,6 +3,7 @@ package com.rustyrazorblade.easydblab.commands.cassandra.stress
 import com.rustyrazorblade.easydblab.Constants
 import com.rustyrazorblade.easydblab.annotations.McpCommand
 import com.rustyrazorblade.easydblab.annotations.RequireProfileSetup
+import com.rustyrazorblade.easydblab.annotations.RequiresProxy
 import com.rustyrazorblade.easydblab.commands.PicoBaseCommand
 import com.rustyrazorblade.easydblab.configuration.ServerType
 import com.rustyrazorblade.easydblab.events.Event
@@ -21,6 +22,7 @@ import picocli.CommandLine.Parameters
  */
 @McpCommand
 @RequireProfileSetup
+@RequiresProxy
 @Command(
     name = "fields",
     description = ["List available cassandra-easy-stress field generators"],

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/stress/StressInfo.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/stress/StressInfo.kt
@@ -3,6 +3,7 @@ package com.rustyrazorblade.easydblab.commands.cassandra.stress
 import com.rustyrazorblade.easydblab.Constants
 import com.rustyrazorblade.easydblab.annotations.McpCommand
 import com.rustyrazorblade.easydblab.annotations.RequireProfileSetup
+import com.rustyrazorblade.easydblab.annotations.RequiresProxy
 import com.rustyrazorblade.easydblab.commands.PicoBaseCommand
 import com.rustyrazorblade.easydblab.configuration.ServerType
 import com.rustyrazorblade.easydblab.events.Event
@@ -21,6 +22,7 @@ import picocli.CommandLine.Parameters
  */
 @McpCommand
 @RequireProfileSetup
+@RequiresProxy
 @Command(
     name = "info",
     description = ["Show information about a cassandra-easy-stress workload"],

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/stress/StressList.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/stress/StressList.kt
@@ -3,6 +3,7 @@ package com.rustyrazorblade.easydblab.commands.cassandra.stress
 import com.rustyrazorblade.easydblab.Constants
 import com.rustyrazorblade.easydblab.annotations.McpCommand
 import com.rustyrazorblade.easydblab.annotations.RequireProfileSetup
+import com.rustyrazorblade.easydblab.annotations.RequiresProxy
 import com.rustyrazorblade.easydblab.commands.PicoBaseCommand
 import com.rustyrazorblade.easydblab.configuration.ServerType
 import com.rustyrazorblade.easydblab.events.Event
@@ -21,6 +22,7 @@ import picocli.CommandLine.Parameters
  */
 @McpCommand
 @RequireProfileSetup
+@RequiresProxy
 @Command(
     name = "list",
     description = ["List available cassandra-easy-stress workloads"],

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/stress/StressLogs.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/stress/StressLogs.kt
@@ -2,6 +2,7 @@ package com.rustyrazorblade.easydblab.commands.cassandra.stress
 
 import com.rustyrazorblade.easydblab.annotations.McpCommand
 import com.rustyrazorblade.easydblab.annotations.RequireProfileSetup
+import com.rustyrazorblade.easydblab.annotations.RequiresProxy
 import com.rustyrazorblade.easydblab.commands.PicoBaseCommand
 import com.rustyrazorblade.easydblab.configuration.ServerType
 import com.rustyrazorblade.easydblab.events.Event
@@ -19,6 +20,7 @@ import picocli.CommandLine.Parameters
  */
 @McpCommand
 @RequireProfileSetup
+@RequiresProxy
 @Command(
     name = "logs",
     description = ["View logs from stress jobs"],

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/stress/StressStart.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/stress/StressStart.kt
@@ -3,6 +3,7 @@ package com.rustyrazorblade.easydblab.commands.cassandra.stress
 import com.rustyrazorblade.easydblab.Constants
 import com.rustyrazorblade.easydblab.annotations.McpCommand
 import com.rustyrazorblade.easydblab.annotations.RequireProfileSetup
+import com.rustyrazorblade.easydblab.annotations.RequiresProxy
 import com.rustyrazorblade.easydblab.commands.PicoBaseCommand
 import com.rustyrazorblade.easydblab.configuration.ServerType
 import com.rustyrazorblade.easydblab.events.Event
@@ -26,6 +27,7 @@ import picocli.CommandLine.Parameters
  */
 @McpCommand
 @RequireProfileSetup
+@RequiresProxy
 @Command(
     name = "start",
     aliases = ["run"],

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/stress/StressStatus.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/stress/StressStatus.kt
@@ -3,6 +3,7 @@ package com.rustyrazorblade.easydblab.commands.cassandra.stress
 import com.rustyrazorblade.easydblab.Constants
 import com.rustyrazorblade.easydblab.annotations.McpCommand
 import com.rustyrazorblade.easydblab.annotations.RequireProfileSetup
+import com.rustyrazorblade.easydblab.annotations.RequiresProxy
 import com.rustyrazorblade.easydblab.commands.PicoBaseCommand
 import com.rustyrazorblade.easydblab.configuration.ServerType
 import com.rustyrazorblade.easydblab.events.Event
@@ -20,6 +21,7 @@ import java.time.Duration
  */
 @McpCommand
 @RequireProfileSetup
+@RequiresProxy
 @Command(
     name = "status",
     description = ["Check status of stress jobs"],

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/stress/StressStop.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/stress/StressStop.kt
@@ -2,6 +2,7 @@ package com.rustyrazorblade.easydblab.commands.cassandra.stress
 
 import com.rustyrazorblade.easydblab.annotations.McpCommand
 import com.rustyrazorblade.easydblab.annotations.RequireProfileSetup
+import com.rustyrazorblade.easydblab.annotations.RequiresProxy
 import com.rustyrazorblade.easydblab.commands.PicoBaseCommand
 import com.rustyrazorblade.easydblab.configuration.ClusterHost
 import com.rustyrazorblade.easydblab.configuration.ServerType
@@ -20,6 +21,7 @@ import picocli.CommandLine.Parameters
  */
 @McpCommand
 @RequireProfileSetup
+@RequiresProxy
 @Command(
     name = "stop",
     description = ["Stop and delete stress jobs"],

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/grafana/GrafanaInstall.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/grafana/GrafanaInstall.kt
@@ -1,6 +1,7 @@
 package com.rustyrazorblade.easydblab.commands.grafana
 
 import com.rustyrazorblade.easydblab.annotations.RequireProfileSetup
+import com.rustyrazorblade.easydblab.annotations.RequiresProxy
 import com.rustyrazorblade.easydblab.commands.PicoBaseCommand
 import com.rustyrazorblade.easydblab.configuration.ServerType
 import com.rustyrazorblade.easydblab.services.GrafanaDashboardService
@@ -11,6 +12,7 @@ import picocli.CommandLine.Parameters
 import java.io.File
 
 @RequireProfileSetup
+@RequiresProxy
 @Command(
     name = "install",
     description = ["Upload a Grafana dashboard JSON file to the running Grafana instance"],

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/grafana/GrafanaUpdateConfig.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/grafana/GrafanaUpdateConfig.kt
@@ -1,7 +1,9 @@
 package com.rustyrazorblade.easydblab.commands.grafana
 
+import com.rustyrazorblade.easydblab.Constants
 import com.rustyrazorblade.easydblab.annotations.McpCommand
 import com.rustyrazorblade.easydblab.annotations.RequireProfileSetup
+import com.rustyrazorblade.easydblab.annotations.RequiresProxy
 import com.rustyrazorblade.easydblab.commands.PicoBaseCommand
 import com.rustyrazorblade.easydblab.configuration.ClusterHost
 import com.rustyrazorblade.easydblab.configuration.ServerType
@@ -45,6 +47,7 @@ import picocli.CommandLine.Command
  */
 @McpCommand
 @RequireProfileSetup
+@RequiresProxy
 @Command(
     name = "update-config",
     description = ["Build and apply the full observability stack to K8s cluster"],
@@ -111,6 +114,21 @@ class GrafanaUpdateConfig : PicoBaseCommand() {
 
         // Restart all observability workloads so they pick up new ConfigMaps
         restartObservabilityWorkloads(controlNode)
+
+        // Gate success on the whole stack actually reaching Ready. waitForPodsReady is namespace-wide
+        // (every pod in `default`) and fail-fast: it aborts immediately on CrashLoopBackOff /
+        // ImagePullBackOff and on timeout. This propagates a non-zero exit up through
+        // `Up.runNestedCommand { GrafanaUpdateConfig() }`, so `up` never reports success while the
+        // observability stack is broken or still coming up.
+        waitForObservabilityReady(controlNode)
+    }
+
+    private fun waitForObservabilityReady(controlNode: ClusterHost) {
+        k8sService
+            .waitForPodsReady(controlNode, Constants.K8s.OBSERVABILITY_READY_TIMEOUT_SECONDS)
+            .getOrElse { exception ->
+                error("Observability stack did not become ready: ${exception.message}")
+            }
     }
 
     private fun restartObservabilityWorkloads(controlNode: ClusterHost) {

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/install/KitInstallCommand.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/install/KitInstallCommand.kt
@@ -1,6 +1,7 @@
 package com.rustyrazorblade.easydblab.commands.install
 
 import com.rustyrazorblade.easydblab.Constants
+import com.rustyrazorblade.easydblab.annotations.RequiresProxy
 import com.rustyrazorblade.easydblab.configuration.ServerType
 import com.rustyrazorblade.easydblab.events.Event
 import com.rustyrazorblade.easydblab.services.ExtensionRegistry
@@ -23,6 +24,7 @@ import java.io.File
  * [OptionSpec][picocli.CommandLine.Model.OptionSpec] API; values land in [argValues] via ISetter
  * callbacks before [execute] is called.
  */
+@RequiresProxy
 class KitInstallCommand(
     private val config: KitConfig,
     private val source: InstallTemplateResolver.TemplateSource,

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/install/KitInstallCommandFactory.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/install/KitInstallCommandFactory.kt
@@ -81,7 +81,13 @@ class KitInstallCommandFactory(
                 .setter(
                     object : ISetter {
                         override fun <T> set(value: T): T {
-                            command.argValues[arg.variable] = "$value"
+                            // PicoCLI invokes this setter with null to initialise an unmatched
+                            // option that has no default (e.g. an optional `--extension`). Skip it:
+                            // stringifying null would record the literal "null" in argValues, which
+                            // then passes `isNotBlank()` downstream and is treated as a real value
+                            // (e.g. looked up as the extension alias "null"). Only record a value
+                            // the user actually supplied.
+                            value?.let { command.argValues[arg.variable] = it.toString() }
                             return value
                         }
                     },

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/install/KitRunnerCommand.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/install/KitRunnerCommand.kt
@@ -1,6 +1,7 @@
 package com.rustyrazorblade.easydblab.commands.install
 
 import com.rustyrazorblade.easydblab.Constants
+import com.rustyrazorblade.easydblab.annotations.RequiresProxy
 import com.rustyrazorblade.easydblab.commands.PicoBaseCommand
 import com.rustyrazorblade.easydblab.configuration.ClusterHost
 import com.rustyrazorblade.easydblab.events.Event
@@ -23,6 +24,7 @@ import java.io.File
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
+@RequiresProxy
 class KitRunnerCommand(
     private val kitName: String,
     private val kitDir: File,

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/install/KitStatusCommand.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/install/KitStatusCommand.kt
@@ -1,6 +1,7 @@
 package com.rustyrazorblade.easydblab.commands.install
 
 import com.rustyrazorblade.easydblab.Constants
+import com.rustyrazorblade.easydblab.annotations.RequiresProxy
 import com.rustyrazorblade.easydblab.commands.PicoBaseCommand
 import com.rustyrazorblade.easydblab.configuration.ClusterHost
 import com.rustyrazorblade.easydblab.configuration.ServerType
@@ -28,6 +29,7 @@ private sealed interface KitRunningState {
     ) : KitRunningState
 }
 
+@RequiresProxy
 @Command(name = "status")
 class KitStatusCommand(
     private val kitName: String,

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/logs/LogsBackup.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/logs/LogsBackup.kt
@@ -2,6 +2,7 @@ package com.rustyrazorblade.easydblab.commands.logs
 
 import com.rustyrazorblade.easydblab.annotations.McpCommand
 import com.rustyrazorblade.easydblab.annotations.RequireProfileSetup
+import com.rustyrazorblade.easydblab.annotations.RequiresProxy
 import com.rustyrazorblade.easydblab.commands.PicoBaseCommand
 import com.rustyrazorblade.easydblab.events.Event
 import com.rustyrazorblade.easydblab.services.VictoriaBackupService
@@ -24,6 +25,7 @@ import picocli.CommandLine.Option
  */
 @McpCommand
 @RequireProfileSetup
+@RequiresProxy
 @Command(
     name = "backup",
     description = ["Backup VictoriaLogs data to S3"],

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/logs/LogsImport.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/logs/LogsImport.kt
@@ -3,6 +3,7 @@ package com.rustyrazorblade.easydblab.commands.logs
 import com.rustyrazorblade.easydblab.Constants
 import com.rustyrazorblade.easydblab.annotations.McpCommand
 import com.rustyrazorblade.easydblab.annotations.RequireProfileSetup
+import com.rustyrazorblade.easydblab.annotations.RequiresProxy
 import com.rustyrazorblade.easydblab.commands.PicoBaseCommand
 import com.rustyrazorblade.easydblab.events.Event
 import com.rustyrazorblade.easydblab.services.VictoriaStreamService
@@ -24,6 +25,7 @@ import picocli.CommandLine.Option
  */
 @McpCommand
 @RequireProfileSetup
+@RequiresProxy
 @Command(
     name = "import",
     description = ["Import logs from cluster VictoriaLogs to an external instance"],

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/logs/LogsQuery.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/logs/LogsQuery.kt
@@ -2,6 +2,7 @@ package com.rustyrazorblade.easydblab.commands.logs
 
 import com.rustyrazorblade.easydblab.annotations.McpCommand
 import com.rustyrazorblade.easydblab.annotations.RequireProfileSetup
+import com.rustyrazorblade.easydblab.annotations.RequiresProxy
 import com.rustyrazorblade.easydblab.commands.PicoBaseCommand
 import com.rustyrazorblade.easydblab.events.Event
 import com.rustyrazorblade.easydblab.services.VictoriaLogsService
@@ -46,6 +47,7 @@ import picocli.CommandLine.Option
  */
 @McpCommand
 @RequireProfileSetup
+@RequiresProxy
 @Command(
     name = "query",
     description = ["Query logs from Victoria Logs"],

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/metrics/MetricsBackup.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/metrics/MetricsBackup.kt
@@ -2,6 +2,7 @@ package com.rustyrazorblade.easydblab.commands.metrics
 
 import com.rustyrazorblade.easydblab.annotations.McpCommand
 import com.rustyrazorblade.easydblab.annotations.RequireProfileSetup
+import com.rustyrazorblade.easydblab.annotations.RequiresProxy
 import com.rustyrazorblade.easydblab.commands.PicoBaseCommand
 import com.rustyrazorblade.easydblab.events.Event
 import com.rustyrazorblade.easydblab.services.VictoriaBackupService
@@ -24,6 +25,7 @@ import picocli.CommandLine.Option
  */
 @McpCommand
 @RequireProfileSetup
+@RequiresProxy
 @Command(
     name = "backup",
     description = ["Backup VictoriaMetrics data to S3"],

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/metrics/MetricsImport.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/metrics/MetricsImport.kt
@@ -3,6 +3,7 @@ package com.rustyrazorblade.easydblab.commands.metrics
 import com.rustyrazorblade.easydblab.Constants
 import com.rustyrazorblade.easydblab.annotations.McpCommand
 import com.rustyrazorblade.easydblab.annotations.RequireProfileSetup
+import com.rustyrazorblade.easydblab.annotations.RequiresProxy
 import com.rustyrazorblade.easydblab.commands.PicoBaseCommand
 import com.rustyrazorblade.easydblab.events.Event
 import com.rustyrazorblade.easydblab.services.VictoriaStreamService
@@ -24,6 +25,7 @@ import picocli.CommandLine.Option
  */
 @McpCommand
 @RequireProfileSetup
+@RequiresProxy
 @Command(
     name = "import",
     description = ["Import metrics from cluster VictoriaMetrics to an external instance"],

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/platform/PlatformCreatePvs.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/platform/PlatformCreatePvs.kt
@@ -2,6 +2,7 @@ package com.rustyrazorblade.easydblab.commands.platform
 
 import com.rustyrazorblade.easydblab.Constants
 import com.rustyrazorblade.easydblab.annotations.RequireProfileSetup
+import com.rustyrazorblade.easydblab.annotations.RequiresProxy
 import com.rustyrazorblade.easydblab.commands.PicoBaseCommand
 import com.rustyrazorblade.easydblab.configuration.ServerType
 import com.rustyrazorblade.easydblab.events.Event
@@ -12,6 +13,7 @@ import picocli.CommandLine.Command
 import picocli.CommandLine.Option
 
 @RequireProfileSetup
+@RequiresProxy
 @Command(
     name = "create-pvs",
     description = ["Create per-kit local PersistentVolumes on cluster nodes"],

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/spark/SparkLogs.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/spark/SparkLogs.kt
@@ -2,6 +2,7 @@ package com.rustyrazorblade.easydblab.commands.spark
 
 import com.rustyrazorblade.easydblab.annotations.McpCommand
 import com.rustyrazorblade.easydblab.annotations.RequireProfileSetup
+import com.rustyrazorblade.easydblab.annotations.RequiresProxy
 import com.rustyrazorblade.easydblab.commands.PicoBaseCommand
 import com.rustyrazorblade.easydblab.events.Event
 import com.rustyrazorblade.easydblab.services.SparkService
@@ -23,6 +24,7 @@ import picocli.CommandLine.Option
  */
 @McpCommand
 @RequireProfileSetup
+@RequiresProxy
 @Command(
     name = "logs",
     description = ["Query Spark/EMR logs from Victoria Logs"],

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/ClusterConfigWriter.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/ClusterConfigWriter.kt
@@ -23,6 +23,12 @@ object ClusterConfigWriter {
     ) {
         // write standard stuff first
         writer.appendLine("StrictHostKeyChecking=no")
+        // AWS recycles public IPs across ephemeral cluster lifetimes, so a host's key
+        // recorded in the developer's ~/.ssh/known_hosts can collide with a different
+        // cluster's key for the same IP. Pin to /dev/null so this config never reads
+        // or writes that file -- matching the MINA SSHD path used everywhere else,
+        // which verifies no host keys at all.
+        writer.appendLine("UserKnownHostsFile=/dev/null")
         writer.appendLine("User ubuntu")
         writer.appendLine("IdentityFile $identityFile")
 

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/grafana/GrafanaManifestBuilder.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/grafana/GrafanaManifestBuilder.kt
@@ -59,8 +59,13 @@ class GrafanaManifestBuilder(
         private const val READINESS_INITIAL_DELAY = 5
         private const val READINESS_PERIOD = 10
 
+        // Only externally-distributed plugins belong here. The Pyroscope datasource
+        // (grafana-pyroscope-datasource) is BUNDLED as a core plugin in Grafana 13.x — listing it
+        // makes the boot-time install step fail ("cannot install a Core plugin") and Grafana
+        // CrashLoopBackOffs. It is still declared as a datasource in GrafanaDatasourceConfig; the
+        // bundled plugin serves it without an install.
         private const val GRAFANA_PLUGINS =
-            "grafana-clickhouse-datasource,victoriametrics-logs-datasource,grafana-pyroscope-datasource,grafana-polystat-panel"
+            "grafana-clickhouse-datasource,victoriametrics-logs-datasource,grafana-polystat-panel"
 
         private const val RENDERER_TOKEN = "easydblab-renderer"
 

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/events/Event.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/events/Event.kt
@@ -2928,6 +2928,27 @@ sealed interface Event {
     @Serializable
     sealed interface Provision : Event {
         @Serializable
+        @SerialName("Provision.ControlNodeRequired")
+        data class ControlNodeRequired(
+            val configuredCount: Int,
+        ) : Provision {
+            override fun toDisplayString(): String =
+                "A control node is required, but the configuration specifies $configuredCount control instance(s)."
+
+            override fun isError(): Boolean = true
+        }
+
+        @Serializable
+        @SerialName("Provision.S3BucketRequired")
+        data class S3BucketRequired(
+            val clusterName: String,
+        ) : Provision {
+            override fun toDisplayString(): String = "An S3 bucket is required to provision cluster '$clusterName', but none is configured."
+
+            override fun isError(): Boolean = true
+        }
+
+        @Serializable
         @SerialName("Provision.IamUpdating")
         data object IamUpdating : Provision {
             override fun toDisplayString(): String = "Ensuring IAM policies are up to date..."
@@ -3062,30 +3083,6 @@ sealed interface Event {
         @SerialName("Provision.TailscaleStarting")
         data object TailscaleStarting : Provision {
             override fun toDisplayString(): String = "Starting Tailscale VPN..."
-        }
-
-        @Serializable
-        @SerialName("Provision.TailscaleWarning")
-        data class TailscaleWarning(
-            val error: String,
-        ) : Provision {
-            override fun toDisplayString(): String = "Warning: Failed to start Tailscale: $error"
-
-            override fun isError(): Boolean = true
-        }
-
-        @Serializable
-        @SerialName("Provision.TailscaleManualInstruction")
-        data object TailscaleManualInstruction : Provision {
-            override fun toDisplayString(): String = "You can manually start it later with: easy-db-lab tailscale start"
-        }
-
-        @Serializable
-        @SerialName("Provision.NoControlNodes")
-        data object NoControlNodes : Provision {
-            override fun toDisplayString(): String = "No control nodes found, skipping K3s setup"
-
-            override fun isError(): Boolean = true
         }
 
         @Serializable
@@ -3366,6 +3363,23 @@ sealed interface Event {
         @SerialName("Status.CassandraNoNodes")
         data object CassandraNoNodes : Status {
             override fun toDisplayString(): String = "\n=== CASSANDRA VERSION ===\n(no Cassandra nodes configured)"
+        }
+
+        /**
+         * A status section could not be read. Used when `status` degrades because the SOCKS
+         * proxy could not be established — see the class-level KDoc on `Status` and design
+         * decision D9 in `openspec/changes/up-fail-fast/design.md`. This is the one place a
+         * missing section is reported as data rather than skipped, because an MCP client or
+         * script reading status needs to know a section was never attempted, not just that it
+         * is absent.
+         */
+        @Serializable
+        @SerialName("Status.SectionUnavailable")
+        data class SectionUnavailable(
+            val section: String,
+            val reason: String,
+        ) : Status {
+            override fun toDisplayString(): String = "\n=== ${section.uppercase()} ===\n(unavailable: $reason)"
         }
     }
 

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/proxy/ProcessSocksProxyService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/proxy/ProcessSocksProxyService.kt
@@ -16,12 +16,40 @@ import kotlin.concurrent.withLock
 
 private val log = KotlinLogging.logger {}
 
+/** TCP port the control node's own `sshd` listens on — the end-to-end reachability target. */
+internal const val SSH_PORT = 22
+
+/** Matches `ssh -v` diagnostic lines (`debug1:`, `debug2:`, `debug3:`) so they can be dropped. */
+private val SSH_DEBUG_LINE = Regex("""^debug\d*:.*""")
+
+/**
+ * Reduces an `ssh -v` transcript to the lines most likely to explain a failure.
+ *
+ * `ssh -v` prefixes its chatter with `debug1:`/`debug2:`/`debug3:`; genuine errors and warnings
+ * (a changed host key, "Permission denied", "Connection refused") are emitted WITHOUT that prefix.
+ * Dropping the debug-prefixed lines and keeping the tail of the remainder surfaces whatever the
+ * real cause was without hardcoding a list of known error strings.
+ *
+ * @param tailLines how many trailing non-debug, non-blank lines to keep.
+ */
+internal fun stripSshDebugNoise(
+    lines: List<String>,
+    tailLines: Int,
+): List<String> =
+    lines
+        .filterNot { SSH_DEBUG_LINE.matches(it) }
+        .filter { it.isNotBlank() }
+        .takeLast(tailLines)
+
 /**
  * SOCKS5 proxy service that launches a detached `ssh -N -D` OS process.
  *
  * Unlike the previous in-process implementation, the SSH process outlives the JVM.
  * On each [ensureRunning] call the service checks `.socks5-proxy-state` for a reusable
- * process (PID alive + same controlIP + same sshConfig path) before starting a new one.
+ * process (PID alive + same controlIP + same sshConfig path + port genuinely accepting
+ * connections) before starting a new one. A live PID whose port is not accepting connections
+ * is a zombie tunnel and is never reused — a fresh proxy is started instead, and that start
+ * fails the calling command if it cannot be verified either.
  * When started, the proxy port is published via the private [Constants.Proxy.PORT_PROPERTY] system
  * property. The clients that need the tunnel (fabric8 K8s, OkHttp) read that port and configure the
  * SOCKS proxy explicitly. We deliberately do NOT set the standard `socksProxyHost`/`socksProxyPort`
@@ -32,11 +60,14 @@ private val log = KotlinLogging.logger {}
  */
 class ProcessSocksProxyService(
     private val context: Context,
+    private val reachabilityProbe: TunnelReachabilityProbe,
 ) : SocksProxyService {
     companion object {
         private const val VERIFY_RETRIES = 10
         private const val VERIFY_DELAY_MS = 500L
         private const val VERIFY_CONNECT_TIMEOUT_MS = 1000
+        private const val SSH_ERROR_TAIL_LINES = 15
+        private const val LOGS_DIR = "logs"
         private val json = Json { prettyPrint = true }
     }
 
@@ -46,9 +77,12 @@ class ProcessSocksProxyService(
 
     override fun ensureRunning(gatewayHost: ClusterHost): SocksProxyState =
         lock.withLock {
-            // Return in-memory state if still alive
+            // Return in-memory state if still alive AND the tunnel is genuinely accepting
+            // connections. A live PID with a dead port is a zombie tunnel (e.g. the remote side
+            // dropped the forward without killing the local process) and must not be reused —
+            // see isValidProxy() below, which enforces the same check on the state-file path.
             val current = state
-            if (current != null && isAlive(pid)) {
+            if (current != null && isAlive(pid) && isPortAccepting(current.localPort)) {
                 log.debug { "SOCKS5 proxy already running in-memory on port ${current.localPort} [PID $pid]" }
                 return@withLock current
             }
@@ -107,6 +141,21 @@ class ProcessSocksProxyService(
             }
         }
 
+    /**
+     * Starts a fresh SOCKS5 proxy `ssh` process to [gatewayHost] and verifies the tunnel is
+     * reachable end-to-end before publishing its port.
+     *
+     * Any previously published port is cleared up front, so a failed start here never leaves a
+     * stale port advertised to clients — they fall back to no-proxy rather than routing through
+     * a dead tunnel. [verifyTunnelReachable] runs before the new port is published; if it cannot
+     * prove the tunnel carries traffic to the control node within its retry window (or the ssh
+     * process dies first), it throws and [applySystemProperties] is never reached, so the dead
+     * port is never republished either. The `ssh -v` transcript is written to
+     * `logs/${Constants.Proxy.SOCKS5_PROXY_LOG_FILE}` and its real error is surfaced in the thrown
+     * message.
+     *
+     * @throws IllegalStateException if the tunnel never becomes reachable or ssh exits early
+     */
     private fun startNewProxy(
         gatewayHost: ClusterHost,
         sshConfigPath: String,
@@ -121,28 +170,45 @@ class ProcessSocksProxyService(
         val port = selectPort()
         log.info { "Starting SOCKS5 proxy to ${gatewayHost.alias} (${gatewayHost.privateIp}) on port $port" }
 
-        val logFile = File(context.workingDirectory, "socks5-proxy.log")
+        // ProcessBuilder's redirect will NOT create parent dirs; without this, ssh's stderr is
+        // silently discarded and the transcript we rely on for diagnosis would be lost.
+        val logDir = File(context.workingDirectory, LOGS_DIR)
+        logDir.mkdirs()
+        val logFile = File(logDir, Constants.Proxy.SOCKS5_PROXY_LOG_FILE)
         val process =
             ProcessBuilder(
                 "nohup",
                 "ssh",
                 "-v",
+                // Exit immediately if the dynamic forward can't be set up, instead of lingering
+                // with a half-open connection — this is what lets us detect a dead ssh fast.
+                "-o",
+                "ExitOnForwardFailure=yes",
                 "-N",
                 "-D",
                 "$port",
                 "-F",
                 sshConfigPath,
-                "control0",
+                gatewayHost.alias,
             ).apply {
                 redirectInput(ProcessBuilder.Redirect.from(File("/dev/null")))
                 redirectOutput(ProcessBuilder.Redirect.to(File("/dev/null")))
-                redirectError(ProcessBuilder.Redirect.appendTo(logFile))
+                // Overwrite (not append) so the log is always exactly this attempt's transcript.
+                redirectError(ProcessBuilder.Redirect.to(logFile))
             }.start()
 
         val newPid = process.pid().toInt()
         log.info { "SSH proxy process started [PID $newPid]" }
 
-        verifyProxyAcceptingConnections(port)
+        try {
+            verifyTunnelReachable(process, port, gatewayHost.privateIp, logFile)
+        } catch (e: IllegalStateException) {
+            // Verification failed: nothing will ever record this PID (the state file write
+            // below is never reached), so it would otherwise be an untracked orphan that
+            // `down` can never find and kill. Destroy it here instead of leaking it.
+            process.destroyForcibly()
+            throw e
+        }
 
         val clusterName = context.workingDirectory.name
         val fileState =
@@ -203,6 +269,10 @@ class ProcessSocksProxyService(
             log.debug { "Control IP changed (was ${loaded.controlIP}, now ${gatewayHost.privateIp})" }
             return false
         }
+        if (!isPortAccepting(loaded.port)) {
+            log.debug { "Proxy PID ${loaded.pid} is alive but port ${loaded.port} is not accepting connections" }
+            return false
+        }
         return true
     }
 
@@ -218,20 +288,76 @@ class ProcessSocksProxyService(
             false
         }
 
+    /**
+     * Verifies the tunnel is reachable end-to-end for up to [VERIFY_RETRIES] * [VERIFY_DELAY_MS],
+     * bailing out the instant the ssh [process] dies rather than polling a corpse for the full
+     * window.
+     *
+     * Success requires the [reachabilityProbe] to confirm an actual SOCKS5 round-trip to
+     * [targetPrivateIp]:[SSH_PORT], not merely that the local `-D` listener opened — the listener
+     * opens even when the remote side is dead. Fails fast by design: the caller must surface the
+     * failure so the invoking command aborts rather than proceeding against a dead tunnel.
+     *
+     * Internal (not private) purely so the loop's decisions — liveness-first, probe as the success
+     * condition, timeout, and exit-code reporting — can be driven directly in tests with a mock
+     * [Process] and a mock probe, without spawning a real ssh process.
+     *
+     * @throws IllegalStateException if ssh exits early or the tunnel never becomes reachable
+     */
     @Suppress("MagicNumber")
-    private fun verifyProxyAcceptingConnections(port: Int) {
+    internal fun verifyTunnelReachable(
+        process: Process,
+        port: Int,
+        targetPrivateIp: String,
+        logFile: File,
+    ) {
         repeat(VERIFY_RETRIES) { attempt ->
-            if (isPortAccepting(port)) {
-                log.debug { "SOCKS5 proxy accepting connections on port $port (attempt ${attempt + 1})" }
+            // A dead ssh (e.g. a changed host key kills it in ~50ms) will never open the tunnel;
+            // stop immediately instead of waiting out the remaining attempts.
+            if (!process.isAlive) {
+                throw IllegalStateException(verificationFailureMessage(logFile, exitCode = process.exitValue()))
+            }
+            if (reachabilityProbe.isReachable(port, targetPrivateIp, SSH_PORT)) {
+                log.debug { "SOCKS5 tunnel reachable end-to-end on port $port (attempt ${attempt + 1})" }
                 return
             }
-            log.debug { "SOCKS5 proxy not ready yet (attempt ${attempt + 1}/$VERIFY_RETRIES)" }
+            log.debug { "SOCKS5 tunnel not reachable yet (attempt ${attempt + 1}/$VERIFY_RETRIES)" }
             if (attempt < VERIFY_RETRIES - 1) {
                 Thread.sleep(VERIFY_DELAY_MS)
             }
         }
-        log.warn { "Could not verify SOCKS5 proxy is accepting connections on port $port — proceeding anyway" }
+        val exitCode = if (process.isAlive) null else process.exitValue()
+        throw IllegalStateException(verificationFailureMessage(logFile, exitCode))
     }
+
+    /**
+     * Builds the failure message for a proxy that never came up, naming the SOCKS proxy as the
+     * failing component, citing the ssh exit code when it died, and surfacing the real ssh error
+     * pulled from [logFile] (debug chatter stripped) plus the full transcript path.
+     */
+    private fun verificationFailureMessage(
+        logFile: File,
+        exitCode: Int?,
+    ): String {
+        val exitInfo = exitCode?.let { " (ssh exited with code $it)" } ?: ""
+        val errors = readSshErrors(logFile)
+        return buildString {
+            append("SOCKS5 proxy failed to establish a working tunnel$exitInfo. ")
+            append("See ${logFile.absolutePath} for the full ssh -v transcript.")
+            if (errors.isNotEmpty()) {
+                append("\nssh reported:\n")
+                append(errors.joinToString("\n"))
+            }
+        }
+    }
+
+    private fun readSshErrors(logFile: File): List<String> =
+        try {
+            stripSshDebugNoise(logFile.readLines(), SSH_ERROR_TAIL_LINES)
+        } catch (e: Exception) {
+            log.debug(e) { "Could not read ssh transcript from ${logFile.absolutePath}" }
+            emptyList()
+        }
 
     private fun buildProxyState(
         port: Int,

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/proxy/ProxyAvailability.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/proxy/ProxyAvailability.kt
@@ -1,0 +1,42 @@
+package com.rustyrazorblade.easydblab.proxy
+
+/**
+ * Records a SOCKS5 proxy establishment failure for the command currently executing, for the
+ * sole benefit of a command whose `@RequiresProxy(tolerateFailure = true)` annotation opts
+ * into tolerating that failure instead of aborting (see `Status`).
+ *
+ * `DefaultCommandExecutor.checkRequirements()` clears this before every command runs and, only
+ * for a tolerant command, records the failure here instead of letting it propagate as an
+ * exception. The command then queries [failure] from its own `execute()` to decide what it can
+ * still do. Every other command's proxy failure still propagates as a normal exception — this
+ * holder exists only to give an explicitly tolerant, read-only command a narrow way to observe
+ * "the tunnel is down" without reintroducing the blanket catch this change removed.
+ *
+ * Backed by a [ThreadLocal] so a stale failure recorded for one command can never leak into the
+ * next command executed on the same thread during a long-running `Server`/`Repl` session.
+ */
+interface ProxyAvailability {
+    /** Records that the proxy failed to establish for the command currently executing. */
+    fun recordFailure(cause: Throwable)
+
+    /** Clears any previously recorded failure. Called before every command executes. */
+    fun clear()
+
+    /** The recorded failure, if the proxy failed to establish for a tolerant command. */
+    fun failure(): Throwable?
+}
+
+/** Default [ProxyAvailability], backed by a [ThreadLocal]. */
+class DefaultProxyAvailability : ProxyAvailability {
+    private val state = ThreadLocal<Throwable?>()
+
+    override fun recordFailure(cause: Throwable) {
+        state.set(cause)
+    }
+
+    override fun clear() {
+        state.remove()
+    }
+
+    override fun failure(): Throwable? = state.get()
+}

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/proxy/ProxyModule.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/proxy/ProxyModule.kt
@@ -3,19 +3,34 @@ package com.rustyrazorblade.easydblab.proxy
 import com.rustyrazorblade.easydblab.services.ResourceManager
 import org.koin.dsl.module
 
+/** Socket timeout (ms) for a single end-to-end tunnel reachability probe. */
+private const val PROBE_CONNECT_TIMEOUT_MS = 1000
+
 /**
  * Koin module for proxy-related dependency injection.
  *
  * Provides:
+ * - [TunnelReachabilityProbe] as a singleton — the real SOCKS-based end-to-end tunnel check
  * - [SocksProxyService] as a singleton — manages the detached SSH proxy process
  * - [HttpClientFactory] for creating OkHttp clients (proxy routing via JVM system properties)
+ * - [ProxyAvailability] as a singleton — lets a `@RequiresProxy(tolerateFailure = true)`
+ *   command (currently only `Status`) observe a proxy establishment failure the executor
+ *   chose not to propagate
  */
 val proxyModule =
     module {
+        // End-to-end tunnel reachability probe — the injectable seam the proxy service uses to
+        // decide whether a freshly started tunnel actually carries traffic.
+        single<TunnelReachabilityProbe> { SocksTunnelReachabilityProbe(PROBE_CONNECT_TIMEOUT_MS) }
+
         // SOCKS proxy service - singleton to share state across requests.
         // Uses ProcessSocksProxyService which launches a detached OS process that
         // persists across JVM restarts and is reused via .socks5-proxy-state.
-        single<SocksProxyService> { ProcessSocksProxyService(get()) }
+        single<SocksProxyService> { ProcessSocksProxyService(get(), get()) }
+
+        // Proxy availability holder - singleton so DefaultCommandExecutor and the command it
+        // executes share the same instance within a process.
+        single<ProxyAvailability> { DefaultProxyAvailability() }
 
         // HTTP client factory — registered with ResourceManager so the cached OkHttpClient
         // is cleaned up on exit.

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/proxy/TunnelReachabilityProbe.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/proxy/TunnelReachabilityProbe.kt
@@ -1,0 +1,68 @@
+package com.rustyrazorblade.easydblab.proxy
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import java.net.InetSocketAddress
+import java.net.Proxy
+import java.net.Socket
+
+private val log = KotlinLogging.logger {}
+
+/** Prefix every `sshd` sends at the very start of its identification string (RFC 4253). */
+private const val SSH_BANNER_PREFIX = "SSH-"
+
+/**
+ * Proves a SOCKS5 tunnel carries traffic end-to-end, not merely that its local listener is open.
+ *
+ * This is the injectable seam [ProcessSocksProxyService] uses to decide whether a freshly started
+ * proxy is actually usable. It is an interface so the verify loop's decisions (liveness-first,
+ * probe-as-success-condition, timeout) can be driven deterministically in tests without a real
+ * ssh tunnel, while production wires in [SocksTunnelReachabilityProbe].
+ */
+fun interface TunnelReachabilityProbe {
+    /**
+     * @param localSocksPort the local port the SOCKS5 proxy listens on.
+     * @param targetHost host to reach THROUGH the tunnel (the control node's private IP).
+     * @param targetPort port to reach on [targetHost].
+     * @return true only if the tunnel demonstrably carried traffic to the target and back.
+     */
+    fun isReachable(
+        localSocksPort: Int,
+        targetHost: String,
+        targetPort: Int,
+    ): Boolean
+}
+
+/**
+ * The production [TunnelReachabilityProbe]: a thin JDK wrapper that performs a real SOCKS5 CONNECT
+ * through the local proxy to the target and reads back the first bytes.
+ *
+ * OpenSSH opens the local `-D` listener regardless of whether the remote side of the tunnel is
+ * healthy, so a bare local TCP connect passes even against a dead tunnel. Routing an actual SOCKS5
+ * CONNECT to the control node's own `sshd` — which is definitionally up because the tunnel rides on
+ * it — and reading its immediate `SSH-2.0-...` identification string proves the full chain: local
+ * listener → ssh tunnel → control node → onward TCP to a private IP → bytes back.
+ */
+class SocksTunnelReachabilityProbe(
+    private val connectTimeoutMs: Int,
+) : TunnelReachabilityProbe {
+    override fun isReachable(
+        localSocksPort: Int,
+        targetHost: String,
+        targetPort: Int,
+    ): Boolean =
+        try {
+            val proxy = Proxy(Proxy.Type.SOCKS, InetSocketAddress("127.0.0.1", localSocksPort))
+            Socket(proxy).use { socket ->
+                socket.soTimeout = connectTimeoutMs
+                socket.connect(InetSocketAddress(targetHost, targetPort), connectTimeoutMs)
+                // Read the SSH banner to prove bytes flow BACK through the tunnel, not just that the
+                // SOCKS CONNECT setup succeeded. sshd sends "SSH-2.0-..." immediately on connect.
+                val buf = ByteArray(SSH_BANNER_PREFIX.length)
+                val read = socket.getInputStream().read(buf)
+                read >= SSH_BANNER_PREFIX.length && String(buf, 0, SSH_BANNER_PREFIX.length) == SSH_BANNER_PREFIX
+            }
+        } catch (e: Exception) {
+            log.debug(e) { "SOCKS tunnel probe to $targetHost:$targetPort via 127.0.0.1:$localSocksPort failed" }
+            false
+        }
+}

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/CommandExecutor.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/CommandExecutor.kt
@@ -5,6 +5,7 @@ import com.rustyrazorblade.easydblab.Context
 import com.rustyrazorblade.easydblab.annotations.RequireDocker
 import com.rustyrazorblade.easydblab.annotations.RequireProfileSetup
 import com.rustyrazorblade.easydblab.annotations.RequireSSHKey
+import com.rustyrazorblade.easydblab.annotations.RequiresProxy
 import com.rustyrazorblade.easydblab.annotations.TriggerBackup
 import com.rustyrazorblade.easydblab.commands.PicoCommand
 import com.rustyrazorblade.easydblab.commands.SetupProfile
@@ -13,6 +14,7 @@ import com.rustyrazorblade.easydblab.configuration.UserConfigProvider
 import com.rustyrazorblade.easydblab.events.Event
 import com.rustyrazorblade.easydblab.events.EventBus
 import com.rustyrazorblade.easydblab.providers.docker.DockerClientProvider
+import com.rustyrazorblade.easydblab.proxy.ProxyAvailability
 import com.rustyrazorblade.easydblab.proxy.SocksProxyService
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.koin.core.component.KoinComponent
@@ -29,7 +31,7 @@ import kotlin.system.exitProcess
  * - [schedule]: Schedule a command to run after the current command's lifecycle completes.
  *
  * The full lifecycle includes:
- * 1. Requirement checks (@RequireProfileSetup, @RequireSSHKey, @RequireDocker)
+ * 1. Requirement checks (@RequireProfileSetup, @RequireSSHKey, @RequireDocker, @RequiresProxy)
  * 2. Pre-execute hooks (@PreExecute)
  * 3. Command execution
  * 4. Post-execute hooks (@PostExecute)
@@ -88,6 +90,7 @@ class DefaultCommandExecutor(
     private val resourceManager: ResourceManager,
     private val eventBus: EventBus,
     private val socksProxyService: SocksProxyService,
+    private val proxyAvailability: ProxyAvailability,
 ) : CommandExecutor,
     KoinComponent {
     // Lazy injection - only resolves when first accessed (defers AWS dependency chain)
@@ -109,10 +112,9 @@ class DefaultCommandExecutor(
      * Execute a command with full lifecycle, then process any scheduled commands.
      * This is the entry point for top-level command execution (called by CommandLineParser).
      *
-     * Starts the SOCKS5 proxy eagerly before executing any command, when the cluster is
-     * provisioned, infrastructure is UP, and Tailscale is not enabled. This guarantees the
-     * proxy is always available before any service needs it, and automatically restarts it
-     * if the process was killed between invocations.
+     * The SOCKS5 proxy is started by [checkRequirements] — see [ensureProxyRunning] — only for
+     * the command(s) actually executed (this one, and any it schedules or delegates to) that
+     * carry [RequiresProxy]. A command that never declares the dependency never starts a tunnel.
      *
      * @param command The command to execute
      * @return Exit code (0 for success, non-zero for failure)
@@ -120,10 +122,6 @@ class DefaultCommandExecutor(
     fun executeTopLevel(command: PicoCommand): Int {
         // VPC reconstruction from environment variable (if set)
         handleVpcReconstructionFromEnv()
-
-        // Eagerly start SOCKS5 proxy when cluster is provisioned and Tailscale is not active.
-        // ensureRunning is idempotent — it reuses the existing OS process if it is still alive.
-        ensureProxyRunning()
 
         try {
             val exitCode = executeWithLifecycle(command)
@@ -153,11 +151,15 @@ class DefaultCommandExecutor(
     }
 
     /**
-     * Starts the SOCKS5 proxy if the cluster is provisioned, infrastructure is UP,
-     * and Tailscale is not active. Failures are logged as warnings and do not abort
-     * the command — the proxy may not be reachable during teardown or partial failures.
+     * Starts the SOCKS5 proxy for commands that carry [RequiresProxy] (see [checkRequirements]),
+     * when the cluster is provisioned, infrastructure is UP, and Tailscale is not active.
+     *
+     * A failure to establish the proxy propagates to the caller rather than being swallowed:
+     * the annotation is the assertion that the command cannot proceed without a working tunnel,
+     * so publishing a dead one (or silently running without it) would only defer the failure to
+     * a more confusing Fabric8/HTTP error later. `Down` is never annotated, so it never starts a
+     * tunnel it would immediately have to tear down.
      */
-    @Suppress("TooGenericExceptionCaught")
     private fun ensureProxyRunning() {
         if (!clusterStateManager.exists()) return
         val state =
@@ -171,26 +173,25 @@ class DefaultCommandExecutor(
         if (state.isTailscaleEnabled()) return
         val controlHost = state.getControlHost() ?: return
 
-        try {
-            socksProxyService.ensureRunning(controlHost)
-        } catch (e: Exception) {
-            log.warn(e) { "SOCKS5 proxy startup failed — proceeding without proxy" }
-        }
+        socksProxyService.ensureRunning(controlHost)
     }
 
     /**
      * Executes a command with the complete lifecycle:
-     * 1. Check requirements
+     * 1. Check requirements (may propagate a failure, exit the process, or run setup)
      * 2. Execute command (includes @PreExecute, execute(), @PostExecute via PicoCommand.call())
      * 3. Handle post-success actions
+     *
+     * Requirement checks and command execution share one try/catch so that a failure raised
+     * while checking requirements (e.g. [RequiresProxy] failing to establish the tunnel) is
+     * reported and converted to a non-zero exit code exactly like a failure inside the command
+     * itself, rather than escaping uncaught.
      */
+    @Suppress("TooGenericExceptionCaught")
     private fun executeWithLifecycle(command: PicoCommand): Int {
-        // 1. Check requirements (may exit process on failure or run setup)
-        checkRequirements(command)
-
-        // 2. Execute with PicoCommand lifecycle (@PreExecute, execute(), @PostExecute)
         val exitCode =
             try {
+                checkRequirements(command)
                 command.call()
             } catch (e: Exception) {
                 log.error(e) { "Command execution failed" }
@@ -216,6 +217,12 @@ class DefaultCommandExecutor(
      */
     private fun checkRequirements(command: PicoCommand) {
         val annotations = command::class.annotations
+
+        // Clear any proxy failure recorded for a previous command before this one runs. Without
+        // this, a Server/Repl session that keeps the process alive across many commands could
+        // let a stale failure from an earlier command leak into a later one that never touched
+        // the proxy at all.
+        proxyAvailability.clear()
 
         // Check if the command requires profile setup
         if (annotations.any { it is RequireProfileSetup }) {
@@ -247,6 +254,33 @@ class DefaultCommandExecutor(
             if (!checkSSHKeyAvailability()) {
                 eventBus.emit(Event.Command.SshKeyMissing(requirementCheckDeps.userConfigProvider.sshKeyPath))
                 exitProcess(1)
+            }
+        }
+
+        // Start the SOCKS5 proxy for commands that declare a dependency on it. A failure here
+        // propagates — see ensureProxyRunning — and is caught by the try/catch in
+        // executeWithLifecycle exactly like a failure inside the command itself.
+        //
+        // The single exception is a command whose annotation sets tolerateFailure = true
+        // (currently only Status, see RequiresProxy's KDoc and design decision D9). For that
+        // narrow, explicitly-declared case, the failure is recorded on ProxyAvailability instead
+        // of propagating, and the command runs anyway — it is the command's own job to query
+        // ProxyAvailability and degrade. This is not the blanket "proceeding without proxy"
+        // swallow this change removed: it applies only to a command that opted in at its
+        // declaration site, and only to this one failure.
+        val requiresProxy = annotations.filterIsInstance<RequiresProxy>().firstOrNull()
+        if (requiresProxy != null) {
+            if (requiresProxy.tolerateFailure) {
+                runCatching { ensureProxyRunning() }
+                    .onFailure { e ->
+                        log.warn(e) {
+                            "Proxy failed to establish for ${command::class.simpleName}; " +
+                                "this command tolerates the failure and will report degraded state"
+                        }
+                        proxyAvailability.recordFailure(e)
+                    }
+            } else {
+                ensureProxyRunning()
             }
         }
     }

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/ServicesModule.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/ServicesModule.kt
@@ -23,6 +23,7 @@ import com.rustyrazorblade.easydblab.providers.aws.AWS
 import com.rustyrazorblade.easydblab.providers.aws.VpcService
 import com.rustyrazorblade.easydblab.providers.docker.DockerClientProvider
 import com.rustyrazorblade.easydblab.proxy.HttpClientFactory
+import com.rustyrazorblade.easydblab.proxy.ProxyAvailability
 import com.rustyrazorblade.easydblab.proxy.SocksProxyService
 import com.rustyrazorblade.easydblab.services.aws.EC2InstanceService
 import com.rustyrazorblade.easydblab.services.aws.EMRService
@@ -168,6 +169,7 @@ val servicesModule =
                 get<ResourceManager>(),
                 get<EventBus>(),
                 get<SocksProxyService>(),
+                get<ProxyAvailability>(),
             )
         }
     }

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/commands/StatusTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/commands/StatusTest.kt
@@ -1,6 +1,7 @@
 package com.rustyrazorblade.easydblab.commands
 
 import com.rustyrazorblade.easydblab.BaseKoinTest
+import com.rustyrazorblade.easydblab.Version
 import com.rustyrazorblade.easydblab.configuration.ClusterHost
 import com.rustyrazorblade.easydblab.configuration.ClusterState
 import com.rustyrazorblade.easydblab.configuration.ClusterStateManager
@@ -9,6 +10,7 @@ import com.rustyrazorblade.easydblab.configuration.InfrastructureState
 import com.rustyrazorblade.easydblab.configuration.InfrastructureStatus
 import com.rustyrazorblade.easydblab.configuration.NodeState
 import com.rustyrazorblade.easydblab.configuration.ServerType
+import com.rustyrazorblade.easydblab.configuration.UserConfigProvider
 import com.rustyrazorblade.easydblab.output.BufferedOutputHandler
 import com.rustyrazorblade.easydblab.output.OutputHandler
 import com.rustyrazorblade.easydblab.providers.aws.EMRClusterStatus
@@ -16,12 +18,20 @@ import com.rustyrazorblade.easydblab.providers.aws.InstanceDetails
 import com.rustyrazorblade.easydblab.providers.aws.SecurityGroupDetails
 import com.rustyrazorblade.easydblab.providers.aws.SecurityGroupRuleInfo
 import com.rustyrazorblade.easydblab.providers.aws.VpcService
+import com.rustyrazorblade.easydblab.providers.docker.DockerClientProvider
 import com.rustyrazorblade.easydblab.providers.ssh.RemoteOperationsService
+import com.rustyrazorblade.easydblab.proxy.DefaultProxyAvailability
+import com.rustyrazorblade.easydblab.proxy.ProxyAvailability
 import com.rustyrazorblade.easydblab.proxy.SocksProxyService
+import com.rustyrazorblade.easydblab.services.CommandExecutor
+import com.rustyrazorblade.easydblab.services.DefaultCommandExecutor
+import com.rustyrazorblade.easydblab.services.RequirementCheckDeps
+import com.rustyrazorblade.easydblab.services.ResourceManager
 import com.rustyrazorblade.easydblab.services.StressJobService
 import com.rustyrazorblade.easydblab.services.aws.EC2InstanceService
 import com.rustyrazorblade.easydblab.services.aws.EMRService
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -43,12 +53,14 @@ class StatusTest : BaseKoinTest() {
     private val mockEmrService: EMRService = mock()
     private val mockStressJobService: StressJobService = mock()
     private lateinit var outputHandler: BufferedOutputHandler
+    private lateinit var proxyAvailability: ProxyAvailability
     private val stdout = ByteArrayOutputStream()
     private val originalOut = System.out
 
     @BeforeEach
     fun captureStdout() {
         outputHandler = getKoin().get<OutputHandler>() as BufferedOutputHandler
+        proxyAvailability = getKoin().get()
         System.setOut(PrintStream(stdout))
     }
 
@@ -121,6 +133,7 @@ class StatusTest : BaseKoinTest() {
                 single<RemoteOperationsService> { mockRemoteOperationsService }
                 single<EMRService> { mockEmrService }
                 single<StressJobService> { mockStressJobService }
+                single<ProxyAvailability> { DefaultProxyAvailability() }
             },
         )
 
@@ -292,6 +305,114 @@ class StatusTest : BaseKoinTest() {
         val output = capturedOutput()
         assertThat(output).contains("=== S3 BUCKET ===")
         assertThat(output).contains("(no S3 bucket configured)")
+    }
+
+    // ========== DEGRADED STATUS (PROXY FAILURE) TESTS ==========
+    //
+    // `status` is the single command permitted to degrade rather than abort when the SOCKS
+    // proxy cannot be established (see openspec/changes/up-fail-fast/design.md, decision D9).
+    // These tests simulate that by recording a failure directly on ProxyAvailability — exactly
+    // what DefaultCommandExecutor.checkRequirements() does for a command whose @RequiresProxy
+    // sets tolerateFailure = true, before Status.execute() ever runs.
+
+    @Test
+    fun `execute still reports EC2 instance and VPC networking state when the proxy cannot be established`() {
+        setupBasicClusterState()
+        setupInstanceStates()
+        proxyAvailability.recordFailure(RuntimeException("port never began accepting connections — see socks5-proxy.log"))
+
+        assertThatThrownBy { Status().execute() }.isInstanceOf(StatusDegradedException::class.java)
+
+        val output = capturedOutput()
+        assertThat(output).contains("=== NODES ===")
+        assertThat(output).contains("db0")
+        assertThat(output).contains("=== NETWORKING ===")
+        assertThat(output).contains("vpc-12345")
+    }
+
+    @Test
+    fun `execute marks only the tunnel-dependent sections unavailable, citing the proxy failure`() {
+        setupBasicClusterState()
+        setupInstanceStates()
+        proxyAvailability.recordFailure(RuntimeException("port never began accepting connections — see socks5-proxy.log"))
+
+        assertThatThrownBy { Status().execute() }.isInstanceOf(StatusDegradedException::class.java)
+
+        val events = outputHandler.messages.joinToString("\n")
+        // The two sections sourced from the private Kubernetes API (Fabric8) are unavailable...
+        assertThat(events).contains("STRESS JOBS")
+        assertThat(events).contains("CLICKHOUSE")
+        // ...each stating the proxy failure as its reason, not merely "unavailable".
+        val reasonOccurrences = events.split("port never began accepting connections").size - 1
+        assertThat(reasonOccurrences).isEqualTo(2)
+        // The database version is sourced over SSH, which never traverses the tunnel, so it is
+        // NOT marked unavailable even though the proxy is down.
+        assertThat(events).doesNotContain("DATABASE VERSION")
+    }
+
+    @Test
+    fun `execute still reports the database version over SSH when the proxy cannot be established`() {
+        setupBasicClusterState()
+        setupInstanceStates()
+        // SSH does not go through the SOCKS tunnel, so a live version is still reachable.
+        whenever(mockRemoteOperationsService.getRemoteVersion(any(), any()))
+            .thenReturn(Version.fromString("5.0.2"))
+        proxyAvailability.recordFailure(RuntimeException("port never began accepting connections — see socks5-proxy.log"))
+
+        assertThatThrownBy { Status().execute() }.isInstanceOf(StatusDegradedException::class.java)
+
+        val output = capturedOutput()
+        // The section a proxy failure previously (wrongly) suppressed now renders over SSH.
+        assertThat(output).contains("=== CASSANDRA VERSION ===")
+        assertThat(output).contains("Version (live): 5.0.2")
+    }
+
+    @Test
+    fun `execute does not abort before rendering the sections it can observe when the proxy cannot be established`() {
+        setupBasicClusterState()
+        setupInstanceStates()
+        proxyAvailability.recordFailure(RuntimeException("port never began accepting connections — see socks5-proxy.log"))
+
+        // The degraded report (cluster/nodes/networking + unavailable markers) must have been
+        // fully rendered before execute() throws to signal the non-zero exit code.
+        assertThatThrownBy { Status().execute() }.isInstanceOf(StatusDegradedException::class.java)
+
+        assertThat(capturedOutput()).contains("=== CLUSTER STATUS ===", "=== NODES ===", "=== NETWORKING ===")
+    }
+
+    @Test
+    fun `execute exits non-zero via the command executor when status degrades due to a proxy failure`() {
+        setupBasicClusterState()
+        setupInstanceStates()
+
+        val mockUserConfigProvider: UserConfigProvider = mock()
+        whenever(mockUserConfigProvider.isSetup()).thenReturn(true)
+        val mockDockerClientProvider: DockerClientProvider = mock()
+        val mockResourceManager: ResourceManager = mock()
+        val mockSocksProxyService: SocksProxyService = mock()
+        whenever(mockSocksProxyService.ensureRunning(any()))
+            .thenThrow(RuntimeException("port never began accepting connections — see socks5-proxy.log"))
+
+        val commandExecutor: CommandExecutor =
+            DefaultCommandExecutor(
+                context = context,
+                clusterStateManager = mockClusterStateManager,
+                requirementCheckDeps =
+                    RequirementCheckDeps(
+                        userConfigProvider = mockUserConfigProvider,
+                        dockerClientProvider = mockDockerClientProvider,
+                    ),
+                resourceManager = mockResourceManager,
+                eventBus = getKoin().get(),
+                socksProxyService = mockSocksProxyService,
+                proxyAvailability = proxyAvailability,
+            )
+
+        // When - status is run through the real executor, exactly as it would be from the CLI
+        val exitCode = commandExecutor.execute { Status() }
+
+        // Then - a partial report must never be read by a script as a healthy cluster
+        assertThat(exitCode).isNotEqualTo(0)
     }
 
     private fun setupBasicClusterStateWithEmr() {

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/commands/UpTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/commands/UpTest.kt
@@ -1,0 +1,546 @@
+package com.rustyrazorblade.easydblab.commands
+
+import com.rustyrazorblade.easydblab.BaseKoinTest
+import com.rustyrazorblade.easydblab.Version
+import com.rustyrazorblade.easydblab.configuration.ClusterHost
+import com.rustyrazorblade.easydblab.configuration.ClusterState
+import com.rustyrazorblade.easydblab.configuration.ClusterStateManager
+import com.rustyrazorblade.easydblab.configuration.Host
+import com.rustyrazorblade.easydblab.configuration.InitConfig
+import com.rustyrazorblade.easydblab.configuration.ServerType
+import com.rustyrazorblade.easydblab.configuration.User
+import com.rustyrazorblade.easydblab.output.BufferedOutputHandler
+import com.rustyrazorblade.easydblab.output.OutputHandler
+import com.rustyrazorblade.easydblab.providers.aws.VpcInfrastructure
+import com.rustyrazorblade.easydblab.providers.aws.VpcService
+import com.rustyrazorblade.easydblab.providers.ssh.RemoteOperationsService
+import com.rustyrazorblade.easydblab.proxy.SocksProxyService
+import com.rustyrazorblade.easydblab.services.CiliumService
+import com.rustyrazorblade.easydblab.services.ClusterConfigurationService
+import com.rustyrazorblade.easydblab.services.ClusterProvisioningService
+import com.rustyrazorblade.easydblab.services.CommandExecutor
+import com.rustyrazorblade.easydblab.services.HostOperationsService
+import com.rustyrazorblade.easydblab.services.K3sClusterService
+import com.rustyrazorblade.easydblab.services.K3sSetupResult
+import com.rustyrazorblade.easydblab.services.K8sService
+import com.rustyrazorblade.easydblab.services.ProvisioningResult
+import com.rustyrazorblade.easydblab.services.RegistryService
+import com.rustyrazorblade.easydblab.services.aws.AMIResolver
+import com.rustyrazorblade.easydblab.services.aws.AwsInfrastructureService
+import com.rustyrazorblade.easydblab.services.aws.AwsS3BucketService
+import com.rustyrazorblade.easydblab.services.aws.DefaultInstanceSpecFactory
+import com.rustyrazorblade.easydblab.services.aws.EC2InstanceService
+import com.rustyrazorblade.easydblab.services.aws.InstanceSpecFactory
+import com.rustyrazorblade.easydblab.services.aws.OpenSearchService
+import com.rustyrazorblade.easydblab.ssh.Response
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatCode
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.koin.core.module.Module
+import org.koin.dsl.module
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.io.File
+import java.nio.file.Path
+
+/**
+ * Tests for [Up], the command that provisions and configures the complete cluster.
+ *
+ * These tests exercise the fail-fast invariant established by the `up-fail-fast` change: if
+ * `up` reports success, every provisioning step actually succeeded. Every failure site is
+ * driven through a full [Up.execute] call against a fully-wired "happy path" fixture, with a
+ * single collaborator overridden per test to induce the failure under test — proving the
+ * behavior actually aborts `up`, not merely that a mock was called.
+ */
+class UpTest : BaseKoinTest() {
+    private lateinit var mockClusterStateManager: ClusterStateManager
+    private lateinit var mockS3BucketService: AwsS3BucketService
+    private lateinit var mockVpcService: VpcService
+    private lateinit var mockAwsInfrastructureService: AwsInfrastructureService
+    private lateinit var mockEc2InstanceService: EC2InstanceService
+    private lateinit var mockAmiResolver: AMIResolver
+    private lateinit var mockClusterProvisioningService: ClusterProvisioningService
+    private lateinit var mockClusterConfigurationService: ClusterConfigurationService
+    private lateinit var mockK3sClusterService: K3sClusterService
+    private lateinit var mockK8sService: K8sService
+    private lateinit var mockCommandExecutor: CommandExecutor
+    private lateinit var outputHandler: BufferedOutputHandler
+
+    /** exit code returned by the fake CommandExecutor for a nested command, keyed by simple class name */
+    private val nestedCommandExitCodes = mutableMapOf<String, Int>()
+
+    /** simple class names of every nested command routed through the fake CommandExecutor, in order */
+    private val invokedCommandNames = mutableListOf<String>()
+
+    /** when non-null, remoteOps.executeRemotely throws this for the given host alias */
+    private var sshFailureAlias: String? = null
+    private var sshFailureException: Exception? = null
+    private val sshCheckedAliases = mutableListOf<String>()
+
+    private val testControlHost =
+        ClusterHost(
+            publicIp = "54.1.1.1",
+            privateIp = "10.0.0.1",
+            alias = "control0",
+            availabilityZone = "us-west-2a",
+            instanceId = "i-control0",
+        )
+    private val testDbHost =
+        ClusterHost(publicIp = "54.1.1.2", privateIp = "10.0.0.2", alias = "db0", availabilityZone = "us-west-2a", instanceId = "i-db0")
+    private val testAppHost =
+        ClusterHost(publicIp = "54.1.1.3", privateIp = "10.0.0.3", alias = "app0", availabilityZone = "us-west-2a", instanceId = "i-app0")
+
+    override fun additionalTestModules(): List<Module> =
+        listOf(
+            module {
+                single<ClusterStateManager> { mock<ClusterStateManager>().also { mockClusterStateManager = it } }
+                single<AwsS3BucketService> { mock<AwsS3BucketService>().also { mockS3BucketService = it } }
+                single<OpenSearchService> { mock<OpenSearchService>() }
+                single<VpcService> { mock<VpcService>().also { mockVpcService = it } }
+                single<AwsInfrastructureService> { mock<AwsInfrastructureService>().also { mockAwsInfrastructureService = it } }
+                single<EC2InstanceService> { mock<EC2InstanceService>().also { mockEc2InstanceService = it } }
+                single<HostOperationsService> { HostOperationsService(get()) }
+                single<AMIResolver> { mock<AMIResolver>().also { mockAmiResolver = it } }
+                single<InstanceSpecFactory> { DefaultInstanceSpecFactory() }
+                single<ClusterProvisioningService> { mock<ClusterProvisioningService>().also { mockClusterProvisioningService = it } }
+                single<ClusterConfigurationService> { mock<ClusterConfigurationService>().also { mockClusterConfigurationService = it } }
+                single<K3sClusterService> { mock<K3sClusterService>().also { mockK3sClusterService = it } }
+                single<CiliumService> { mock<CiliumService>() }
+                single<K8sService> { mock<K8sService>().also { mockK8sService = it } }
+                single<RegistryService> { mock<RegistryService>() }
+                single<SocksProxyService> { mock<SocksProxyService>() }
+                single<CommandExecutor> { mock<CommandExecutor>().also { mockCommandExecutor = it } }
+
+                factory<RemoteOperationsService> {
+                    object : RemoteOperationsService {
+                        override fun executeRemotely(
+                            host: Host,
+                            command: String,
+                            output: Boolean,
+                            secret: Boolean,
+                        ): Response {
+                            if (command == "echo 1") sshCheckedAliases.add(host.alias)
+                            val failingAlias = sshFailureAlias
+                            val failure = sshFailureException
+                            if (failingAlias != null && failure != null && host.alias == failingAlias) {
+                                throw failure
+                            }
+                            return Response("")
+                        }
+
+                        override fun upload(
+                            host: Host,
+                            local: Path,
+                            remote: String,
+                        ) = Unit
+
+                        override fun uploadDirectory(
+                            host: Host,
+                            localDir: File,
+                            remoteDir: String,
+                        ) = Unit
+
+                        override fun uploadDirectory(
+                            host: Host,
+                            version: Version,
+                        ) = Unit
+
+                        override fun download(
+                            host: Host,
+                            remote: String,
+                            local: Path,
+                        ) = Unit
+
+                        override fun downloadDirectory(
+                            host: Host,
+                            remoteDir: String,
+                            localDir: File,
+                            includeFilters: List<String>,
+                            excludeFilters: List<String>,
+                        ) = Unit
+
+                        override fun getRemoteVersion(
+                            host: Host,
+                            inputVersion: String,
+                        ): Version = Version.fromString("5.0")
+                    }
+                }
+            },
+        )
+
+    @BeforeEach
+    fun setupMocks() {
+        mockClusterStateManager = getKoin().get()
+        mockS3BucketService = getKoin().get()
+        mockVpcService = getKoin().get()
+        mockAwsInfrastructureService = getKoin().get()
+        mockEc2InstanceService = getKoin().get()
+        mockAmiResolver = getKoin().get()
+        mockClusterProvisioningService = getKoin().get()
+        mockClusterConfigurationService = getKoin().get()
+        mockK3sClusterService = getKoin().get()
+        mockK8sService = getKoin().get()
+        mockCommandExecutor = getKoin().get()
+        outputHandler = getKoin().get<OutputHandler>() as BufferedOutputHandler
+
+        nestedCommandExitCodes.clear()
+        invokedCommandNames.clear()
+        sshFailureAlias = null
+        sshFailureException = null
+        sshCheckedAliases.clear()
+
+        whenever(mockClusterStateManager.load()).thenReturn(happyState())
+
+        whenever(mockS3BucketService.ensureAccountBucket(any())).thenReturn("easy-db-lab-test-bucket")
+
+        whenever(mockVpcService.createVpc(any(), any(), any())).thenReturn("vpc-123")
+
+        whenever(mockAwsInfrastructureService.setupVpcNetworking(any(), any())).thenReturn(
+            VpcInfrastructure(
+                vpcId = "vpc-123",
+                subnetIds = listOf("subnet-1"),
+                securityGroupId = "sg-1",
+                internetGatewayId = "igw-1",
+            ),
+        )
+
+        whenever(mockEc2InstanceService.findInstancesByClusterId(any())).thenReturn(emptyMap())
+        whenever(mockEc2InstanceService.hasInstanceStore(any())).thenReturn(true)
+
+        whenever(mockAmiResolver.resolveAmiId(any(), any())).thenReturn(Result.success("ami-123"))
+
+        whenever(mockClusterProvisioningService.provisionAll(any(), any(), any(), any())).thenReturn(
+            ProvisioningResult(hosts = happyHosts(), errors = emptyMap()),
+        )
+
+        whenever(mockClusterConfigurationService.writeAllConfigurationFiles(any(), any(), any()))
+            .thenReturn(Result.success(Unit))
+
+        whenever(mockK3sClusterService.setupCluster(any())).thenReturn(K3sSetupResult(serverStarted = true))
+
+        whenever(mockK8sService.labelNode(any(), any(), any())).thenReturn(Result.success(Unit))
+        whenever(mockK8sService.ensureLocalStorageClass(any())).thenReturn(Result.success(Unit))
+        whenever(mockK8sService.ensureLocalStorageWfcClass(any())).thenReturn(Result.success(Unit))
+
+        whenever(mockCommandExecutor.execute<PicoCommand>(any())).thenAnswer { invocation ->
+            @Suppress("UNCHECKED_CAST")
+            val factory = invocation.arguments[0] as () -> PicoCommand
+            val command = factory()
+            invokedCommandNames.add(command::class.simpleName ?: "unknown")
+            nestedCommandExitCodes[command::class.simpleName] ?: 0
+        }
+    }
+
+    private fun happyHosts(): Map<ServerType, List<ClusterHost>> =
+        mapOf(
+            ServerType.Control to listOf(testControlHost),
+            ServerType.Cassandra to listOf(testDbHost),
+            ServerType.Stress to listOf(testAppHost),
+        )
+
+    /**
+     * A ClusterState with everything `up` needs already present, and Tailscale marked active
+     * so [Up.startProxyIfNeeded] and [Up.startTailscaleIfConfigured]'s inner body are both
+     * skipped (the test User has blank Tailscale credentials) — keeping the happy-path fixture
+     * from needing to model the SOCKS tunnel at all.
+     */
+    private fun happyState(
+        controlInstances: Int = 1,
+        cassandraInstances: Int = 1,
+        stressInstances: Int = 1,
+    ): ClusterState =
+        ClusterState(
+            name = "test-cluster",
+            versions = mutableMapOf(),
+            tailscaleActive = true,
+            initConfig =
+                InitConfig(
+                    cassandraInstances = cassandraInstances,
+                    stressInstances = stressInstances,
+                    controlInstances = controlInstances,
+                    cidr = "10.0.0.0/16",
+                    name = "test-cluster",
+                ),
+        )
+
+    private fun tailscaleUser(): User =
+        User(
+            email = "test@example.com",
+            region = "us-west-2",
+            keyName = "test-key",
+            awsProfile = "",
+            awsAccessKey = "test-access-key",
+            awsSecret = "test-secret",
+            axonOpsOrg = "",
+            axonOpsKey = "",
+            tailscaleClientId = "tailscale-client-id",
+            tailscaleClientSecret = "tailscale-client-secret",
+        )
+
+    // =========================================================================
+    // Baseline: the happy-path fixture itself must succeed end to end
+    // =========================================================================
+
+    @Test
+    fun `up provisions successfully when every step succeeds`() {
+        assertThatCode { Up().execute() }.doesNotThrowAnyException()
+
+        verify(mockClusterProvisioningService).provisionAll(any(), any(), any(), any())
+        verify(mockK8sService).labelNode(eq(testControlHost), eq("control0"), any())
+        verify(mockK8sService).labelNode(eq(testControlHost), eq("db0"), any())
+        verify(mockK8sService).labelNode(eq(testControlHost), eq("app0"), any())
+        verify(mockK8sService).ensureLocalStorageClass(eq(testControlHost))
+        verify(mockK8sService).ensureLocalStorageWfcClass(eq(testControlHost))
+    }
+
+    // =========================================================================
+    // Group 4: cluster shape invariants
+    // =========================================================================
+
+    @Test
+    fun `up fails before any EC2 instance is launched when configuration produces no control node`() {
+        whenever(mockClusterStateManager.load()).thenReturn(happyState(controlInstances = 0))
+
+        assertThatThrownBy { Up().execute() }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("control node is required")
+
+        verify(mockClusterProvisioningService, never()).provisionAll(any(), any(), any(), any())
+        verify(mockEc2InstanceService, never()).findInstancesByClusterId(any())
+    }
+
+    @Test
+    fun `up fails before any EC2 instance is launched when no S3 bucket is configured`() {
+        whenever(mockS3BucketService.ensureAccountBucket(any())).thenReturn("")
+
+        assertThatThrownBy { Up().execute() }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("S3 bucket is required")
+
+        verify(mockClusterProvisioningService, never()).provisionAll(any(), any(), any(), any())
+    }
+
+    @Test
+    fun `up provisions successfully with zero db nodes and emits no error output`() {
+        whenever(mockClusterStateManager.load()).thenReturn(happyState(cassandraInstances = 0))
+        whenever(mockClusterProvisioningService.provisionAll(any(), any(), any(), any())).thenReturn(
+            ProvisioningResult(
+                hosts = mapOf(ServerType.Control to listOf(testControlHost), ServerType.Stress to listOf(testAppHost)),
+                errors = emptyMap(),
+            ),
+        )
+
+        assertThatCode { Up().execute() }.doesNotThrowAnyException()
+
+        assertThat(outputHandler.errors).isEmpty()
+        verify(mockK8sService, never()).labelNode(any(), eq("db0"), any())
+        verify(mockK8sService).labelNode(eq(testControlHost), eq("app0"), any())
+    }
+
+    // =========================================================================
+    // Group 5: `up` fails fast at every swallow site
+    // =========================================================================
+
+    @Test
+    fun `up aborts when the nested WriteConfig command fails`() {
+        nestedCommandExitCodes["WriteConfig"] = 1
+
+        assertThatThrownBy { Up().execute() }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("WriteConfig")
+
+        verify(mockK3sClusterService, never()).setupCluster(any())
+    }
+
+    @Test
+    fun `up aborts when the nested SetupInstance command fails`() {
+        nestedCommandExitCodes["SetupInstance"] = 1
+
+        assertThatThrownBy { Up().execute() }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("SetupInstance")
+
+        verify(mockK3sClusterService, never()).setupCluster(any())
+    }
+
+    @Test
+    fun `up aborts when the nested ConfigureAxonOps command fails`() {
+        val userWithAxonOps =
+            tailscaleUser().copy(axonOpsOrg = "test-org", axonOpsKey = "test-key", tailscaleClientId = "", tailscaleClientSecret = "")
+        overrideUser(userWithAxonOps)
+        nestedCommandExitCodes["ConfigureAxonOps"] = 1
+
+        assertThatThrownBy { Up().execute() }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("ConfigureAxonOps")
+    }
+
+    @Test
+    fun `up aborts when the nested GrafanaUpdateConfig command fails`() {
+        nestedCommandExitCodes["GrafanaUpdateConfig"] = 1
+
+        assertThatThrownBy { Up().execute() }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("GrafanaUpdateConfig")
+    }
+
+    @Test
+    fun `up aborts when writeAllConfigurationFiles fails`() {
+        whenever(mockClusterConfigurationService.writeAllConfigurationFiles(any(), any(), any()))
+            .thenReturn(Result.failure(RuntimeException("disk full")))
+
+        assertThatThrownBy { Up().execute() }
+            .isInstanceOf(RuntimeException::class.java)
+            .hasMessageContaining("disk full")
+
+        verify(mockK3sClusterService, never()).setupCluster(any())
+    }
+
+    @Test
+    fun `up aborts when k3s cluster setup reports failure`() {
+        whenever(mockK3sClusterService.setupCluster(any())).thenReturn(
+            K3sSetupResult(serverStarted = false, errors = mapOf("K3s server start" to Exception("connection refused"))),
+        )
+
+        assertThatThrownBy { Up().execute() }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("K3s cluster setup failed")
+
+        verify(mockK8sService, never()).labelNode(any(), any(), any())
+    }
+
+    @Test
+    fun `up aborts when ensureLocalStorageClass fails`() {
+        whenever(mockK8sService.ensureLocalStorageClass(any())).thenReturn(Result.failure(RuntimeException("apply failed")))
+
+        assertThatThrownBy { Up().execute() }
+            .isInstanceOf(RuntimeException::class.java)
+            .hasMessageContaining("apply failed")
+
+        verify(mockK8sService, never()).ensureLocalStorageWfcClass(any())
+        assertThat(invokedCommandNames).doesNotContain("GrafanaUpdateConfig")
+    }
+
+    @Test
+    fun `up aborts when ensureLocalStorageWfcClass fails`() {
+        whenever(mockK8sService.ensureLocalStorageWfcClass(any())).thenReturn(Result.failure(RuntimeException("apply failed")))
+
+        assertThatThrownBy { Up().execute() }
+            .isInstanceOf(RuntimeException::class.java)
+            .hasMessageContaining("apply failed")
+    }
+
+    @Test
+    fun `up aborts when labeling the control node fails`() {
+        whenever(mockK8sService.labelNode(eq(testControlHost), eq("control0"), any()))
+            .thenReturn(Result.failure(RuntimeException("k8s api unreachable")))
+
+        assertThatThrownBy { Up().execute() }
+            .isInstanceOf(RuntimeException::class.java)
+            .hasMessageContaining("k8s api unreachable")
+
+        verify(mockK8sService, times(1)).labelNode(any(), any(), any())
+        assertThat(outputHandler.messages).doesNotContain("Node labeling complete")
+    }
+
+    @Test
+    fun `up aborts when labeling a db node fails and never emits NodeLabelingComplete`() {
+        whenever(mockK8sService.labelNode(eq(testControlHost), eq("db0"), any()))
+            .thenReturn(Result.failure(RuntimeException("db label failed")))
+
+        assertThatThrownBy { Up().execute() }
+            .isInstanceOf(RuntimeException::class.java)
+            .hasMessageContaining("db label failed")
+
+        assertThat(outputHandler.messages.count { it == "Node labeling complete" }).isZero()
+    }
+
+    @Test
+    fun `up aborts when labeling an app node fails after db labeling already succeeded`() {
+        whenever(mockK8sService.labelNode(eq(testControlHost), eq("app0"), any()))
+            .thenReturn(Result.failure(RuntimeException("app label failed")))
+
+        assertThatThrownBy { Up().execute() }
+            .isInstanceOf(RuntimeException::class.java)
+            .hasMessageContaining("app label failed")
+
+        // db's completion event fired before the app loop started and failed; app's never did.
+        assertThat(outputHandler.messages.count { it == "Node labeling complete" }).isEqualTo(1)
+    }
+
+    @Test
+    fun `up aborts before provisioning when reapplying the S3 policy fails`() {
+        whenever(mockS3BucketService.attachS3Policy(any())).thenThrow(RuntimeException("access denied"))
+
+        assertThatThrownBy { Up().execute() }
+            .isInstanceOf(RuntimeException::class.java)
+            .hasMessageContaining("access denied")
+
+        verify(mockClusterProvisioningService, never()).provisionAll(any(), any(), any(), any())
+    }
+
+    @Test
+    fun `up aborts when Tailscale fails to start and preserves the manual-start instruction`() {
+        overrideUser(tailscaleUser())
+        nestedCommandExitCodes["TailscaleStart"] = 1
+
+        assertThatThrownBy { Up().execute() }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("easy-db-lab tailscale start")
+
+        verify(mockK3sClusterService, never()).setupCluster(any())
+    }
+
+    @Test
+    fun `no-setup exits cleanly without touching K3s or nested setup commands`() {
+        val command = Up()
+        command.noSetup = true
+
+        assertThatCode { command.execute() }.doesNotThrowAnyException()
+
+        assertThat(
+            outputHandler.messages,
+        ).contains("Skipping node setup.  You will need to run easy-db-lab setup-instance to complete setup")
+        verify(mockK3sClusterService, never()).setupCluster(any())
+    }
+
+    // =========================================================================
+    // Group 6: control node SSH readiness
+    // =========================================================================
+
+    @Test
+    fun `ssh readiness wait covers the control host, not only db hosts`() {
+        assertThatCode { Up().execute() }.doesNotThrowAnyException()
+
+        assertThat(sshCheckedAliases).contains("control0", "db0")
+    }
+
+    @Test
+    fun `up aborts when the control node never accepts ssh`() {
+        sshFailureAlias = "control0"
+        // A non-retryable exception type: RetryUtil's SSH retry config only retries
+        // SshException/IOException, so this fails on the first attempt instead of exhausting
+        // the real 30-attempt / 10s-interval retry window, which would make this test take
+        // minutes. The behavior under test — that a control-node SSH failure aborts `up` — is
+        // exercised either way; only the wait time differs.
+        sshFailureException = IllegalStateException("connection refused")
+
+        assertThatThrownBy { Up().execute() }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("connection refused")
+
+        verify(mockK3sClusterService, never()).setupCluster(any())
+    }
+
+    private fun overrideUser(user: User) {
+        whenever(mockClusterStateManager.load()).thenReturn(happyState())
+        getKoin().loadModules(listOf(module { single<User> { user } }), allowOverride = true)
+    }
+}

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/commands/grafana/GrafanaUpdateConfigTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/commands/grafana/GrafanaUpdateConfigTest.kt
@@ -162,6 +162,7 @@ class GrafanaUpdateConfigTest : BaseKoinTest() {
         whenever(mockDashboardService.uploadDashboards(any())).thenReturn(Result.success(Unit))
         whenever(mockK8sService.rolloutRestartDeployment(any(), any(), any())).thenReturn(Result.success(Unit))
         whenever(mockK8sService.rolloutRestartDaemonSet(any(), any(), any())).thenReturn(Result.success(Unit))
+        whenever(mockK8sService.waitForPodsReady(any(), any())).thenReturn(Result.success(Unit))
 
         val command = GrafanaUpdateConfig()
         command.execute()
@@ -173,6 +174,42 @@ class GrafanaUpdateConfigTest : BaseKoinTest() {
         // Verify observability workloads were restarted
         verify(mockK8sService, atLeastOnce()).rolloutRestartDeployment(any(), any(), any())
         verify(mockK8sService, atLeastOnce()).rolloutRestartDaemonSet(any(), any(), any())
+
+        // Verify success is gated on the stack reaching Ready
+        verify(mockK8sService).waitForPodsReady(any(), any())
+    }
+
+    @Test
+    fun `execute fails when observability stack does not become ready`() {
+        val stateWithControl =
+            ClusterState(
+                name = "test-cluster",
+                versions = mutableMapOf(),
+                hosts =
+                    mutableMapOf(
+                        ServerType.Control to listOf(testControlHost),
+                    ),
+            )
+
+        whenever(mockClusterStateManager.load()).thenReturn(stateWithControl)
+        whenever(mockK8sService.applyResource(any(), any<HasMetadata>())).thenReturn(Result.success(Unit))
+        whenever(mockDashboardService.uploadDashboards(any())).thenReturn(Result.success(Unit))
+        whenever(mockK8sService.rolloutRestartDeployment(any(), any(), any())).thenReturn(Result.success(Unit))
+        whenever(mockK8sService.rolloutRestartDaemonSet(any(), any(), any())).thenReturn(Result.success(Unit))
+        // The stack applied and restarted, but a pod never reached Ready (e.g. Grafana CrashLoopBackOff).
+        whenever(mockK8sService.waitForPodsReady(any(), any()))
+            .thenReturn(
+                Result.failure(
+                    IllegalStateException("Pod grafana-xyz container grafana is in CrashLoopBackOff state"),
+                ),
+            )
+
+        val command = GrafanaUpdateConfig()
+
+        assertThatThrownBy { command.execute() }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("Observability stack did not become ready")
+            .hasMessageContaining("CrashLoopBackOff")
     }
 
     @Test

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/commands/install/KitInstallCommandFactoryTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/commands/install/KitInstallCommandFactoryTest.kt
@@ -189,4 +189,25 @@ class KitInstallCommandFactoryTest : BaseKoinTest() {
         cl.parseArgs("--version", "v7.5.0")
         assertThat(command.argValues["TIDB_VERSION"]).isEqualTo("v7.5.0")
     }
+
+    @Test
+    fun `optional arg omitted from the command line does not record the string null`() {
+        // Regression: PicoCLI invokes the ISetter with null to initialise an unmatched option
+        // that has no default. Stringifying that null recorded the literal "null" in argValues,
+        // which then passed isNotBlank() downstream and was treated as a real value — e.g. the
+        // postgres kit looked it up as the extension alias "null" and aborted the install.
+        val cl = factory.build(config(arg("--extension", "EXTENSION")), directorySource)
+        val command = cl.commandSpec.userObject() as KitInstallCommand
+        cl.parseArgs()
+        assertThat(command.argValues["EXTENSION"]).isNull()
+        assertThat(command.argValues).doesNotContainValue("null")
+    }
+
+    @Test
+    fun `optional arg supplied on the command line is recorded verbatim`() {
+        val cl = factory.build(config(arg("--extension", "EXTENSION")), directorySource)
+        val command = cl.commandSpec.userObject() as KitInstallCommand
+        cl.parseArgs("--extension", "duckdb")
+        assertThat(command.argValues["EXTENSION"]).isEqualTo("duckdb")
+    }
 }

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/configuration/ClusterConfigWriterTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/configuration/ClusterConfigWriterTest.kt
@@ -1,0 +1,101 @@
+package com.rustyrazorblade.easydblab.configuration
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.io.BufferedWriter
+import java.io.StringWriter
+
+/**
+ * Tests for [ClusterConfigWriter], focused on the generated SSH config's
+ * host-key verification directives and per-host structure.
+ *
+ * See openspec/changes/up-fail-fast/specs/networking/spec.md, requirement
+ * "Generated SSH configuration is self-contained": the generated config must
+ * fully determine host-key verification and must not depend on the developer's
+ * `~/.ssh/known_hosts`, because AWS recycles public IPs across ephemeral
+ * cluster lifetimes.
+ */
+internal class ClusterConfigWriterTest {
+    private fun renderSshConfig(hosts: Map<ServerType, List<ClusterHost>>): String {
+        val stringWriter = StringWriter()
+        val bufferedWriter = BufferedWriter(stringWriter)
+        ClusterConfigWriter.writeSshConfig(bufferedWriter, "/path/to/identity", hosts)
+        return stringWriter.toString()
+    }
+
+    @Test
+    fun `writeSshConfig pins UserKnownHostsFile to dev null alongside StrictHostKeyChecking before any Host block`() {
+        val controlHost =
+            ClusterHost(
+                publicIp = "54.1.1.1",
+                privateIp = "10.0.0.1",
+                alias = "control0",
+                availabilityZone = "us-west-2a",
+            )
+        val config = renderSshConfig(mapOf(ServerType.Control to listOf(controlHost)))
+
+        assertThat(config).contains("StrictHostKeyChecking=no")
+        assertThat(config).contains("UserKnownHostsFile=/dev/null")
+
+        val strictHostKeyCheckingIndex = config.indexOf("StrictHostKeyChecking=no")
+        val userKnownHostsFileIndex = config.indexOf("UserKnownHostsFile=/dev/null")
+        val firstHostBlockIndex = config.indexOf("Host control0")
+        assertThat(firstHostBlockIndex).isGreaterThanOrEqualTo(0)
+
+        // Both directives are global (outside any Host block), so they must precede
+        // the first "Host <alias>" line -- ssh_config applies later Host-scoped
+        // settings only within that block, but global settings must come first to
+        // apply to every host, including hosts with recycled public IPs.
+        assertThat(strictHostKeyCheckingIndex).isLessThan(firstHostBlockIndex)
+        assertThat(userKnownHostsFileIndex).isLessThan(firstHostBlockIndex)
+    }
+
+    @Test
+    fun `writeSshConfig emits one Host alias and Hostname pair per host across multiple server types`() {
+        val controlHost =
+            ClusterHost(
+                publicIp = "54.1.1.1",
+                privateIp = "10.0.0.1",
+                alias = "control0",
+                availabilityZone = "us-west-2a",
+            )
+        val dbHosts =
+            listOf(
+                ClusterHost(
+                    publicIp = "54.1.1.2",
+                    privateIp = "10.0.0.2",
+                    alias = "db0",
+                    availabilityZone = "us-west-2a",
+                ),
+                ClusterHost(
+                    publicIp = "54.1.1.3",
+                    privateIp = "10.0.0.3",
+                    alias = "db1",
+                    availabilityZone = "us-west-2b",
+                ),
+            )
+        val hosts =
+            mapOf(
+                ServerType.Control to listOf(controlHost),
+                ServerType.Cassandra to dbHosts,
+            )
+
+        val config = renderSshConfig(hosts)
+
+        val expectedPairs =
+            listOf(
+                "control0" to "54.1.1.1",
+                "db0" to "54.1.1.2",
+                "db1" to "54.1.1.3",
+            )
+
+        expectedPairs.forEach { (alias, publicIp) ->
+            assertThat(config).contains("Host $alias")
+            assertThat(config).contains("Hostname $publicIp")
+        }
+
+        // Exactly one Host block per host -- no duplicates, no missing entries.
+        val hostBlockCount = Regex("(?m)^Host ").findAll(config).count()
+        assertThat(hostBlockCount).isEqualTo(expectedPairs.size)
+    }
+}

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/configuration/grafana/GrafanaManifestBuilderTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/configuration/grafana/GrafanaManifestBuilderTest.kt
@@ -82,6 +82,30 @@ class GrafanaManifestBuilderTest : BaseKoinTest() {
     }
 
     @Test
+    fun `buildDeployment does not attempt to install the bundled Pyroscope core plugin`() {
+        // Regression: grafana-pyroscope-datasource is a BUNDLED core plugin in Grafana 13.x.
+        // Listing it in GF_INSTALL_PLUGINS makes the boot-time install fail
+        // ("cannot install a Core plugin") and Grafana CrashLoopBackOffs. Only externally
+        // distributed plugins may appear here.
+        val deployment = builder.buildDeployment()
+        val grafanaContainer =
+            deployment.spec.template.spec.containers
+                .first { it.name == "grafana" }
+        val plugins =
+            grafanaContainer.env
+                .first { it.name == "GF_INSTALL_PLUGINS" }
+                .value
+                .split(",")
+
+        assertThat(plugins).doesNotContain("grafana-pyroscope-datasource")
+        assertThat(plugins).contains(
+            "grafana-clickhouse-datasource",
+            "victoriametrics-logs-datasource",
+            "grafana-polystat-panel",
+        )
+    }
+
+    @Test
     fun `buildDeployment includes volume mounts for all dashboards`() {
         val deployment = builder.buildDeployment()
         val container =

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/proxy/ProcessSocksProxyServiceTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/proxy/ProcessSocksProxyServiceTest.kt
@@ -6,17 +6,31 @@ import com.rustyrazorblade.easydblab.configuration.ClusterHost
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.assertj.core.api.Assertions.catchThrowable
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import org.junit.jupiter.api.parallel.ResourceLock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import java.io.File
 import java.net.ServerSocket
 import java.time.Instant
 
 @ResourceLock(Constants.Proxy.PORT_PROPERTY)
 class ProcessSocksProxyServiceTest {
+    private companion object {
+        /** Socket timeout for the real probe used by the real-ssh integration tests. */
+        const val PROBE_TIMEOUT_MS = 1000
+    }
+
     @TempDir
     lateinit var tempDir: File
 
@@ -44,9 +58,11 @@ class ProcessSocksProxyServiceTest {
         System.clearProperty(Constants.Proxy.PORT_PROPERTY)
     }
 
-    private fun service() =
+    // Real-ssh integration tests default to the real probe; loop tests inject a mock probe.
+    private fun service(probe: TunnelReachabilityProbe = SocksTunnelReachabilityProbe(PROBE_TIMEOUT_MS)) =
         ProcessSocksProxyService(
             Context.forCli(File(System.getProperty("user.home"), ".easy-db-lab")).copy(workingDirectory = tempDir),
+            probe,
         )
 
     private fun writeStateFile(
@@ -68,23 +84,45 @@ class ProcessSocksProxyServiceTest {
         File(tempDir, Constants.Vpc.SOCKS5_PROXY_STATE_FILE).writeText(json.encodeToString(stateFile))
     }
 
+    /**
+     * Points sshConfig's only Host stanza at a loopback port nothing listens on, so `ssh`
+     * refuses the connection immediately (no DNS/network flakiness) and the local `-D` listener
+     * is never opened — a deterministic, fast way to exercise the proxy's failure path for real,
+     * without mocking the `ssh` process.
+     */
+    private fun writeUnreachableSshConfig(alias: String) {
+        File(tempDir, "sshConfig").writeText(
+            """
+            Host $alias
+              Hostname 127.0.0.1
+              Port 1
+              ConnectTimeout 1
+            """.trimIndent(),
+        )
+    }
+
     @Test
     fun `reuses proxy when state file has live PID matching IP and sshConfig`() {
-        // Use the current JVM process PID as a "live" PID
+        // Use the current JVM process PID as a "live" PID, and actually bind the recorded port
+        // so it is genuinely accepting connections — isValidProxy() now checks that, not just
+        // the PID, so a merely-recorded-but-unbound port would (correctly) be rejected as a
+        // zombie tunnel rather than reused.
         val livePid = ProcessHandle.current().pid().toInt()
         val port = 19080 // arbitrary high port unlikely to be bound
-        writeStateFile(pid = livePid, port = port)
+        ServerSocket(port).use {
+            writeStateFile(pid = livePid, port = port)
 
-        val svc = service()
-        val state = svc.ensureRunning(testHost)
+            val svc = service()
+            val state = svc.ensureRunning(testHost)
 
-        assertThat(state.localPort).isEqualTo(port)
-        // No new state file written with a different PID — still the original PID
-        val loaded =
-            json.decodeFromString<Socks5ProxyStateFile>(
-                File(tempDir, Constants.Vpc.SOCKS5_PROXY_STATE_FILE).readText(),
-            )
-        assertThat(loaded.pid).isEqualTo(livePid)
+            assertThat(state.localPort).isEqualTo(port)
+            // No new state file written with a different PID — still the original PID
+            val loaded =
+                json.decodeFromString<Socks5ProxyStateFile>(
+                    File(tempDir, Constants.Vpc.SOCKS5_PROXY_STATE_FILE).readText(),
+                )
+            assertThat(loaded.pid).isEqualTo(livePid)
+        }
     }
 
     @Test
@@ -112,15 +150,19 @@ class ProcessSocksProxyServiceTest {
     fun `publishes the proxy port property but never the global socksProxyHost when reusing valid proxy`() {
         val livePid = ProcessHandle.current().pid().toInt()
         val port = 19082
-        writeStateFile(pid = livePid, port = port)
+        // Actually bind the recorded port so the proxy is genuinely reusable — see comment on
+        // the "reuses proxy..." test above for why this must be a real listening socket.
+        ServerSocket(port).use {
+            writeStateFile(pid = livePid, port = port)
 
-        val svc = service()
-        svc.ensureRunning(testHost)
+            val svc = service()
+            svc.ensureRunning(testHost)
 
-        // The private port property is published for the cluster clients...
-        assertThat(System.getProperty(Constants.Proxy.PORT_PROPERTY)).isEqualTo("$port")
-        // ...but the standard global socksProxyHost is NOT set, so java.net (and the AWS SDK) stay direct.
-        assertThat(System.getProperty("socksProxyHost")).isNull()
+            // The private port property is published for the cluster clients...
+            assertThat(System.getProperty(Constants.Proxy.PORT_PROPERTY)).isEqualTo("$port")
+            // ...but the standard global socksProxyHost is NOT set, so java.net (and the AWS SDK) stay direct.
+            assertThat(System.getProperty("socksProxyHost")).isNull()
+        }
     }
 
     @Test
@@ -171,4 +213,256 @@ class ProcessSocksProxyServiceTest {
         // isRunning() checks in-memory state only, so it returns false
         assertThat(svc.isRunning()).isFalse()
     }
+
+    @Test
+    fun `startNewProxy fails fast with the ssh exit code when ssh cannot connect`() {
+        val unreachableAlias = "unreachable-control"
+        writeUnreachableSshConfig(unreachableAlias)
+        val unreachableHost = testHost.copy(alias = unreachableAlias)
+
+        val svc = service()
+
+        // ssh to a refused port exits almost immediately; with ExitOnForwardFailure + the
+        // process-liveness check, verification must bail on the dead process rather than poll it
+        // for the full window (VERIFY_RETRIES * VERIFY_DELAY_MS = 5000ms).
+        val start = System.nanoTime()
+        val thrown = catchThrowable { svc.ensureRunning(unreachableHost) }
+        val elapsedMs = (System.nanoTime() - start) / 1_000_000
+
+        assertThat(thrown)
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("SOCKS5 proxy")
+            .hasMessageContaining("socks5-proxy.log")
+            .hasMessageContaining("ssh exited with code")
+        assertThat(elapsedMs).isLessThan(4000L)
+
+        // No stale/dead port is ever published — clients fall back to no-proxy.
+        assertThat(System.getProperty(Constants.Proxy.PORT_PROPERTY)).isNull()
+    }
+
+    @Test
+    fun `failure message surfaces the real ssh error and omits debug noise`() {
+        val alias = "refused-control"
+        writeUnreachableSshConfig(alias)
+        val host = testHost.copy(alias = alias)
+        val svc = service()
+
+        val thrown = catchThrowable { svc.ensureRunning(host) }
+
+        // The real, un-prefixed ssh error ("Connection refused") must be pulled from the
+        // transcript into the message; the debug1: chatter must NOT be.
+        assertThat(thrown)
+            .isInstanceOf(IllegalStateException::class.java)
+        assertThat(thrown.message)
+            .contains("Connection refused")
+            .doesNotContain("debug1:")
+    }
+
+    @Test
+    fun `a live process with a dead tunnel port is not reused`() {
+        val livePid = ProcessHandle.current().pid().toInt()
+        val zombiePort = 19090 // recorded but nothing is listening on it
+        writeStateFile(pid = livePid, port = zombiePort)
+
+        // The fallback fresh-start attempt must also fail fast rather than hang or succeed,
+        // so we can observe that the zombie was rejected rather than silently reused.
+        val unreachableAlias = "unreachable-control"
+        writeUnreachableSshConfig(unreachableAlias)
+        val unreachableHost = testHost.copy(alias = unreachableAlias)
+
+        val svc = service()
+
+        assertThatThrownBy { svc.ensureRunning(unreachableHost) }
+            .isInstanceOf(IllegalStateException::class.java)
+
+        // The zombie's port must never be republished under any circumstances — it was
+        // rejected as invalid, not reused, and the fresh attempt also failed.
+        assertThat(System.getProperty(Constants.Proxy.PORT_PROPERTY)).isNull()
+    }
+
+    @Test
+    fun `startNewProxy dials the gateway host's recorded alias, not a hardcoded control0`() {
+        val gatewayAlias = "custom-gateway-alias"
+        writeUnreachableSshConfig(gatewayAlias)
+        val host = testHost.copy(alias = gatewayAlias)
+
+        val svc = service()
+
+        assertThatThrownBy { svc.ensureRunning(host) }
+            .isInstanceOf(IllegalStateException::class.java)
+
+        // ssh -v only logs "Applying options for <alias>" when the literal argument passed on
+        // the command line matches a Host stanza in the config. sshConfig here defines ONLY
+        // gatewayAlias — a hardcoded "control0" argument would not match it and this line
+        // would be absent. The transcript now lives under logs/ (alongside logs/info.log).
+        val sshTranscript = File(tempDir, "logs/socks5-proxy.log").readText()
+        assertThat(sshTranscript).contains("Applying options for $gatewayAlias")
+    }
+
+    @Test
+    fun `in-memory state with a dead tunnel port is not reused across ensureRunning calls`() {
+        // Populate in-memory state via a genuine reuse (real listening socket), then kill the
+        // listener so the port stops accepting connections while the recorded PID (this JVM)
+        // stays alive — the "process alive, tunnel dead" case the in-memory fast path must not
+        // trust just because isAlive(pid) is still true.
+        val livePid = ProcessHandle.current().pid().toInt()
+        val port = 19091
+        val svc = service()
+        ServerSocket(port).use {
+            writeStateFile(pid = livePid, port = port)
+            val first = svc.ensureRunning(testHost)
+            assertThat(first.localPort).isEqualTo(port)
+        }
+
+        // The socket is now closed: the previously-valid in-memory state's port is dead. A
+        // second call on the SAME service instance must not shortcut through the in-memory
+        // cache — it must re-validate and, finding nothing reusable, attempt a fresh start.
+        val unreachableAlias = "unreachable-control"
+        writeUnreachableSshConfig(unreachableAlias)
+        val unreachableHost = testHost.copy(alias = unreachableAlias)
+
+        assertThatThrownBy { svc.ensureRunning(unreachableHost) }
+            .isInstanceOf(IllegalStateException::class.java)
+    }
+
+    @Test
+    fun `orphaned ssh process is destroyed rather than leaked when verification fails`() {
+        // Accept the TCP connection but never send the SSH banner. The real ssh client
+        // completes its TCP connect and then hangs mid-handshake for the whole verify window,
+        // staying alive without ever opening the local -D listener — exactly the case where a
+        // naive fail-fast fix would otherwise leak an untracked background process that `down`
+        // can never find (the state file, which normally records the PID, is never written on
+        // a failed start).
+        val alias = "hanging-gateway"
+        val hangingPort = 19510
+        val listener = ServerSocket(hangingPort)
+        val holdMillis = 8000L
+        Thread {
+            try {
+                listener.accept().use { Thread.sleep(holdMillis) }
+            } catch (_: Exception) {
+                // Listener closed by test teardown below — nothing to clean up.
+            }
+        }.apply {
+            isDaemon = true
+            start()
+        }
+
+        File(tempDir, "sshConfig").writeText(
+            """
+            Host $alias
+              Hostname 127.0.0.1
+              Port $hangingPort
+            """.trimIndent(),
+        )
+        val hangingHost = testHost.copy(alias = alias)
+        val svc = service()
+
+        try {
+            assertThatThrownBy { svc.ensureRunning(hangingHost) }
+                .isInstanceOf(IllegalStateException::class.java)
+
+            assertThat(sshProcessesMatching(alias)).isEmpty()
+        } finally {
+            listener.close()
+        }
+    }
+
+    @Test
+    fun `verify loop succeeds once the probe reports the tunnel reachable`() {
+        // Process stays alive; the probe is not reachable on the first two polls, then is.
+        // The loop must keep polling and return normally on the third — no exception.
+        val process = mock<Process> { on { isAlive } doReturn true }
+        val probe = mock<TunnelReachabilityProbe>()
+        whenever(probe.isReachable(any<Int>(), any<String>(), any<Int>())).thenReturn(false, false, true)
+
+        val svc = service(probe)
+        svc.verifyTunnelReachable(process, port = 1080, targetPrivateIp = "10.0.1.5", logFile = logFile())
+
+        verify(probe, times(3)).isReachable(1080, "10.0.1.5", SSH_PORT)
+    }
+
+    @Test
+    fun `verify loop throws when the probe never reports the tunnel reachable`() {
+        // A live ssh whose tunnel is a black hole (probe always false) must time out and fail,
+        // not hang or succeed — the fail-fast contract.
+        val process = mock<Process> { on { isAlive } doReturn true }
+        val probe = mock<TunnelReachabilityProbe>()
+        whenever(probe.isReachable(any<Int>(), any<String>(), any<Int>())).thenReturn(false)
+
+        val svc = service(probe)
+
+        assertThatThrownBy {
+            svc.verifyTunnelReachable(process, port = 1080, targetPrivateIp = "10.0.1.5", logFile = logFile())
+        }.isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("SOCKS5 proxy")
+    }
+
+    @Test
+    fun `verify loop fails immediately with the ssh exit code when the process is already dead`() {
+        // Liveness is checked FIRST, before the probe: a dead ssh (e.g. a changed host key) must
+        // abort at once with its exit code, never polling the probe against a corpse.
+        val process =
+            mock<Process> {
+                on { isAlive } doReturn false
+                on { exitValue() } doReturn 255
+            }
+        val probe = mock<TunnelReachabilityProbe>()
+
+        val svc = service(probe)
+
+        assertThatThrownBy {
+            svc.verifyTunnelReachable(process, port = 1080, targetPrivateIp = "10.0.1.5", logFile = logFile())
+        }.isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("ssh exited with code 255")
+        verify(probe, never()).isReachable(any<Int>(), any<String>(), any<Int>())
+    }
+
+    /** A log path under the workspace that may or may not exist — error extraction tolerates both. */
+    private fun logFile(): File = File(File(tempDir, "logs"), Constants.Proxy.SOCKS5_PROXY_LOG_FILE)
+
+    @Test
+    fun `stripSshDebugNoise drops debug-prefixed lines and keeps the real error`() {
+        val transcript =
+            listOf(
+                "OpenSSH_9.9p2, LibreSSL 3.3.6",
+                "debug1: Reading configuration data sshConfig",
+                "debug2: resolving \"control0\" port 22",
+                "debug3: send packet: type 21",
+                "Permission denied (publickey).",
+                "",
+            )
+
+        val result = stripSshDebugNoise(transcript, tailLines = 15)
+
+        assertThat(result).contains("Permission denied (publickey).")
+        assertThat(result).noneMatch { it.startsWith("debug") }
+        assertThat(result).doesNotContain("")
+    }
+
+    @Test
+    fun `stripSshDebugNoise keeps only the trailing lines up to the limit`() {
+        val transcript = (1..30).map { "error line $it" }
+
+        val result = stripSshDebugNoise(transcript, tailLines = 15)
+
+        assertThat(result).hasSize(15)
+        assertThat(result.first()).isEqualTo("error line 16")
+        assertThat(result.last()).isEqualTo("error line 30")
+    }
+
+    /**
+     * Finds live OS processes whose command line contains [marker]. Used to confirm a spawned
+     * `ssh` process was actually killed rather than left running as an untracked orphan.
+     */
+    private fun sshProcessesMatching(marker: String): List<ProcessHandle> =
+        ProcessHandle
+            .allProcesses()
+            .filter { handle ->
+                handle
+                    .info()
+                    .commandLine()
+                    .orElse("")
+                    .contains(marker)
+            }.toList()
 }

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/services/CommandExecutorTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/services/CommandExecutorTest.kt
@@ -2,7 +2,9 @@ package com.rustyrazorblade.easydblab.services
 
 import com.rustyrazorblade.easydblab.BaseKoinTest
 import com.rustyrazorblade.easydblab.Constants
+import com.rustyrazorblade.easydblab.annotations.RequiresProxy
 import com.rustyrazorblade.easydblab.annotations.TriggerBackup
+import com.rustyrazorblade.easydblab.commands.Down
 import com.rustyrazorblade.easydblab.commands.PicoBaseCommand
 import com.rustyrazorblade.easydblab.configuration.ClusterHost
 import com.rustyrazorblade.easydblab.configuration.ClusterState
@@ -12,6 +14,8 @@ import com.rustyrazorblade.easydblab.configuration.User
 import com.rustyrazorblade.easydblab.configuration.UserConfigProvider
 import com.rustyrazorblade.easydblab.events.EventBus
 import com.rustyrazorblade.easydblab.providers.docker.DockerClientProvider
+import com.rustyrazorblade.easydblab.proxy.DefaultProxyAvailability
+import com.rustyrazorblade.easydblab.proxy.ProxyAvailability
 import com.rustyrazorblade.easydblab.proxy.SocksProxyService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -43,6 +47,7 @@ class CommandExecutorTest : BaseKoinTest() {
     private lateinit var mockResourceManager: ResourceManager
     private lateinit var mockSocksProxyService: SocksProxyService
     private lateinit var mockUserConfig: User
+    private lateinit var proxyAvailability: ProxyAvailability
     private lateinit var commandExecutor: DefaultCommandExecutor
 
     // Track command execution order
@@ -71,6 +76,7 @@ class CommandExecutorTest : BaseKoinTest() {
         mockResourceManager = mock()
         mockSocksProxyService = mock()
         mockUserConfig = mock()
+        proxyAvailability = DefaultProxyAvailability()
 
         // Default: profile is already set up
         whenever(mockUserConfigProvider.isSetup()).thenReturn(true)
@@ -87,6 +93,7 @@ class CommandExecutorTest : BaseKoinTest() {
                 resourceManager = mockResourceManager,
                 eventBus = EventBus(),
                 socksProxyService = mockSocksProxyService,
+                proxyAvailability = proxyAvailability,
             )
     }
 
@@ -315,7 +322,37 @@ class CommandExecutorTest : BaseKoinTest() {
     // ========== PROXY STARTUP TESTS ==========
 
     @Test
-    fun `executeTopLevel starts proxy when infra is UP and Tailscale is disabled`() {
+    fun `executeTopLevel does not start proxy for a command without RequiresProxy even when infra is UP`() {
+        // Given - cluster is fully provisioned, infra UP, Tailscale disabled: every gating
+        // condition ensureProxyRunning checks is satisfied. Only the missing annotation should
+        // stop the proxy from starting.
+        val controlHost =
+            ClusterHost(
+                publicIp = "1.2.3.4",
+                privateIp = "10.0.0.1",
+                alias = "control0",
+                availabilityZone = "us-west-2a",
+            )
+        val state =
+            ClusterState(
+                name = "test",
+                versions = mutableMapOf(),
+                infrastructureStatus = InfrastructureStatus.UP,
+                tailscaleActive = false,
+                hosts = mapOf(com.rustyrazorblade.easydblab.configuration.ServerType.Control to listOf(controlHost)),
+            )
+        whenever(mockClusterStateManager.exists()).thenReturn(true)
+        whenever(mockClusterStateManager.load()).thenReturn(state)
+
+        // When - TestCommand carries no @RequiresProxy
+        commandExecutor.executeTopLevel(TestCommand { })
+
+        // Then
+        verify(mockSocksProxyService, never()).ensureRunning(any())
+    }
+
+    @Test
+    fun `executeTopLevel starts proxy for a RequiresProxy command when infra is UP and Tailscale is disabled`() {
         // Given
         val controlHost =
             ClusterHost(
@@ -336,14 +373,14 @@ class CommandExecutorTest : BaseKoinTest() {
         whenever(mockClusterStateManager.load()).thenReturn(state)
 
         // When
-        commandExecutor.executeTopLevel(TestCommand { })
+        commandExecutor.executeTopLevel(ProxyRequiringCommand { })
 
         // Then
         verify(mockSocksProxyService).ensureRunning(controlHost)
     }
 
     @Test
-    fun `executeTopLevel skips proxy when Tailscale is enabled`() {
+    fun `executeTopLevel skips proxy for a RequiresProxy command when Tailscale is enabled`() {
         // Given
         val state =
             ClusterState(
@@ -356,19 +393,188 @@ class CommandExecutorTest : BaseKoinTest() {
         whenever(mockClusterStateManager.load()).thenReturn(state)
 
         // When
-        commandExecutor.executeTopLevel(TestCommand { })
+        commandExecutor.executeTopLevel(ProxyRequiringCommand { })
 
         // Then
         verify(mockSocksProxyService, never()).ensureRunning(any())
     }
 
     @Test
-    fun `executeTopLevel skips proxy when no state file exists`() {
+    fun `executeTopLevel skips proxy for a RequiresProxy command when no state file exists`() {
         // Given
         whenever(mockClusterStateManager.exists()).thenReturn(false)
 
         // When
-        commandExecutor.executeTopLevel(TestCommand { })
+        commandExecutor.executeTopLevel(ProxyRequiringCommand { })
+
+        // Then
+        verify(mockSocksProxyService, never()).ensureRunning(any())
+    }
+
+    @Test
+    fun `executeTopLevel propagates proxy establishment failure and returns non-zero for a RequiresProxy command`() {
+        // Given
+        val controlHost =
+            ClusterHost(
+                publicIp = "1.2.3.4",
+                privateIp = "10.0.0.1",
+                alias = "control0",
+                availabilityZone = "us-west-2a",
+            )
+        val state =
+            ClusterState(
+                name = "test",
+                versions = mutableMapOf(),
+                infrastructureStatus = InfrastructureStatus.UP,
+                tailscaleActive = false,
+                hosts = mapOf(com.rustyrazorblade.easydblab.configuration.ServerType.Control to listOf(controlHost)),
+            )
+        whenever(mockClusterStateManager.exists()).thenReturn(true)
+        whenever(mockClusterStateManager.load()).thenReturn(state)
+        whenever(mockSocksProxyService.ensureRunning(controlHost))
+            .thenThrow(RuntimeException("port never began accepting connections — see socks5-proxy.log"))
+
+        // When - the command body itself must never run once the proxy fails to establish
+        val exitCode =
+            commandExecutor.executeTopLevel(
+                ProxyRequiringCommand { executionOrder.add("should_not_run") },
+            )
+
+        // Then - the failure propagates out of the proxy check and is reported like any other
+        // command failure, not swallowed into a warning that lets the command proceed
+        assertThat(exitCode).isEqualTo(Constants.ExitCodes.ERROR)
+        assertThat(executionOrder).doesNotContain("should_not_run")
+    }
+
+    @Test
+    fun `executeTopLevel runs a tolerateFailure command's body even when proxy establishment fails`() {
+        // Given - RequiresProxy(tolerateFailure = true) is the narrow, explicit opt-in that lets
+        // a command survive a proxy failure. Everything else about the failure mode is identical
+        // to the non-tolerant case: ensureRunning still throws.
+        val controlHost =
+            ClusterHost(
+                publicIp = "1.2.3.4",
+                privateIp = "10.0.0.1",
+                alias = "control0",
+                availabilityZone = "us-west-2a",
+            )
+        val state =
+            ClusterState(
+                name = "test",
+                versions = mutableMapOf(),
+                infrastructureStatus = InfrastructureStatus.UP,
+                tailscaleActive = false,
+                hosts = mapOf(com.rustyrazorblade.easydblab.configuration.ServerType.Control to listOf(controlHost)),
+            )
+        whenever(mockClusterStateManager.exists()).thenReturn(true)
+        whenever(mockClusterStateManager.load()).thenReturn(state)
+        whenever(mockSocksProxyService.ensureRunning(controlHost))
+            .thenThrow(RuntimeException("port never began accepting connections — see socks5-proxy.log"))
+
+        // When
+        val exitCode =
+            commandExecutor.executeTopLevel(
+                ToleratingProxyRequiringCommand { executionOrder.add("ran despite proxy failure") },
+            )
+
+        // Then - unlike the non-tolerant case, the command body runs and the command succeeds
+        assertThat(exitCode).isEqualTo(0)
+        assertThat(executionOrder).containsExactly("ran despite proxy failure")
+    }
+
+    @Test
+    fun `executeTopLevel records the proxy failure so a tolerateFailure command can observe it`() {
+        // Given
+        val controlHost =
+            ClusterHost(
+                publicIp = "1.2.3.4",
+                privateIp = "10.0.0.1",
+                alias = "control0",
+                availabilityZone = "us-west-2a",
+            )
+        val state =
+            ClusterState(
+                name = "test",
+                versions = mutableMapOf(),
+                infrastructureStatus = InfrastructureStatus.UP,
+                tailscaleActive = false,
+                hosts = mapOf(com.rustyrazorblade.easydblab.configuration.ServerType.Control to listOf(controlHost)),
+            )
+        whenever(mockClusterStateManager.exists()).thenReturn(true)
+        whenever(mockClusterStateManager.load()).thenReturn(state)
+        whenever(mockSocksProxyService.ensureRunning(controlHost))
+            .thenThrow(RuntimeException("port never began accepting connections — see socks5-proxy.log"))
+        var observedFailureMessage: String? = null
+
+        // When - the command reads ProxyAvailability itself, from inside its own execute()
+        commandExecutor.executeTopLevel(
+            ToleratingProxyRequiringCommand {
+                observedFailureMessage = proxyAvailability.failure()?.message
+            },
+        )
+
+        // Then - the command actually observed why the proxy failed, not just that it failed
+        assertThat(observedFailureMessage).contains("port never began accepting connections")
+    }
+
+    @Test
+    fun `executeTopLevel clears a stale proxy failure before the next command runs`() {
+        // Given - a tolerant command fails to establish the proxy and records it
+        val controlHost =
+            ClusterHost(
+                publicIp = "1.2.3.4",
+                privateIp = "10.0.0.1",
+                alias = "control0",
+                availabilityZone = "us-west-2a",
+            )
+        val state =
+            ClusterState(
+                name = "test",
+                versions = mutableMapOf(),
+                infrastructureStatus = InfrastructureStatus.UP,
+                tailscaleActive = false,
+                hosts = mapOf(com.rustyrazorblade.easydblab.configuration.ServerType.Control to listOf(controlHost)),
+            )
+        whenever(mockClusterStateManager.exists()).thenReturn(true)
+        whenever(mockClusterStateManager.load()).thenReturn(state)
+        whenever(mockSocksProxyService.ensureRunning(controlHost))
+            .thenThrow(RuntimeException("port never began accepting connections — see socks5-proxy.log"))
+        commandExecutor.executeTopLevel(ToleratingProxyRequiringCommand { })
+        assertThat(proxyAvailability.failure()).isNotNull()
+
+        // When - a later command runs in the same (long-running Server/Repl) process
+        commandExecutor.execute { TestCommand { } }
+
+        // Then - the stale failure from the earlier command must not leak into this one
+        assertThat(proxyAvailability.failure()).isNull()
+    }
+
+    @Test
+    fun `executeTopLevel does not start proxy for Down even when infra is UP and Tailscale is disabled`() {
+        // Given - Down is never annotated with @RequiresProxy: it tears down the tunnel itself
+        // as its first action (clearProxySystemProperties + cleanupSocks5Proxy), so a pre-flight
+        // proxy start would only start a tunnel Down immediately destroys.
+        val controlHost =
+            ClusterHost(
+                publicIp = "1.2.3.4",
+                privateIp = "10.0.0.1",
+                alias = "control0",
+                availabilityZone = "us-west-2a",
+            )
+        val state =
+            ClusterState(
+                name = "test",
+                versions = mutableMapOf(),
+                infrastructureStatus = InfrastructureStatus.UP,
+                tailscaleActive = false,
+                hosts = mapOf(com.rustyrazorblade.easydblab.configuration.ServerType.Control to listOf(controlHost)),
+            )
+        whenever(mockClusterStateManager.exists()).thenReturn(true)
+        whenever(mockClusterStateManager.load()).thenReturn(state)
+
+        // When - Down's own execute() may fail against this test's minimal AWS mocks; that is
+        // irrelevant here, only whether the proxy pre-flight ran is under test.
+        commandExecutor.execute { Down() }
 
         // Then
         verify(mockSocksProxyService, never()).ensureRunning(any())
@@ -379,6 +585,32 @@ class CommandExecutorTest : BaseKoinTest() {
     /** Simple test command that executes a provided action */
     @Command(name = "test-command")
     inner class TestCommand(
+        private val action: () -> Unit = {},
+    ) : PicoBaseCommand() {
+        override fun execute() {
+            action()
+        }
+    }
+
+    /** Test command carrying [RequiresProxy], otherwise identical to [TestCommand]. */
+    @RequiresProxy
+    @Command(name = "proxy-requiring-command")
+    inner class ProxyRequiringCommand(
+        private val action: () -> Unit = {},
+    ) : PicoBaseCommand() {
+        override fun execute() {
+            action()
+        }
+    }
+
+    /**
+     * Test command carrying `@RequiresProxy(tolerateFailure = true)` — the narrow opt-in that
+     * lets a command survive a proxy establishment failure instead of aborting. Otherwise
+     * identical to [TestCommand].
+     */
+    @RequiresProxy(tolerateFailure = true)
+    @Command(name = "tolerating-proxy-requiring-command")
+    inner class ToleratingProxyRequiringCommand(
         private val action: () -> Unit = {},
     ) : PicoBaseCommand() {
         override fun execute() {

--- a/test-plans/socks5-proxy-no-tailscale-validation.md
+++ b/test-plans/socks5-proxy-no-tailscale-validation.md
@@ -14,7 +14,7 @@ single
 
 ## Environment
 
-Single DC, 3 database nodes on `i4i.xlarge` (local NVMe, no EBS required), 0 app nodes. Tailscale disabled via `--no-tailscale`.
+Single DC, 1 database node on `i4i.xlarge` (local NVMe, no EBS required), 0 app nodes. Tailscale disabled via `--no-tailscale`.
 
 ## Steps
 
@@ -23,7 +23,7 @@ Single DC, 3 database nodes on `i4i.xlarge` (local NVMe, no EBS required), 0 app
 Provision a 3-node cluster with Tailscale explicitly disabled.
 
 ```bash
-$EDB init socks5-validation --db 3 --instance i4i.xlarge --no-tailscale --up
+$EDB init socks5-validation --db 1 --instance i4i.xlarge --no-tailscale --up
 ```
 
 ### 2. Select Cassandra 5.0
@@ -40,7 +40,7 @@ $EDB cassandra start
 
 ### 4. Verify cluster health via nodetool
 
-All 3 nodes should show UN (Up/Normal). This command routes through the SOCKS proxy.
+The single node should show UN (Up/Normal). This command routes through the SOCKS proxy.
 
 ```bash
 $EDB cassandra nt status


### PR DESCRIPTION
Closes #734.

## Summary

`init --up` could exit 0 having provisioned a cluster with **no observability stack, no `local-storage` StorageClasses, and no node labels**. The user was told the cluster was ready. Three defects compounded; the reported symptom was the last one in the chain.

This change establishes the governing invariant:

> **If `up` reports success, every provisioning step succeeded.** There is never a valid case for a step to fail during `up` and for provisioning to continue.

## Root cause

`ClusterConfigWriter.writeSshConfig()` emitted `StrictHostKeyChecking=no` but never set `UserKnownHostsFile`, so the `ssh -N -D` SOCKS tunnel read the developer's `~/.ssh/known_hosts`. Every *other* SSH in the codebase goes through Apache MINA SSHD, which uses the default `AcceptAllServerKeyVerifier` and reads no known-hosts file at all.

`StrictHostKeyChecking=no` auto-adds *unknown* hosts; it does **not** bypass a *changed* key for a known host. AWS recycles public EC2 IPs, and `sshConfig` keys `Hostname` by `publicIp` — so on a recycled IP, `ssh` hard-failed with `REMOTE HOST IDENTIFICATION HAS CHANGED` and exited, while `SetupInstance`, the K3s install, and node labeling all connected fine over MINA.

This was **not** a timing/race issue. Control's `sshd` was accepting connections throughout.

## Why it was silent

`ProcessSocksProxyService.verifyProxyAcceptingConnections()` polled the port for 5s, logged `"proceeding anyway"`, and returned. `startNewProxy()` then published the port regardless — despite the comment directly above it promising *"the new port is republished by applySystemProperties() only after the proxy is verified."* The contract was written and never implemented.

Every Fabric8 call then got `Connection refused: localhost:1080`, and `Up.kt` swallowed those failures at **14 sites**. Because `labelNode`, `ensureLocalStorageClass`, and `ensureLocalStorageWfcClass` are all Fabric8 calls through that same dead tunnel, the blast radius was wider than the reported symptom: the cluster silently lost its `type=control` label, all db/app node ordinals (breaking StatefulSet pod-to-node pinning for every kit), and both StorageClasses (PVCs never bind).

`Event.Provision.NodeLabelingComplete` was emitted unconditionally after labeling failed — the exact line users read as the last-good checkpoint, asserting an outcome it never checked.

## What changed

**Host-key verification (root cause).** The generated `sshConfig` now sets `UserKnownHostsFile=/dev/null` alongside `StrictHostKeyChecking=no`, matching the accept-all behavior the MINA path has always had. Clusters are ephemeral and get fresh host keys on every provision.

**`up` fails fast at all 14 sites.** `installCilium()`'s existing `.getOrThrow()` was the precedent; every other site now follows it. Nested `commandExecutor.execute { }` calls (`WriteConfig`, `SetupInstance`, `ConfigureAxonOps`, `GrafanaUpdateConfig`) route through a helper that inspects the returned exit code — the executor already catches and converts to a non-zero `Int`, which is precisely why those four swallowed silently. `NodeLabelingComplete` now emits only on success.

**Two invariants moved ahead of provisioning.** A control node must exist and an S3 bucket must be configured — both validated before any EC2 instance is launched, rather than discovered mid-`up`. The three `controlHosts.isEmpty()` guards that silently skipped K3s, Cilium, node labeling, StorageClasses, and observability are removed rather than left as dead defensive code. **Zero db nodes remains a valid configuration** (Trino + OpenSearch) and no longer warns.

**The proxy fails fast.** `startNewProxy()` throws when the port never opens, so a dead port is never published, and terminates the unverified `ssh` process rather than orphaning it. `isValidProxy()` verifies the port is accepting before reusing a proxy — PID-alive was never evidence a tunnel is alive, at any of the **three** sites that asked (the in-memory fast path in `ensureRunning()` was a third door found during implementation). `startNewProxy()` now dials `gatewayHost.alias` rather than the hardcoded literal `"control0"`.

**The proxy pre-flight is opt-in.** A new `@RequiresProxy` annotation, checked in `CommandExecutor.checkRequirements()` alongside `@RequireDocker` / `@RequireSSHKey` / `@RequireProfileSetup`, declares which commands reach the private K8s API. `ensureProxyRunning()` no longer catches. `Down` doesn't declare it — its first two actions unpublish the proxy port and kill the ssh process, so the pre-flight was starting a tunnel that `Down` exists to tear down. That contradiction is what forced the swallow, and its KDoc rationale (*"the proxy may not be reachable during teardown"*) was fabricated to excuse it.

25 commands qualified by execution path — including `Server`, which reaches Fabric8 only transitively.

**`status` degrades rather than failing — the single specified exception.** Permitted *only* because `status` is read-only, and it's the command a user reaches for when the cluster is already broken. Unavailability follows the **transport**, not a section list: SSH never traverses the tunnel, so database versions still render; only the two sections sourced from the private Kubernetes API (stress jobs, ClickHouse) are marked unavailable. There is one rendering path for both the healthy and degraded reports, so a new section cannot silently vanish from the degraded one. It still exits non-zero, so a script cannot read a partial report as a healthy cluster. **No state-mutating command may take this exception.**

**The SSH readiness wait covers control nodes.** `waitForSshAndDownloadVersions()` waited only on db hosts. Split into `waitForSshReady()` (control + db) and `downloadCassandraVersions()` (db only). An independent real bug — **not** the cause of this incident.

## Spec impact

- `networking` — `REQ-NET-005: SOCKS Proxy` had five scenarios, all happy-path or reuse. None specified what happens when the proxy cannot be established. Now nine, covering failure, zombie-tunnel reuse, orphan cleanup, opt-in gating, and dialing the recorded alias. Adds a requirement that generated SSH config never depends on the developer's `~/.ssh/known_hosts`.
- `cluster-lifecycle` — adds the governing invariant, the two pre-provisioning invariants, zero-db-nodes as valid, and control-node SSH readiness. Modifies `REQ-CL-004: Cluster Status` for the degradation.

## Breaking change

`up` now exits non-zero on failures it previously logged and ignored. Any `up` that now fails was already producing a degraded cluster — this makes existing breakage visible rather than introducing it. Clusters are ephemeral, so there is no migration path: `down` and re-provision.

Aborting mid-`up` leaves EC2 instances running by design. There is no rollback; `down` reclaims them.

`ssh` no longer writes host keys into the developer's `~/.ssh/known_hosts`. Stale entries accumulated from previous clusters can be pruned.

## Notes for review

- **The two new invariants are defensive, not reachable today.** `controlInstances` isn't CLI-settable, and `configureAccountS3Bucket()` self-heals a blank bucket. They guard hand-edited `state.json` and future config surfaces. Their tests exercise stubs, not reachable paths — unlike the 14 swallow sites.
- **Two events were deleted.** Removing `TailscaleStart`'s catch left `Event.Provision.TailscaleWarning` and `TailscaleManualInstruction` with no emitter. The manual-setup guidance now lives inline in the thrown error. An MCP client subscribed to those events will no longer receive them.
- **No test enforces `@RequiresProxy` is applied.** A guard test was written and deleted: every form of it degenerates into a hand-maintained list (of service types, or of suppressions for bytecode-reachability false positives) that passes forever while covering less. The opt-in design is what makes a missed annotation benign — it reproduces today's behavior rather than breaking a working command.
- **Test 6.3 doesn't exercise the retry window.** It injects a non-retryable exception so it fails on attempt 1 rather than burning ~5 minutes. `RetryUtilTest` covers the predicate separately.

## Explicitly out of scope

- `grafana update-config` dropping kit-installed dashboards (noted in #734).
- MINA SSHD's `AcceptAllServerKeyVerifier` — the library SSH path verifies no host keys at all. This change makes the CLI *match* that rather than diverge from it; fixing both is a separate change.
- `Down.cleanupSocks5Proxy()` resolving its state file against cwd rather than `context.workingDirectory` — filed as #738.

## Verification

- Targeted suites green: `UpTest` (20 new tests), `StatusTest`, `CommandExecutorTest`, `ProcessSocksProxyServiceTest` (13), `ClusterConfigWriterTest` (2).
- `ktlintCheck` clean; `detekt` reports zero new findings in changed files.
- Full suite deferred to CI.
- **Not yet done:** end-to-end validation against a real AWS cluster — provision with `init --up`, confirm the observability stack, both StorageClasses, and all node labels are present, and confirm a dead tunnel exits non-zero.
