### PR TITLE
fix(openspec): repair all specs and changes to pass validation (#742)

### DIFF
--- a/openspec/changes/kit-capabilities/specs/kit-capabilities/spec.md
+++ b/openspec/changes/kit-capabilities/specs/kit-capabilities/spec.md
@@ -1,0 +1,86 @@
+## ADDED Requirements
+
+### Requirement: capabilities block in kit.yaml
+
+`kit.yaml` SHALL support an optional `capabilities:` list. Each entry declares a named
+capability type and its configuration. Unrecognised capability types MUST be ignored
+without raising an error.
+
+#### Scenario: Recognised capability registers a command
+- **WHEN** `kit.yaml` contains a `capabilities:` list with a recognised type
+- **THEN** the corresponding CLI command is registered under that kit's subcommand group
+
+#### Scenario: No capabilities block leaves behaviour unchanged
+- **WHEN** `kit.yaml` contains no `capabilities:` block
+- **THEN** kit behaviour is unchanged from today
+
+#### Scenario: Unrecognised capability type is ignored
+- **WHEN** `kit.yaml` declares a capability whose type is not recognised
+- **THEN** deserialization succeeds and the unrecognised capability produces no command
+
+### Requirement: sql capability type
+
+The `sql` capability type SHALL register a `sql` subcommand under the kit group that
+executes SQL statements against the kit's JDBC endpoint. The capability SHALL read
+connection details from the kit's existing `endpoints:` declaration — specifically the
+first endpoint of type `jdbc` — so no separate connection block is needed.
+
+The `sql` capability SHALL accept an optional `user` (JDBC username, defaulting to empty
+string) and an optional `driver-class` (fully-qualified JDBC driver class to force-load
+before connecting, required for drivers that do not auto-register via ServiceLoader).
+
+#### Scenario: Inline statement executes against jdbc endpoint
+- **WHEN** a kit declares `capabilities: [{type: sql, user: easy-db-lab}]` and has a
+  `jdbc` endpoint
+- **THEN** `easy-db-lab <kit> sql "<statement>"` executes the query and displays results
+  in tabular format
+
+#### Scenario: SQL read from a file
+- **WHEN** the user runs `easy-db-lab <kit> sql --file query.sql`
+- **THEN** SQL is read from the file and executed
+
+#### Scenario: Trailing semicolon is stripped
+- **WHEN** a trailing semicolon is present in the SQL statement
+- **THEN** it is stripped before execution
+
+#### Scenario: Successful query emits structured output
+- **WHEN** the query succeeds
+- **THEN** column names and row values are emitted as a structured output event
+
+#### Scenario: Failed query emits structured error
+- **WHEN** the query fails
+- **THEN** the error message is emitted as a structured error event
+
+#### Scenario: No SQL provided prints usage
+- **WHEN** no SQL is provided (neither inline nor `--file`)
+- **THEN** usage text is printed and the service is not called
+
+#### Scenario: driver-class is force-loaded
+- **WHEN** a `driver-class` is specified
+- **THEN** that class is force-loaded before the JDBC connection is attempted
+
+#### Scenario: No matching nodes emits an error
+- **WHEN** no nodes of the endpoint's node type exist in cluster state
+- **THEN** an error is emitted before any connection is attempted
+
+### Requirement: Capabilities and @KitCommand commands are additive
+
+Capability-generated commands and `@KitCommand`-annotated Kotlin commands SHALL both
+appear under the same kit subcommand group. They MUST NOT conflict.
+
+#### Scenario: Capability and annotated commands coexist
+- **WHEN** a kit declares a `sql` capability and also has `@KitCommand`-annotated classes
+- **THEN** both appear as subcommands under the kit group
+
+### Requirement: Existing per-kit SQL commands are removed
+
+The `presto sql` and `clickhouse sql` commands SHALL be implemented via the `sql`
+capability. The dedicated per-kit Kotlin service and command classes MUST be deleted.
+
+#### Scenario: presto sql uses the generic capability
+- **WHEN** the user runs `easy-db-lab presto sql "SELECT 1"`
+- **THEN** the query executes via the generic sql capability, not a presto-specific class
+
+#### Scenario: clickhouse sql uses the generic capability
+- **WHEN** the user runs `easy-db-lab clickhouse sql "SELECT 1"`
+- **THEN** the query executes via the generic sql capability, not a clickhouse-specific class

--- a/openspec/changes/kit-node-type-requirement/specs/install-command/spec.md
+++ b/openspec/changes/kit-node-type-requirement/specs/install-command/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: Kit node-type requirement field
+A kit MAY declare `type: db` or `type: app` in `kit.yaml`; when declared, the cluster MUST have at least
+one node of that type before installation proceeds. The field is optional — a kit without it has no
+node-type requirement. The check runs at the start of `install`, before any templates are rendered or
+files are written, so a failure leaves nothing on disk.
+
+#### Scenario: Install fails when required node pool is absent
+- **GIVEN** a kit declares `type: app`
+- **WHEN** the user runs `easy-db-lab install <kit>` and the cluster has no app nodes
+- **THEN** the install fails immediately with `Event.Kit.RequirementNotMet`
+- **THEN** no files are written to disk
+
+#### Scenario: Install proceeds when required node pool is present
+- **GIVEN** a kit declares `type: db`
+- **WHEN** the user runs `easy-db-lab install <kit>` and the cluster has at least one db node
+- **THEN** the install proceeds normally
+
+#### Scenario: No type field means no requirement check
+- **GIVEN** a kit declares no `type` field
+- **WHEN** the user runs `easy-db-lab install <kit>`
+- **THEN** no node-type check is performed

--- a/openspec/changes/kit-subcommand-restructure/specs/kit-command-group/spec.md
+++ b/openspec/changes/kit-subcommand-restructure/specs/kit-command-group/spec.md
@@ -36,8 +36,7 @@ The CLI SHALL expose `kit uninstall` as a subcommand that removes an installed k
 - **THEN** the kit is uninstalled as before
 
 ### Requirement: Uninstalled kit hint references `kit install`
-When the user types a top-level argument that matches an installable kit name,
-the hint message SHALL reference `kit install <name>`, not `install <name>`.
+When the user types a top-level argument that matches an installable kit name, the hint message SHALL reference `kit install <name>`, not `install <name>`.
 
 #### Scenario: Hint message uses new command path
 - **WHEN** the user runs `easy-db-lab clickhouse` before installing the clickhouse kit

--- a/openspec/changes/presto-sql-command/specs/presto/spec.md
+++ b/openspec/changes/presto-sql-command/specs/presto/spec.md
@@ -1,0 +1,58 @@
+## ADDED Requirements
+
+### Requirement: presto sql command
+The system SHALL provide a `presto sql` command that executes SQL against a running
+Presto cluster, giving the same in-tool "run a quick query" UX as `cassandra cql`.
+The command MUST accept SQL either as an inline positional argument (`presto sql <query>`)
+or from a file (`presto sql --file <path>`).
+
+#### Scenario: Inline query returns tabular results
+- **WHEN** the user runs `presto sql "SELECT count(*) FROM cassandra.ks.tbl"`
+- **THEN** the query is submitted to the Presto cluster and the results are displayed in
+  tabular format with column headers
+
+#### Scenario: Query read from a file
+- **WHEN** the user runs `presto sql --file query.sql`
+- **THEN** the SQL is read from the file and executed against the Presto cluster
+
+#### Scenario: No SQL provided prints usage
+- **WHEN** the user runs `presto sql` with neither an inline query nor `--file`
+- **THEN** a usage hint is emitted and no query is submitted
+
+### Requirement: presto sql visibility is gated on the presto kit
+The `presto sql` command SHALL only be visible and executable when the presto kit is
+installed. Registration MUST NOT interfere with the kit's own `presto start` and
+`presto stop` lifecycle subcommands.
+
+#### Scenario: sql appears only when presto is installed
+- **WHEN** the presto kit is installed
+- **THEN** `presto sql` is registered under the `presto` command group alongside
+  `presto start` and `presto stop`
+
+#### Scenario: Lifecycle subcommands are preserved
+- **WHEN** the `presto sql` command is registered under the presto group
+- **THEN** `presto start` and `presto stop` continue to work unchanged
+
+#### Scenario: kit info lists the sql command
+- **WHEN** the user runs `kit info presto`
+- **THEN** the Commands section lists `presto sql` with the description declared on the
+  command
+
+### Requirement: Presto HTTP API execution
+The `presto sql` command SHALL submit statements to the Presto HTTP API by POSTing the
+SQL to `/v1/statement` on the app node's private IP (port 8080) and following the
+`nextUri` links until pagination is exhausted, accumulating all columns and rows. The
+request MUST route through the SOCKS proxy when Tailscale direct connectivity is not
+active, reusing the shared HTTP client factory.
+
+#### Scenario: Paginated results are fully accumulated
+- **WHEN** a query returns results across multiple `nextUri` pages
+- **THEN** all pages are fetched and every row is included in the displayed output
+
+#### Scenario: Query error emits a structured error
+- **WHEN** the Presto API returns an error for the submitted statement
+- **THEN** the error message is emitted as a structured error event and the command fails
+
+#### Scenario: No app nodes emits an error before any request
+- **WHEN** no app nodes exist in cluster state
+- **THEN** an error is emitted before any HTTP request is made to the Presto API

--- a/openspec/changes/proxy-eager-startup/specs/networking/spec.md
+++ b/openspec/changes/proxy-eager-startup/specs/networking/spec.md
@@ -1,0 +1,43 @@
+## MODIFIED Requirements
+
+### Requirement: SOCKS Proxy
+
+The system MUST support a SOCKS5 proxy via SSH dynamic port forwarding as an alternative to Tailscale for routing traffic to internal cluster services. The proxy MUST be started eagerly at command startup rather than lazily by individual services: when the cluster state exists, infrastructure is UP, and Tailscale is not enabled, the command executor SHALL start (or reuse) the proxy before any command logic executes. Because starting the proxy is idempotent and the process persists as a detached OS process, it MUST be started unconditionally on every command invocation under these conditions, and no individual service SHALL be responsible for starting it.
+
+The `env.sh` environment file MUST NOT start the proxy itself. It SHALL read `SOCKS5_PROXY_PORT` from the proxy state file written by the CLI (via `jq`) so that shell wrappers use the same port as the Kotlin CLI, rather than hardcoding a port.
+
+#### Scenario: Proxy starts before command logic
+
+- **GIVEN** a provisioned cluster with infrastructure UP and Tailscale not enabled
+- **WHEN** any CLI command is invoked
+- **THEN** the SOCKS5 proxy is started (or reused if already running) before any command logic executes.
+
+#### Scenario: Proxy auto-restarts after being killed
+
+- **GIVEN** the SOCKS5 proxy OS process has been killed since the last invocation
+- **WHEN** any CLI command is invoked next
+- **THEN** the proxy is automatically restarted without user intervention.
+
+#### Scenario: Tailscale enabled bypasses the proxy
+
+- **GIVEN** Tailscale is enabled for the cluster
+- **WHEN** any CLI command is invoked
+- **THEN** the SOCKS5 proxy is not started and connections use direct private IP access.
+
+#### Scenario: Proxy skipped when cluster is not provisioned
+
+- **GIVEN** no cluster state file exists or infrastructure is not UP
+- **WHEN** a CLI command is invoked
+- **THEN** the SOCKS5 proxy is not started.
+
+#### Scenario: Proxy persists for session lifetime
+
+- **GIVEN** the REPL or server is running
+- **WHEN** the proxy is needed
+- **THEN** it persists for the lifetime of the session rather than per-command.
+
+#### Scenario: Proxy port exported to shell wrappers from state file
+
+- **GIVEN** a running cluster whose proxy state file records the active port
+- **WHEN** the user sources `env.sh`
+- **THEN** `SOCKS5_PROXY_PORT` is populated from the state file written by the CLI (not started by `env.sh`), so shell wrappers such as kubectl, helm, and curl use the correct port.

--- a/openspec/changes/sql-benchmarking-framework/specs/kit-capabilities/spec.md
+++ b/openspec/changes/sql-benchmarking-framework/specs/kit-capabilities/spec.md
@@ -1,9 +1,10 @@
 ## ADDED Requirements
 
 ### Requirement: kit-ref is a valid arg type in the capabilities arg system
-The `capabilities` arg system (REQ-KCAP-001) already supports typed args (`string`,
-`int`, `boolean`, `float`). A new `kit-ref` type SHALL be valid in the `args:` block
-of any kit, with the same `flag`, `variable`, `description`, and `required` fields.
+A new `kit-ref` type SHALL be a valid arg type in the `capabilities` arg system
+(REQ-KCAP-001), alongside the existing `string`, `int`, `boolean`, and `float` types.
+It is usable in the `args:` block of any kit, with the same `flag`, `variable`,
+`description`, and `required` fields.
 
 #### Scenario: kit-ref arg parsed alongside other arg types
 - **WHEN** a `kit.yaml` declares args including one with `type: kit-ref`

--- a/openspec/changes/sql-benchmarking-framework/specs/kit-cross-targeting/spec.md
+++ b/openspec/changes/sql-benchmarking-framework/specs/kit-cross-targeting/spec.md
@@ -14,9 +14,9 @@ field names the env var that stores the target kit name (conventionally `TARGET`
 - **THEN** deserialization does not throw; the arg defaults to `STRING` type
 
 ### Requirement: Instance directory named after bench kit and target
-When a bench kit is installed and its `kit-ref` arg is provided, the install command
-SHALL create a directory named `<kit-name>-<target-kit-name>` in the cluster workspace
-rather than the kit's base name.
+The install command SHALL create a directory named `<kit-name>-<target-kit-name>` in the
+cluster workspace, rather than the kit's base name, when a bench kit is installed and its
+`kit-ref` arg is provided.
 
 #### Scenario: Bench kit installed with target
 - **WHEN** the user runs `easy-db-lab kit install sysbench --target clickhouse`

--- a/openspec/specs/ami-building/spec.md
+++ b/openspec/specs/ami-building/spec.md
@@ -1,5 +1,7 @@
 # AMI Building
 
+## Purpose
+
 Manages creation and maintenance of pre-built Amazon Machine Images containing database software and supporting tools.
 
 ## Requirements
@@ -8,15 +10,24 @@ Manages creation and maintenance of pre-built Amazon Machine Images containing d
 
 The system MUST support building AMIs with multiple database versions and supporting tools pre-installed.
 
-**Scenarios:**
+#### Scenario: Build a base or Cassandra image
 
-- **GIVEN** Packer build configuration, **WHEN** the user builds a base or Cassandra image, **THEN** an AMI is created with the requested software installed.
-- **GIVEN** multiple Cassandra versions in the build config, **WHEN** the AMI is built, **THEN** all specified versions are installed and selectable at runtime.
+- **GIVEN** Packer build configuration
+- **WHEN** the user builds a base or Cassandra image
+- **THEN** an AMI is created with the requested software installed.
+
+#### Scenario: Multiple versions installed and selectable
+
+- **GIVEN** multiple Cassandra versions in the build config
+- **WHEN** the AMI is built
+- **THEN** all specified versions are installed and selectable at runtime.
 
 ### REQ-AMI-002: AMI Maintenance
 
 The system MUST support pruning old AMIs to manage costs.
 
-**Scenarios:**
+#### Scenario: Prune older AMIs
 
-- **GIVEN** multiple AMI versions exist, **WHEN** the user prunes AMIs, **THEN** older AMIs are deregistered while retaining the most recent ones.
+- **GIVEN** multiple AMI versions exist
+- **WHEN** the user prunes AMIs
+- **THEN** older AMIs are deregistered while retaining the most recent ones.

--- a/openspec/specs/cassandra/spec.md
+++ b/openspec/specs/cassandra/spec.md
@@ -1,5 +1,7 @@
 # Cassandra
 
+## Purpose
+
 Manages Apache Cassandra deployment, version selection, configuration, and cluster operations.
 
 ## Requirements
@@ -8,54 +10,90 @@ Manages Apache Cassandra deployment, version selection, configuration, and clust
 
 The system MUST support multiple Cassandra versions (3.0 through trunk) on the same AMI.
 
-**Scenarios:**
+#### Scenario: Select a Cassandra version
 
-- **GIVEN** a running cluster, **WHEN** the user selects a Cassandra version, **THEN** that version is activated with appropriate Java and Python runtime versions.
-- **GIVEN** a selected version, **WHEN** the user starts the cluster, **THEN** all nodes run the selected Cassandra version and join the ring.
+- **GIVEN** a running cluster
+- **WHEN** the user selects a Cassandra version
+- **THEN** that version is activated with appropriate Java and Python runtime versions.
+
+#### Scenario: Start cluster on selected version
+
+- **GIVEN** a selected version
+- **WHEN** the user starts the cluster
+- **THEN** all nodes run the selected Cassandra version and join the ring.
 
 ### REQ-CA-002: Configuration Management
 
 The system MUST allow configuration of Cassandra via YAML patch files.
 
-**Scenarios:**
+#### Scenario: Push a YAML patch
 
-- **GIVEN** a local YAML patch file with configuration overrides, **WHEN** the user pushes configuration, **THEN** the patch is applied to cassandra.yaml on all targeted nodes.
-- **GIVEN** updated configuration, **WHEN** the user requests a restart alongside the config push, **THEN** nodes are restarted with the new configuration.
+- **GIVEN** a local YAML patch file with configuration overrides
+- **WHEN** the user pushes configuration
+- **THEN** the patch is applied to cassandra.yaml on all targeted nodes.
+
+#### Scenario: Restart on config push
+
+- **GIVEN** updated configuration
+- **WHEN** the user requests a restart alongside the config push
+- **THEN** nodes are restarted with the new configuration.
 
 ### REQ-CA-003: Cluster Lifecycle
 
 The system MUST support starting, stopping, and restarting Cassandra across cluster nodes. When starting, the system SHALL also deploy the Cassandra sidecar as a K3s DaemonSet after all Cassandra nodes are up.
 
-**Scenarios:**
+#### Scenario: Sequential start with delay
 
-- **GIVEN** a configured Cassandra version, **WHEN** the user starts the cluster, **THEN** nodes start sequentially with a configurable delay between them.
-- **GIVEN** a running Cassandra cluster, **WHEN** the user stops it, **THEN** all nodes are stopped gracefully.
-- **WHEN** the user runs `cassandra start`, **THEN** after all Cassandra nodes are up, the sidecar DaemonSet is applied to K3s.
+- **GIVEN** a configured Cassandra version
+- **WHEN** the user starts the cluster
+- **THEN** nodes start sequentially with a configurable delay between them.
+
+#### Scenario: Graceful stop
+
+- **GIVEN** a running Cassandra cluster
+- **WHEN** the user stops it
+- **THEN** all nodes are stopped gracefully.
+
+#### Scenario: Sidecar DaemonSet applied after start
+
+- **WHEN** the user runs `cassandra start`
+- **THEN** after all Cassandra nodes are up, the sidecar DaemonSet is applied to K3s.
 
 ### REQ-CA-004: Mixed-Version Clusters
 
 The system MUST support running different Cassandra versions on different nodes for upgrade testing.
 
-**Scenarios:**
+#### Scenario: Per-host version selection
 
-- **GIVEN** a running cluster, **WHEN** the user selects different versions for different hosts, **THEN** each host runs its assigned version independently.
+- **GIVEN** a running cluster
+- **WHEN** the user selects different versions for different hosts
+- **THEN** each host runs its assigned version independently.
 
 ### REQ-CA-005: CQL Access
 
 The system MUST provide CQL query execution against the cluster via the Java driver, routed through the network access layer (SOCKS proxy or Tailscale).
 
-**Scenarios:**
+#### Scenario: Execute a CQL query
 
-- **GIVEN** a running Cassandra cluster, **WHEN** the user executes a CQL query, **THEN** the query is routed through the available network path and results are displayed.
-- **GIVEN** the REPL or server is running, **WHEN** multiple CQL queries are executed, **THEN** the CQL session is reused across queries.
+- **GIVEN** a running Cassandra cluster
+- **WHEN** the user executes a CQL query
+- **THEN** the query is routed through the available network path and results are displayed.
+
+#### Scenario: CQL session reuse
+
+- **GIVEN** the REPL or server is running
+- **WHEN** multiple CQL queries are executed
+- **THEN** the CQL session is reused across queries.
 
 ### REQ-CA-006: Nodetool Access
 
 The system MUST provide nodetool execution on cluster nodes.
 
-**Scenarios:**
+#### Scenario: Invoke nodetool
 
-- **GIVEN** a running cluster, **WHEN** the user invokes nodetool, **THEN** the specified nodetool command is executed on the targeted node.
+- **GIVEN** a running cluster
+- **WHEN** the user invokes nodetool
+- **THEN** the specified nodetool command is executed on the targeted node.
 
 ## Success Criteria
 

--- a/openspec/specs/clickhouse-backup-restore/spec.md
+++ b/openspec/specs/clickhouse-backup-restore/spec.md
@@ -1,5 +1,7 @@
 # ClickHouse Backup and Restore
 
+## Purpose
+
 Covers backup, restore, and list-backups commands for ClickHouse clusters using native BACKUP/RESTORE SQL and S3 storage.
 
 ## Requirements
@@ -8,50 +10,72 @@ Covers backup, restore, and list-backups commands for ClickHouse clusters using 
 
 The system SHALL back up the full schema and data of a running ClickHouse cluster to a named location in the account S3 bucket using ClickHouse's native BACKUP command.
 
-**Scenarios:**
+#### Scenario: Backup a running cluster
 
-- **WHEN** the user runs `clickhouse backup <name>` against a running cluster, **THEN** the system executes `BACKUP DATABASE default ON CLUSTER easy_db_lab TO Disk('s3_backup', '<name>/')` and emits a success event with the backup name and S3 location.
-- **WHEN** the user runs `clickhouse backup <name>` and a backup with that name already exists, **THEN** the system fails fast with a clear error message before executing the BACKUP command.
-- **WHEN** a backup completes successfully, **THEN** the system writes a `backup-metadata.json` sidecar at `clickhouse-backups/<name>/backup-metadata.json` containing backupName, timestamp, sourceCluster, and totalSizeBytes.
+- **WHEN** the user runs `clickhouse backup <name>` against a running cluster
+- **THEN** the system executes `BACKUP DATABASE default ON CLUSTER easy_db_lab TO Disk('s3_backup', '<name>/')` and emits a success event with the backup name and S3 location.
+
+#### Scenario: Backup name already exists
+
+- **WHEN** the user runs `clickhouse backup <name>` and a backup with that name already exists
+- **THEN** the system fails fast with a clear error message before executing the BACKUP command.
+
+#### Scenario: Backup writes metadata sidecar
+
+- **WHEN** a backup completes successfully
+- **THEN** the system writes a `backup-metadata.json` sidecar at `clickhouse-backups/<name>/backup-metadata.json` containing backupName, timestamp, sourceCluster, and totalSizeBytes.
 
 ### REQ-CHBR-002: User Can Restore a ClickHouse Cluster from a Named Backup
 
 The system SHALL restore schema and data into a running ClickHouse cluster from a named backup in the account S3 bucket.
 
-**Scenarios:**
+#### Scenario: Restore from a named backup
 
-- **WHEN** the user runs `clickhouse restore <name>` against a running cluster, **THEN** the system executes `RESTORE DATABASE default ON CLUSTER easy_db_lab FROM Disk('s3_backup', '<name>/')` and emits a success event.
-- **WHEN** the user runs `clickhouse restore <name>` and no backup with that name exists, **THEN** the system fails with a clear error message.
+- **WHEN** the user runs `clickhouse restore <name>` against a running cluster
+- **THEN** the system executes `RESTORE DATABASE default ON CLUSTER easy_db_lab FROM Disk('s3_backup', '<name>/')` and emits a success event.
+
+#### Scenario: Restore from a missing backup
+
+- **WHEN** the user runs `clickhouse restore <name>` and no backup with that name exists
+- **THEN** the system fails with a clear error message.
 
 ### REQ-CHBR-003: User Can Restore on Cluster Startup
 
 The system SHALL support restoring from a named backup immediately after `clickhouse start` completes.
 
-**Scenarios:**
+#### Scenario: Restore after start
 
-- **WHEN** the user runs `clickhouse start --restore-from <name>`, **THEN** the system starts the ClickHouse cluster and, once pods are ready, automatically runs `clickhouse restore <name>`.
+- **WHEN** the user runs `clickhouse start --restore-from <name>`
+- **THEN** the system starts the ClickHouse cluster and, once pods are ready, automatically runs `clickhouse restore <name>`.
 
 ### REQ-CHBR-004: User Can List Available Backups
 
 The system SHALL list all named backups in the account S3 bucket with their metadata.
 
-**Scenarios:**
+#### Scenario: List existing backups
 
-- **WHEN** the user runs `clickhouse list-backups`, **THEN** the system scans `clickhouse-backups/` in the account bucket and displays each backup's name, timestamp, size, and source cluster.
-- **WHEN** the user runs `clickhouse list-backups` and no backups exist, **THEN** the system emits an event indicating no backups were found.
+- **WHEN** the user runs `clickhouse list-backups`
+- **THEN** the system scans `clickhouse-backups/` in the account bucket and displays each backup's name, timestamp, size, and source cluster.
+
+#### Scenario: List when no backups exist
+
+- **WHEN** the user runs `clickhouse list-backups` and no backups exist
+- **THEN** the system emits an event indicating no backups were found.
 
 ### REQ-CHBR-005: User Can Back Up Before Cluster Teardown
 
 The system SHALL support triggering a ClickHouse backup as part of the `down` command before AWS infrastructure is torn down.
 
-**Scenarios:**
+#### Scenario: Backup during teardown
 
-- **WHEN** the user runs `down --clickhouse.backup <name>`, **THEN** the system performs the ClickHouse backup before beginning AWS teardown, and fails the teardown if the backup fails.
+- **WHEN** the user runs `down --clickhouse.backup <name>`
+- **THEN** the system performs the ClickHouse backup before beginning AWS teardown, and fails the teardown if the backup fails.
 
 ### REQ-CHBR-006: Backup S3 Path Is Decoupled from Cluster Lifecycle
 
 Backups SHALL be stored at `s3://<account-bucket>/clickhouse-backups/<name>/`, independent of any cluster prefix, so they persist across cluster runs.
 
-**Scenarios:**
+#### Scenario: Backup persists across cluster teardown
 
-- **WHEN** a cluster is torn down after a backup, **THEN** the backup remains accessible in the account bucket under `clickhouse-backups/<name>/`.
+- **WHEN** a cluster is torn down after a backup
+- **THEN** the backup remains accessible in the account bucket under `clickhouse-backups/<name>/`.

--- a/openspec/specs/clickhouse-volume-persistence/spec.md
+++ b/openspec/specs/clickhouse-volume-persistence/spec.md
@@ -1,5 +1,7 @@
 # ClickHouse Volume Persistence
 
+## Purpose
+
 PersistentVolumes for ClickHouse are created lazily at `start` time and survive `stop`, so stop/start cycles resume existing data. Only `uninstall` deletes PVs and on-disk data.
 
 ## Requirements
@@ -8,33 +10,49 @@ PersistentVolumes for ClickHouse are created lazily at `start` time and survive 
 
 The system SHALL create ClickHouse PersistentVolumes as the first step of `clickhouse start`, not during `clickhouse install`. The `platform-pvs` step in `config.yaml` MUST appear in the `start` lifecycle and MUST NOT appear in the `install` lifecycle.
 
-**Scenarios:**
+#### Scenario: PVs created on start after fresh install
 
-- **WHEN** `clickhouse start` is run after a fresh install with no existing PVs, **THEN** the system creates one PV per db node before deploying the ClickHouseInstallation.
-- **WHEN** `clickhouse install` completes, **THEN** no PVs exist for the clickhouse workload.
+- **WHEN** `clickhouse start` is run after a fresh install with no existing PVs
+- **THEN** the system creates one PV per db node before deploying the ClickHouseInstallation.
+
+#### Scenario: No PVs after install
+
+- **WHEN** `clickhouse install` completes
+- **THEN** no PVs exist for the clickhouse workload.
 
 ### Requirement: Start is idempotent with respect to PVs
 
 The `platform-pvs` step in `start` MUST be idempotent: if PVs already exist (from a previous run), the system SHALL clear any stale claimRef UIDs and continue without error, not attempt to recreate the PVs.
 
-**Scenarios:**
+#### Scenario: Released PVs rebind on restart
 
-- **WHEN** `clickhouse stop` is run (deleting the CHI and PVCs) and then `clickhouse start` is run again, **THEN** the system detects the Released PVs, clears the stale claimRef UID, and the new PVCs bind successfully.
-- **WHEN** data is written to ClickHouse, then `clickhouse stop` is run, then `clickhouse start` is run again, **THEN** the data written before the stop is still accessible after the restart.
+- **WHEN** `clickhouse stop` is run (deleting the CHI and PVCs) and then `clickhouse start` is run again
+- **THEN** the system detects the Released PVs, clears the stale claimRef UID, and the new PVCs bind successfully.
+
+#### Scenario: Data survives a stop/start cycle
+
+- **WHEN** data is written to ClickHouse, then `clickhouse stop` is run, then `clickhouse start` is run again
+- **THEN** the data written before the stop is still accessible after the restart.
 
 ### Requirement: PVs survive stop
 
 The system MUST NOT delete ClickHouse PVs or data during `clickhouse stop`. PVs SHALL persist until `clickhouse uninstall` is executed.
 
-**Scenarios:**
+#### Scenario: PVs persist after stop
 
-- **WHEN** `clickhouse stop` is run, **THEN** the PVs for the clickhouse workload still exist in the cluster.
+- **WHEN** `clickhouse stop` is run
+- **THEN** the PVs for the clickhouse workload still exist in the cluster.
 
 ### Requirement: Uninstall cleans up PVs
 
 `clickhouse uninstall` MUST delete all PVs and the on-disk data for the clickhouse workload, even if `clickhouse start` was never run (no PVs to delete is not an error).
 
-**Scenarios:**
+#### Scenario: Uninstall after start removes PVs and data
 
-- **WHEN** `clickhouse start` has been run and then `clickhouse uninstall` is run, **THEN** all clickhouse PVs are deleted and the data directory is removed from cluster nodes.
-- **WHEN** `clickhouse install` is run but `clickhouse start` is never run, then `clickhouse uninstall` is run, **THEN** the uninstall completes successfully with zero PVs deleted.
+- **WHEN** `clickhouse start` has been run and then `clickhouse uninstall` is run
+- **THEN** all clickhouse PVs are deleted and the data directory is removed from cluster nodes.
+
+#### Scenario: Uninstall without prior start succeeds
+
+- **WHEN** `clickhouse install` is run but `clickhouse start` is never run, then `clickhouse uninstall` is run
+- **THEN** the uninstall completes successfully with zero PVs deleted.

--- a/openspec/specs/clickhouse/spec.md
+++ b/openspec/specs/clickhouse/spec.md
@@ -1,5 +1,7 @@
 # ClickHouse
 
+## Purpose
+
 Manages ClickHouse deployment on K3s with sharding, replication, and S3 storage integration.
 
 ## Requirements
@@ -8,57 +10,103 @@ Manages ClickHouse deployment on K3s with sharding, replication, and S3 storage 
 
 The system MUST deploy ClickHouse clusters via Kubernetes with configurable sharding and replication.
 
-**Scenarios:**
+#### Scenario: Deploy sharded cluster
 
-- **GIVEN** a running cluster with K3s, **WHEN** the user initializes and starts ClickHouse, **THEN** a sharded ClickHouse cluster is deployed with distributed tables.
-- **GIVEN** ClickHouse configuration, **WHEN** the user specifies a replica count per shard, **THEN** the deployment creates the requested number of replicas.
+- **GIVEN** a running cluster with K3s
+- **WHEN** the user initializes and starts ClickHouse
+- **THEN** a sharded ClickHouse cluster is deployed with distributed tables.
+
+#### Scenario: Replica count per shard
+
+- **GIVEN** ClickHouse configuration
+- **WHEN** the user specifies a replica count per shard
+- **THEN** the deployment creates the requested number of replicas.
 
 ### REQ-CH-002: S3 Storage Integration
 
 The system MUST use the per-cluster data bucket for ClickHouse S3 storage.
 
-**Scenarios:**
+#### Scenario: S3 endpoint points to data bucket
 
-- **GIVEN** a provisioned cluster, **WHEN** ClickHouse S3 storage is configured, **THEN** the S3 endpoint points to the per-cluster data bucket.
-- **GIVEN** S3 cache options, **WHEN** the user enables S3 caching, **THEN** ClickHouse caches S3 data locally for faster reads.
+- **GIVEN** a provisioned cluster
+- **WHEN** ClickHouse S3 storage is configured
+- **THEN** the S3 endpoint points to the per-cluster data bucket.
+
+#### Scenario: Local S3 caching
+
+- **GIVEN** S3 cache options
+- **WHEN** the user enables S3 caching
+- **THEN** ClickHouse caches S3 data locally for faster reads.
 
 ### REQ-CH-003: Lifecycle Management
 
 The system MUST support installing, starting, stopping, and uninstalling ClickHouse deployments. Stopping MUST preserve data; data is only deleted on uninstall. Starting after a stop MUST resume the existing dataset without any additional user steps.
 
-**Scenarios:**
+#### Scenario: Stop preserves data
 
-- **WHEN** the user runs `clickhouse stop`, **THEN** the ClickHouseInstallation and NodePort service are deleted, but PVs and on-disk data remain.
-- **WHEN** data is written to ClickHouse, `clickhouse stop` is run, and then `clickhouse start` is run again, **THEN** the previously written data is accessible without any restore step.
-- **WHEN** `clickhouse start` is run after a fresh install with no prior starts, **THEN** PVs are created and the ClickHouseInstallation is deployed successfully.
-- **GIVEN** a running ClickHouse cluster, **WHEN** the user checks status, **THEN** the deployment state is displayed.
+- **WHEN** the user runs `clickhouse stop`
+- **THEN** the ClickHouseInstallation and NodePort service are deleted, but PVs and on-disk data remain.
+
+#### Scenario: Start after stop resumes dataset
+
+- **WHEN** data is written to ClickHouse, `clickhouse stop` is run, and then `clickhouse start` is run again
+- **THEN** the previously written data is accessible without any restore step.
+
+#### Scenario: Start after fresh install
+
+- **WHEN** `clickhouse start` is run after a fresh install with no prior starts
+- **THEN** PVs are created and the ClickHouseInstallation is deployed successfully.
+
+#### Scenario: Status display
+
+- **GIVEN** a running ClickHouse cluster
+- **WHEN** the user checks status
+- **THEN** the deployment state is displayed.
 
 ### REQ-CH-004: S3 Backup Disk Configured at Startup
 
 The system SHALL configure an `s3_backup` disk of type `s3_plain` in the ClickHouse config at `clickhouse start` time, pointing to the account bucket's `clickhouse-backups/` prefix, using IAM role credentials.
 
-**Scenarios:**
+#### Scenario: Backup endpoint injected at start
 
-- **WHEN** the user runs `clickhouse start`, **THEN** the system injects `CLICKHOUSE_BACKUP_S3_ENDPOINT` into the ClickHouse ConfigMap, pointing to `https://<account-bucket>.s3.<region>.amazonaws.com/clickhouse-backups/`
-- **WHEN** a ClickHouse pod has the `s3_backup` disk configured, **THEN** `BACKUP DATABASE default TO Disk('s3_backup', 'name/')` executes without explicit credentials, using the EC2 IAM role
+- **WHEN** the user runs `clickhouse start`
+- **THEN** the system injects `CLICKHOUSE_BACKUP_S3_ENDPOINT` into the ClickHouse ConfigMap, pointing to `https://<account-bucket>.s3.<region>.amazonaws.com/clickhouse-backups/`
+
+#### Scenario: Backup uses IAM role credentials
+
+- **WHEN** a ClickHouse pod has the `s3_backup` disk configured
+- **THEN** `BACKUP DATABASE default TO Disk('s3_backup', 'name/')` executes without explicit credentials, using the EC2 IAM role
 
 ### REQ-CH-005: SQL Execution
 
 The `clickhouse sql` command SHALL execute SQL statements against a running ClickHouse cluster.
 SQL execution is provided via the `sql` capability declared in `clickhouse/kit.yaml` — see REQ-KCAP-002.
 
-**Scenarios:**
+#### Scenario: Execute inline SQL
 
-- **WHEN** the user runs `clickhouse sql "SELECT count(*) FROM default.events"`,
-  **THEN** the query is submitted via JDBC and results are displayed in tabular format.
-- **WHEN** the user runs `clickhouse sql --file query.sql`, **THEN** the SQL from the file is executed.
-- **WHEN** no db nodes exist in cluster state, **THEN** an error is emitted before any connection is made.
+- **WHEN** the user runs `clickhouse sql "SELECT count(*) FROM default.events"`
+- **THEN** the query is submitted via JDBC and results are displayed in tabular format.
+
+#### Scenario: Execute SQL from file
+
+- **WHEN** the user runs `clickhouse sql --file query.sql`
+- **THEN** the SQL from the file is executed.
+
+#### Scenario: No db nodes present
+
+- **WHEN** no db nodes exist in cluster state
+- **THEN** an error is emitted before any connection is made.
 
 ### REQ-CH-006: Version Selection
 
 The ClickHouse kit MUST accept a `--version` flag at install time to select the ClickHouse server image version. The flag MUST NOT use the prefix form `--clickhouse-version`.
 
-**Scenarios:**
+#### Scenario: Install with explicit version
 
-- **WHEN** the user runs `kit install clickhouse --version 25.4`, **THEN** the deployed ClickHouse uses image version 25.4.
-- **WHEN** the user runs `kit install clickhouse` without `--version`, **THEN** the kit deploys with the default version (`latest`).
+- **WHEN** the user runs `kit install clickhouse --version 25.4`
+- **THEN** the deployed ClickHouse uses image version 25.4.
+
+#### Scenario: Install with default version
+
+- **WHEN** the user runs `kit install clickhouse` without `--version`
+- **THEN** the kit deploys with the default version (`latest`).

--- a/openspec/specs/cloudwatch-metrics-export/spec.md
+++ b/openspec/specs/cloudwatch-metrics-export/spec.md
@@ -1,4 +1,10 @@
-## ADDED Requirements
+# Cloudwatch Metrics Export
+
+## Purpose
+
+Exports CloudWatch metrics into VictoriaMetrics via YACE so that EMR, S3/EBS, and OpenSearch metrics are queryable and survive cluster teardown, and provides Grafana dashboards that render this data from VictoriaMetrics.
+
+## Requirements
 
 ### Requirement: CloudWatch metrics scraped into VictoriaMetrics
 

--- a/openspec/specs/cluster-comparison-dashboard/spec.md
+++ b/openspec/specs/cluster-comparison-dashboard/spec.md
@@ -1,3 +1,11 @@
+# Cluster Comparison Dashboard
+
+## Purpose
+
+Provides a Grafana "Cluster Comparison" dashboard that renders side-by-side fleet, throughput, error, latency, activity, percentile, and system-resource views across multiple selected clusters.
+
+## Requirements
+
 ### Requirement: Cluster comparison dashboard exists and is registered
 
 A Grafana dashboard named "Cluster Comparison" SHALL exist at `dashboards/cluster-comparison.json` and SHALL be registered in the `GrafanaDashboard` enum as an optional entry named `CLUSTER_COMPARISON`.

--- a/openspec/specs/cluster-lifecycle/spec.md
+++ b/openspec/specs/cluster-lifecycle/spec.md
@@ -1,5 +1,7 @@
 # Cluster Lifecycle
 
+## Purpose
+
 Manages the full lifecycle of lab environments: initialization, provisioning, teardown, and status.
 
 ## Requirements
@@ -8,66 +10,125 @@ Manages the full lifecycle of lab environments: initialization, provisioning, te
 
 The system MUST allow users to initialize a cluster configuration specifying a name and node counts.
 
-**Scenarios:**
+#### Scenario: Initialize a new cluster
 
-- **GIVEN** a configured AWS profile, **WHEN** a user initializes a cluster with a name and node count, **THEN** cluster configuration is created and persisted locally.
-- **GIVEN** an initialized cluster, **WHEN** the user re-initializes with different parameters, **THEN** the configuration is updated.
+- **GIVEN** a configured AWS profile
+- **WHEN** a user initializes a cluster with a name and node count
+- **THEN** cluster configuration is created and persisted locally.
+
+#### Scenario: Re-initialize with different parameters
+
+- **GIVEN** an initialized cluster
+- **WHEN** the user re-initializes with different parameters
+- **THEN** the configuration is updated.
 
 ### REQ-CL-002: Infrastructure Provisioning
 
 The system MUST provision EC2 instances in AWS with configurable instance types and counts. The system MUST create a per-cluster data bucket for high-volume storage and CloudWatch metrics.
 
-**Scenarios:**
+#### Scenario: Provision EC2 instances
 
-- **GIVEN** an initialized cluster configuration, **WHEN** the user provisions the cluster, **THEN** EC2 instances are launched and accessible via SSH.
-- **GIVEN** provisioned instances, **WHEN** provisioning completes, **THEN** K3s Kubernetes is deployed on all nodes.
-- **GIVEN** cluster provisioning, **WHEN** infrastructure is created, **THEN** a per-cluster S3 data bucket named `easy-db-lab-data-<cluster-id>` is created and tagged with cluster metadata.
-- **GIVEN** a per-cluster data bucket, **WHEN** provisioning completes, **THEN** CloudWatch S3 request metrics are configured on the data bucket.
+- **GIVEN** an initialized cluster configuration
+- **WHEN** the user provisions the cluster
+- **THEN** EC2 instances are launched and accessible via SSH.
+
+#### Scenario: K3s deployed on provisioned instances
+
+- **GIVEN** provisioned instances
+- **WHEN** provisioning completes
+- **THEN** K3s Kubernetes is deployed on all nodes.
+
+#### Scenario: Per-cluster data bucket created
+
+- **GIVEN** cluster provisioning
+- **WHEN** infrastructure is created
+- **THEN** a per-cluster S3 data bucket named `easy-db-lab-data-<cluster-id>` is created and tagged with cluster metadata.
+
+#### Scenario: CloudWatch metrics on data bucket
+
+- **GIVEN** a per-cluster data bucket
+- **WHEN** provisioning completes
+- **THEN** CloudWatch S3 request metrics are configured on the data bucket.
 
 ### REQ-CL-003: Cluster Teardown
 
 The system MUST clean up all AWS resources on cluster teardown. Data bucket cleanup MUST use lifecycle expiration rather than individual object deletion.
 
-**Scenarios:**
+#### Scenario: Teardown removes AWS resources
 
-- **GIVEN** a running cluster, **WHEN** the user tears it down with confirmation, **THEN** all AWS resources (EC2, NAT gateways, security groups, route tables, subnets, internet gateways, VPC) are terminated.
-- **GIVEN** a running cluster with a data bucket, **WHEN** the user tears it down, **THEN** a lifecycle expiration rule is set on the data bucket to expire all objects after the retention period.
-- **GIVEN** multiple clusters, **WHEN** the user tears down all clusters, **THEN** every tagged VPC and its resources are removed, and all per-cluster data buckets are deleted.
-- **GIVEN** a teardown request without confirmation, **WHEN** the command runs, **THEN** the user is prompted for approval before proceeding.
+- **GIVEN** a running cluster
+- **WHEN** the user tears it down with confirmation
+- **THEN** all AWS resources (EC2, NAT gateways, security groups, route tables, subnets, internet gateways, VPC) are terminated.
+
+#### Scenario: Data bucket expires via lifecycle rule
+
+- **GIVEN** a running cluster with a data bucket
+- **WHEN** the user tears it down
+- **THEN** a lifecycle expiration rule is set on the data bucket to expire all objects after the retention period.
+
+#### Scenario: Teardown of all clusters
+
+- **GIVEN** multiple clusters
+- **WHEN** the user tears down all clusters
+- **THEN** every tagged VPC and its resources are removed, and all per-cluster data buckets are deleted.
+
+#### Scenario: Teardown requires confirmation
+
+- **GIVEN** a teardown request without confirmation
+- **WHEN** the command runs
+- **THEN** the user is prompted for approval before proceeding.
 
 ### REQ-CL-004: Cluster Status
 
 The system MUST provide comprehensive status of cluster resources including nodes, networking, Kubernetes pods, and running workloads.
 
-**Scenarios:**
+#### Scenario: Display cluster status
 
-- **GIVEN** a running cluster, **WHEN** the user checks status, **THEN** the state of EC2 instances, VPC networking, K8s pods, stress jobs, and database versions is displayed.
+- **GIVEN** a running cluster
+- **WHEN** the user checks status
+- **THEN** the state of EC2 instances, VPC networking, K8s pods, stress jobs, and database versions is displayed.
 
 ### REQ-CL-005: Local Cleanup
 
 The system MUST allow cleanup of locally generated cluster files.
 
-**Scenarios:**
+#### Scenario: Remove local cluster files
 
-- **GIVEN** a previously initialized cluster, **WHEN** the user runs local cleanup, **THEN** state files, SSH config, and cached configuration are removed.
+- **GIVEN** a previously initialized cluster
+- **WHEN** the user runs local cleanup
+- **THEN** state files, SSH config, and cached configuration are removed.
 
 ### REQ-CL-006: Cluster State Backup
 
 The system MUST back up cluster configuration files to S3 for recovery.
 
-**Scenarios:**
+#### Scenario: Incremental config backup
 
-- **GIVEN** a running cluster, **WHEN** configuration changes occur, **THEN** changed files are incrementally backed up to S3.
-- **GIVEN** a cluster with backed-up state, **WHEN** the user triggers a full backup, **THEN** all configuration files (state, SSH config, kubeconfig, cassandra patches) are persisted to S3.
+- **GIVEN** a running cluster
+- **WHEN** configuration changes occur
+- **THEN** changed files are incrementally backed up to S3.
+
+#### Scenario: Full config backup
+
+- **GIVEN** a cluster with backed-up state
+- **WHEN** the user triggers a full backup
+- **THEN** all configuration files (state, SSH config, kubeconfig, cassandra patches) are persisted to S3.
 
 ### REQ-CL-007: Cluster State Restore
 
 The system MUST support restoring cluster configuration from S3 using VPC identification.
 
-**Scenarios:**
+#### Scenario: Restore state from VPC ID
 
-- **GIVEN** a VPC ID from a previously provisioned cluster, **WHEN** the user restores state, **THEN** cluster configuration is recovered from S3 and the local environment is rebuilt.
-- **GIVEN** no backup exists for a VPC, **WHEN** restore is attempted, **THEN** the user is informed that no configuration was found.
+- **GIVEN** a VPC ID from a previously provisioned cluster
+- **WHEN** the user restores state
+- **THEN** cluster configuration is recovered from S3 and the local environment is rebuilt.
+
+#### Scenario: Restore when no backup exists
+
+- **GIVEN** no backup exists for a VPC
+- **WHEN** restore is attempted
+- **THEN** the user is informed that no configuration was found.
 
 ## Success Criteria
 

--- a/openspec/specs/container-wrapper/spec.md
+++ b/openspec/specs/container-wrapper/spec.md
@@ -1,4 +1,10 @@
-## ADDED Requirements
+# Container Wrapper
+
+## Purpose
+
+Provides an executable `easy-db-lab` wrapper script inside the jib-built container image so workload scripts can invoke the CLI directly, and resolves the `EASY_DB_LAB_EXEC` path correctly in both dev and container environments.
+
+## Requirements
 
 ### Requirement: Container image includes easy-db-lab executable at /usr/local/bin/easy-db-lab
 The jib-built container image SHALL include a shell script at `/usr/local/bin/easy-db-lab` that invokes the application JAR with the correct JVM flags. This script SHALL be executable.

--- a/openspec/specs/containerized-sidecar/spec.md
+++ b/openspec/specs/containerized-sidecar/spec.md
@@ -1,4 +1,10 @@
-## ADDED Requirements
+# Containerized Sidecar
+
+## Purpose
+
+Deploys the Cassandra sidecar as a K3s DaemonSet on database nodes with per-node configuration, host data access, and Pyroscope/OTel instrumentation wired to node-local observability endpoints.
+
+## Requirements
 
 ### Requirement: Sidecar runs as a K3s DaemonSet on database nodes
 

--- a/openspec/specs/dashboard-publishing/spec.md
+++ b/openspec/specs/dashboard-publishing/spec.md
@@ -1,4 +1,10 @@
-## ADDED Requirements
+# Dashboard Publishing
+
+## Purpose
+
+Grafana dashboard JSON files live as top-level project artifacts and are published as a standalone zip archive on every push to the main branch, so they are available both on the JAR classpath and as a downloadable release asset.
+
+## Requirements
 
 ### Requirement: Dashboard files are top-level project artifacts
 

--- a/openspec/specs/dynamic-otel-scrape-config/spec.md
+++ b/openspec/specs/dynamic-otel-scrape-config/spec.md
@@ -1,6 +1,6 @@
 # Dynamic OTel Scrape Config
 
-## Overview
+## Purpose
 
 The OTel Collector ConfigMap is generated dynamically by `OtelManifestBuilder`, combining a fixed set of static scrape jobs for host processes with a dynamic set of per-workload scrape jobs read from the K8s metrics registry (`easydblab-metrics-*` ConfigMaps). This allows workloads to register and deregister their metrics endpoints at runtime without manual config changes.
 

--- a/openspec/specs/end-to-end-testing/spec.md
+++ b/openspec/specs/end-to-end-testing/spec.md
@@ -1,3 +1,9 @@
+# End To End Testing
+
+## Purpose
+
+A bash test runner provisions real AWS infrastructure, deploys services, runs validation steps for optional service domains (Cassandra, Spark, ClickHouse, OpenSearch, observability), and tears down the environment, with resilient step execution, breakpoints, resume, and interactive failure recovery.
+
 ## Requirements
 
 ### Requirement: End-to-end test runner

--- a/openspec/specs/env-file-config/spec.md
+++ b/openspec/specs/env-file-config/spec.md
@@ -1,3 +1,9 @@
+# Env File Config
+
+## Purpose
+
+Project scripts load configuration from a gitignored `.env` file at the project root without overwriting variables already set in the shell, and a committed `.env.example` documents every supported variable.
+
 ## Requirements
 
 ### Requirement: Scripts source a gitignored .env file at project root

--- a/openspec/specs/event-system/spec.md
+++ b/openspec/specs/event-system/spec.md
@@ -1,5 +1,7 @@
 # Event System
 
+## Purpose
+
 Structured event bus for all user-facing output, with pluggable output destinations.
 
 ## Requirements
@@ -8,76 +10,147 @@ Structured event bus for all user-facing output, with pluggable output destinati
 
 The system MUST emit structured events containing: event type, timestamp, and command name (when available). Event constructors MUST carry only structured domain data fields — never pre-formatted display strings. The `toDisplayString()` method constructs human-readable output internally from those data fields.
 
-**Scenarios:**
+#### Scenario: Event carries typed domain fields
 
-- **GIVEN** a command that produces output, **WHEN** it emits an event, **THEN** the event carries domain-specific typed fields (e.g., host name, resource ID, count) rather than a pre-formatted string.
-- **GIVEN** a concrete event type, **WHEN** it is rendered for console display, **THEN** `toDisplayString()` constructs the human-readable text from its structured data fields.
-- **GIVEN** an event with no meaningful data fields, **WHEN** it is defined, **THEN** it uses a singleton object form rather than carrying empty or dummy fields.
+- **GIVEN** a command that produces output
+- **WHEN** it emits an event
+- **THEN** the event carries domain-specific typed fields (e.g., host name, resource ID, count) rather than a pre-formatted string.
+
+#### Scenario: Display string built from data fields
+
+- **GIVEN** a concrete event type
+- **WHEN** it is rendered for console display
+- **THEN** `toDisplayString()` constructs the human-readable text from its structured data fields.
+
+#### Scenario: Fieldless events use singleton form
+
+- **GIVEN** an event with no meaningful data fields
+- **WHEN** it is defined
+- **THEN** it uses a singleton object form rather than carrying empty or dummy fields.
 
 ### REQ-ES-002: Event Type Hierarchy
 
 Events MUST be organized into domain-specific groups, enabling consumers to filter by domain prefix or match on specific event types. Types follow the pattern `<Domain>.<Action>` (e.g., `Cassandra.Starting`, `K3s.ClusterStarted`).
 
-**Scenarios:**
+#### Scenario: Filter events by domain prefix
 
-- **GIVEN** a consumer interested only in Cassandra events, **WHEN** it filters by the `Cassandra.*` prefix, **THEN** only Cassandra-related events match.
-- **GIVEN** a new feature area, **WHEN** events are needed, **THEN** a new domain interface is added to the sealed hierarchy.
+- **GIVEN** a consumer interested only in Cassandra events
+- **WHEN** it filters by the `Cassandra.*` prefix
+- **THEN** only Cassandra-related events match.
+
+#### Scenario: New domain added to hierarchy
+
+- **GIVEN** a new feature area
+- **WHEN** events are needed
+- **THEN** a new domain interface is added to the sealed hierarchy.
 
 ### REQ-ES-003: Backward-Compatible Console Output
 
 The system MUST preserve existing console output behavior. The migration to structured events is transparent to CLI users.
 
-**Scenarios:**
+#### Scenario: Terminal output unchanged after migration
 
-- **GIVEN** a user runs any command, **WHEN** events are emitted, **THEN** terminal output appears identical to pre-migration behavior.
-- **GIVEN** no external output destinations are configured, **WHEN** commands run, **THEN** only console output is produced with no errors about missing destinations.
+- **GIVEN** a user runs any command
+- **WHEN** events are emitted
+- **THEN** terminal output appears identical to pre-migration behavior.
+
+#### Scenario: Console-only produces no destination errors
+
+- **GIVEN** no external output destinations are configured
+- **WHEN** commands run
+- **THEN** only console output is produced with no errors about missing destinations.
 
 ### REQ-ES-004: Multiple Output Destinations
 
 The system MUST support multiple simultaneous output destinations via fan-out. Adding a new destination requires no changes to event-emitting code.
 
-**Scenarios:**
+#### Scenario: All configured destinations receive the event
 
-- **GIVEN** console, MCP, and Redis destinations are all configured, **WHEN** an event is emitted, **THEN** all three destinations receive the event.
-- **GIVEN** only console is configured, **WHEN** an event is emitted, **THEN** only console output is produced.
+- **GIVEN** console, MCP, and Redis destinations are all configured
+- **WHEN** an event is emitted
+- **THEN** all three destinations receive the event.
+
+#### Scenario: Only configured destination receives the event
+
+- **GIVEN** only console is configured
+- **WHEN** an event is emitted
+- **THEN** only console output is produced.
 
 ### REQ-ES-005: Redis Pub/Sub Destination
 
 The system MUST support publishing events to a Redis pub/sub channel using the Jedis client library, configured via environment variable.
 
-**Scenarios:**
+#### Scenario: Publish events to configured Redis channel
 
-- **GIVEN** `EASY_DB_LAB_REDIS_URL` is set (format: `redis://host:port/channel`), **WHEN** the tool starts, **THEN** the tool connects using Jedis and publishes events to the specified Redis channel.
-- **GIVEN** a Redis subscriber listening on the channel, **WHEN** commands run, **THEN** the subscriber receives structured event envelopes as JSON.
-- **GIVEN** Redis is unavailable at startup, **WHEN** the environment variable is set, **THEN** the tool fails fast with a connection error.
-- **GIVEN** the Redis URL has no path component, **WHEN** the tool starts, **THEN** the system uses the default channel from Constants.
+- **GIVEN** `EASY_DB_LAB_REDIS_URL` is set (format: `redis://host:port/channel`)
+- **WHEN** the tool starts
+- **THEN** the tool connects using Jedis and publishes events to the specified Redis channel.
+
+#### Scenario: Subscriber receives JSON envelopes
+
+- **GIVEN** a Redis subscriber listening on the channel
+- **WHEN** commands run
+- **THEN** the subscriber receives structured event envelopes as JSON.
+
+#### Scenario: Fail fast when Redis unavailable
+
+- **GIVEN** Redis is unavailable at startup
+- **WHEN** the environment variable is set
+- **THEN** the tool fails fast with a connection error.
+
+#### Scenario: Default channel when URL has no path
+
+- **GIVEN** the Redis URL has no path component
+- **WHEN** the tool starts
+- **THEN** the system uses the default channel from Constants.
 
 ### REQ-ES-006: Wire Format Serialization
 
 Events MUST be serializable to a JSON wire format suitable for cross-system consumption. The wire format uses a `type` discriminator field for polymorphic deserialization.
 
-**Scenarios:**
+#### Scenario: Envelope serializes with discriminator
 
-- **GIVEN** an event envelope, **WHEN** it is serialized, **THEN** the JSON contains `timestamp`, optional `commandName`, and a nested `event` object with a `type` discriminator and domain-specific fields.
-- **GIVEN** serialized event JSON, **WHEN** a consumer deserializes it, **THEN** the event can be reconstructed with all typed fields intact.
-- **GIVEN** an event, **WHEN** it is serialized, **THEN** no `message`, `text`, or `displayString` field appears in the wire format — only structured data fields.
+- **GIVEN** an event envelope
+- **WHEN** it is serialized
+- **THEN** the JSON contains `timestamp`, optional `commandName`, and a nested `event` object with a `type` discriminator and domain-specific fields.
+
+#### Scenario: Deserialization reconstructs typed fields
+
+- **GIVEN** serialized event JSON
+- **WHEN** a consumer deserializes it
+- **THEN** the event can be reconstructed with all typed fields intact.
+
+#### Scenario: No display strings in wire format
+
+- **GIVEN** an event
+- **WHEN** it is serialized
+- **THEN** no `message`, `text`, or `displayString` field appears in the wire format — only structured data fields.
 
 ### REQ-ES-007: Command Context Tracking
 
 The system MUST track which command is currently executing and include this in event metadata. Nested command execution (e.g., `init` calling `up`) MUST reflect the innermost command.
 
-**Scenarios:**
+#### Scenario: Nested command reflects innermost
 
-- **GIVEN** a user runs `init` which internally calls `up`, **WHEN** events are emitted during `up`, **THEN** the `commandName` metadata reads `up`.
-- **GIVEN** `up` completes and control returns to `init`, **WHEN** events are emitted, **THEN** the `commandName` metadata reads `init`.
+- **GIVEN** a user runs `init` which internally calls `up`
+- **WHEN** events are emitted during `up`
+- **THEN** the `commandName` metadata reads `up`.
+
+#### Scenario: Command context restored on return
+
+- **GIVEN** `up` completes and control returns to `init`
+- **WHEN** events are emitted
+- **THEN** the `commandName` metadata reads `init`.
 
 ### REQ-ES-008: No Generic Event Types in Production
 
 `Event.Message` and `Event.Error` generic types exist only for test convenience. All production output MUST use domain-specific typed events with structured data fields.
 
-**Scenarios:**
+#### Scenario: Developers use domain-specific event types
 
-- **GIVEN** a command needs to emit output, **WHEN** the developer writes the emit call, **THEN** they use a domain-specific event type, not `Event.Message` or `Event.Error`.
+- **GIVEN** a command needs to emit output
+- **WHEN** the developer writes the emit call
+- **THEN** they use a domain-specific event type, not `Event.Message` or `Event.Error`.
 
 ## Data Contract: Event Envelope
 

--- a/openspec/specs/grafana-install-dashboard/spec.md
+++ b/openspec/specs/grafana-install-dashboard/spec.md
@@ -1,4 +1,10 @@
-## ADDED Requirements
+# Grafana Install Dashboard
+
+## Purpose
+
+Persist Grafana's data across pod restarts and provide a `grafana install <path>` command that uploads a dashboard JSON file to the running Grafana instance.
+
+## Requirements
 
 ### Requirement: Grafana data persists across pod restarts
 Grafana's data volume SHALL use a `hostPath` mount at `/mnt/db1/grafana` on the control node instead of `emptyDir`. The directory SHALL be created by `grafana update-config` before the Deployment is applied.

--- a/openspec/specs/install-command/spec.md
+++ b/openspec/specs/install-command/spec.md
@@ -1,15 +1,15 @@
 # Install Command Spec
 
-## Overview
+## Purpose
 
 The `install` command group scaffolds kit-specific files (Helm values, scripts, README) into a
 local directory. Users then run the kit via `easy-db-lab <kit> start` — the CLI reads the
 generated `bin/` scripts and registers them as top-level subcommands automatically.
 
-## Template Discovery
+## Requirements
 
 ### Requirement: Template discovery sources
-Templates are resolved from four sources in priority order:
+Templates SHALL be resolved from four sources in priority order:
 
 1. **Profile directory**: `~/.easy-db-lab/profiles/<profile>/kits/<name>/`
 2. **Additional sources**: directories registered via `kit source add`, searched in registration order; each registered directory's subdirectories are treated as individual kit templates
@@ -68,6 +68,26 @@ The CLI loader SHALL look for `kit.yaml` when resolving a kit's configuration fr
 - **WHEN** a template directory contains `config.yaml` but no `kit.yaml`
 - **THEN** the CLI does not load it (no silent fallback)
 
+### Requirement: Kit node-type requirement field
+A kit MAY declare `type: db` or `type: app` in `kit.yaml`; when declared, the cluster MUST have at least
+one node of that type before installation proceeds.
+
+#### Scenario: Install fails when required node pool is absent
+- **GIVEN** a kit declares `type: app`
+- **WHEN** the user runs `easy-db-lab install <kit>` and the cluster has no app nodes
+- **THEN** the install fails immediately with `Event.Kit.RequirementNotMet`
+- **THEN** no files are written to disk
+
+#### Scenario: Install proceeds when required node pool is present
+- **GIVEN** a kit declares `type: db`
+- **WHEN** the user runs `easy-db-lab install <kit>` and the cluster has at least one db node
+- **THEN** the install proceeds normally
+
+#### Scenario: No type field means no requirement check
+- **GIVEN** a kit declares no `type` field
+- **WHEN** the user runs `easy-db-lab install <kit>`
+- **THEN** no node-type check is performed
+
 ## Template Structure
 
 Each template directory contains a `kit.yaml` descriptor and files with a `.template` suffix:
@@ -110,26 +130,6 @@ args:
 
 `default` values support `${VAR}` interpolation from cluster state (e.g. `${DB_NODE_COUNT}`,
 `${APP_NODE_COUNT}`). Raw `${VAR}` text is kept when cluster state is unavailable.
-
-### Requirement: Kit node-type requirement field
-A kit MAY declare `type: db` or `type: app` in `kit.yaml` to assert that the cluster has at least
-one node of that type before installation proceeds.
-
-#### Scenario: Install fails when required node pool is absent
-- **GIVEN** a kit declares `type: app`
-- **WHEN** the user runs `easy-db-lab install <kit>` and the cluster has no app nodes
-- **THEN** the install fails immediately with `Event.Kit.RequirementNotMet`
-- **THEN** no files are written to disk
-
-#### Scenario: Install proceeds when required node pool is present
-- **GIVEN** a kit declares `type: db`
-- **WHEN** the user runs `easy-db-lab install <kit>` and the cluster has at least one db node
-- **THEN** the install proceeds normally
-
-#### Scenario: No type field means no requirement check
-- **GIVEN** a kit declares no `type` field
-- **WHEN** the user runs `easy-db-lab install <kit>`
-- **THEN** no node-type check is performed
 
 ## Kit Lifecycle Hooks
 

--- a/openspec/specs/instance-storage-validation/spec.md
+++ b/openspec/specs/instance-storage-validation/spec.md
@@ -1,3 +1,11 @@
+# Instance Storage Validation
+
+## Purpose
+
+Validate at init time that a database instance type has adequate data storage — either local instance store or an explicitly specified EBS volume — and fail fast with a clear error before any instances are created if it does not.
+
+## Requirements
+
 ### Requirement: Database instance storage validation at init time
 
 The system SHALL validate that the database instance type has adequate storage before provisioning. An instance type MUST either have local instance store (NVMe) or the user MUST specify `--ebs.type` with a value other than `NONE`. If neither condition is met, the system SHALL fail with a clear error message and NOT proceed with instance creation.

--- a/openspec/specs/kit-capabilities/spec.md
+++ b/openspec/specs/kit-capabilities/spec.md
@@ -1,5 +1,7 @@
 # Kit Capabilities
 
+## Purpose
+
 Declarative database capabilities in `kit.yaml` that generate CLI commands automatically,
 eliminating per-kit Kotlin service and command classes for standard patterns.
 
@@ -10,11 +12,11 @@ eliminating per-kit Kotlin service and command classes for standard patterns.
 `kit.yaml` SHALL support an optional `capabilities:` list. Each entry declares a named
 capability type and its configuration. Unrecognised capability types are ignored.
 
-**Scenarios:**
-
+#### Scenario: Recognised capability registers a command
 - **WHEN** `kit.yaml` contains a `capabilities:` list with a recognised type
 - **THEN** the corresponding CLI command is registered under that kit's subcommand group
 
+#### Scenario: No capabilities block leaves behaviour unchanged
 - **WHEN** `kit.yaml` contains no `capabilities:` block
 - **THEN** kit behaviour is unchanged from today
 
@@ -32,52 +34,59 @@ The `sql` capability SHALL accept:
 - `driver-class` (string, optional) — fully-qualified JDBC driver class to force-load
   before connecting; required for drivers that do not auto-register via ServiceLoader
 
-**Scenarios:**
-
+#### Scenario: Inline statement executes against jdbc endpoint
 - **WHEN** a kit declares `capabilities: [{type: sql, user: easy-db-lab}]` and has a
-  `jdbc` endpoint, **THEN** `easy-db-lab <kit> sql "<statement>"` executes the query
+  `jdbc` endpoint
+- **THEN** `easy-db-lab <kit> sql "<statement>"` executes the query
   and displays results in tabular format
 
-- **WHEN** the user runs `easy-db-lab <kit> sql --file query.sql`, **THEN** SQL is
-  read from the file and executed
+#### Scenario: SQL read from a file
+- **WHEN** the user runs `easy-db-lab <kit> sql --file query.sql`
+- **THEN** SQL is read from the file and executed
 
-- **WHEN** a trailing semicolon is present in the SQL statement, **THEN** it is
-  stripped before execution
+#### Scenario: Trailing semicolon is stripped
+- **WHEN** a trailing semicolon is present in the SQL statement
+- **THEN** it is stripped before execution
 
-- **WHEN** the query succeeds, **THEN** column names and row values are emitted as a
-  structured output event
+#### Scenario: Successful query emits structured output
+- **WHEN** the query succeeds
+- **THEN** column names and row values are emitted as a structured output event
 
-- **WHEN** the query fails, **THEN** the error message is emitted as a structured
-  error event
+#### Scenario: Failed query emits structured error
+- **WHEN** the query fails
+- **THEN** the error message is emitted as a structured error event
 
-- **WHEN** no SQL is provided (neither inline nor `--file`), **THEN** usage text is
-  printed and the service is not called
+#### Scenario: No SQL provided prints usage
+- **WHEN** no SQL is provided (neither inline nor `--file`)
+- **THEN** usage text is printed and the service is not called
 
-- **WHEN** a `driver-class` is specified, **THEN** that class is force-loaded before
-  the JDBC connection is attempted
+#### Scenario: driver-class is force-loaded
+- **WHEN** a `driver-class` is specified
+- **THEN** that class is force-loaded before the JDBC connection is attempted
 
-- **WHEN** no nodes of the endpoint's node type exist in cluster state, **THEN** an
-  error is emitted before any connection is attempted
+#### Scenario: No matching nodes emits an error
+- **WHEN** no nodes of the endpoint's node type exist in cluster state
+- **THEN** an error is emitted before any connection is attempted
 
 ### REQ-KCAP-003: Capabilities and @KitCommand commands are additive
 
 Capability-generated commands and `@KitCommand`-annotated Kotlin commands SHALL both
 appear under the same kit subcommand group. They do not conflict.
 
-**Scenarios:**
-
+#### Scenario: Capability and annotated commands coexist
 - **WHEN** a kit declares a `sql` capability and also has `@KitCommand`-annotated
-  classes, **THEN** both appear as subcommands under the kit group
+  classes
+- **THEN** both appear as subcommands under the kit group
 
 ### REQ-KCAP-004: Existing per-kit SQL commands are removed
 
 The `presto sql` and `clickhouse sql` commands SHALL be implemented via the `sql`
 capability. The dedicated per-kit Kotlin service and command classes are deleted.
 
-**Scenarios:**
+#### Scenario: presto sql uses the generic capability
+- **WHEN** the user runs `easy-db-lab presto sql "SELECT 1"`
+- **THEN** the query executes via the generic sql capability, not a presto-specific class
 
-- **WHEN** the user runs `easy-db-lab presto sql "SELECT 1"`, **THEN** the query
-  executes via the generic sql capability, not a presto-specific class
-
-- **WHEN** the user runs `easy-db-lab clickhouse sql "SELECT 1"`, **THEN** the query
-  executes via the generic sql capability, not a clickhouse-specific class
+#### Scenario: clickhouse sql uses the generic capability
+- **WHEN** the user runs `easy-db-lab clickhouse sql "SELECT 1"`
+- **THEN** the query executes via the generic sql capability, not a clickhouse-specific class

--- a/openspec/specs/kit-lifecycle-hooks/spec.md
+++ b/openspec/specs/kit-lifecycle-hooks/spec.md
@@ -1,7 +1,13 @@
-## ADDED Requirements
+# Kit Lifecycle Hooks
+
+## Purpose
+
+Let a kit declare hook scripts in its `config.yaml` that run after any other kit starts or stops, so observer kits can react to peer kit lifecycle events with retry-on-failure semantics.
+
+## Requirements
 
 ### Requirement: config.yaml declares post-kit hooks
-A kit's `config.yaml` MAY declare hook scripts that execute after any other kit starts or stops. Hooks are declared under a `hooks` key with `post-workload-start` and/or `post-workload-stop` sub-keys, each specifying a `script` path relative to the kit directory. An optional `kits` list scopes the hook to specific triggering kit names; when absent the hook fires for all kits.
+A kit's `config.yaml` MAY declare hook scripts that execute after any other kit starts or stops. Hooks SHALL be declared under a `hooks` key with `post-workload-start` and/or `post-workload-stop` sub-keys, each specifying a `script` path relative to the kit directory. An optional `kits` list scopes the hook to specific triggering kit names; when absent the hook fires for all kits.
 
 #### Scenario: Hook fires after any kit starts
 - **WHEN** kit A declares `hooks.post-workload-start.script` with no `kits` filter

--- a/openspec/specs/kit-metrics-declaration/spec.md
+++ b/openspec/specs/kit-metrics-declaration/spec.md
@@ -1,6 +1,6 @@
 # Kit Metrics Declaration
 
-## Overview
+## Purpose
 
 `config.yaml` supports a top-level `metrics` block that declares how a kit's metrics reach the OTel collector. After a kit starts or stops, a K8s ConfigMap registry entry is created or deleted, and the OTel collector ConfigMap is regenerated automatically to include or exclude the kit's scrape job.
 

--- a/openspec/specs/kit-running-state/spec.md
+++ b/openspec/specs/kit-running-state/spec.md
@@ -1,4 +1,10 @@
-## ADDED Requirements
+# Kit Running State
+
+## Purpose
+
+Tracks which kits have been successfully started and not yet stopped, persisting the set in cluster state and exposing it to install templates and hook scripts.
+
+## Requirements
 
 ### Requirement: ClusterState tracks running kits
 `ClusterState` SHALL include a `runningKits: Set<String>` field persisted in `state.json`. The set contains the names of kits that have been successfully started and not yet stopped. `WorkloadRunnerCommand` and EC2/SystemD service commands (Cassandra, OpenSearch) SHALL update this set on successful start or stop.

--- a/openspec/specs/kit-source-management/spec.md
+++ b/openspec/specs/kit-source-management/spec.md
@@ -1,6 +1,6 @@
 # Kit Source Management Spec
 
-## Overview
+## Purpose
 
 Users can register additional parent directories as named kit sources. Each source has a
 user-chosen name and a filesystem path — analogous to `git remote`. Kits found in registered

--- a/openspec/specs/kit-uninstall-command/spec.md
+++ b/openspec/specs/kit-uninstall-command/spec.md
@@ -1,4 +1,10 @@
-## ADDED Requirements
+# Kit Uninstall Command
+
+## Purpose
+
+Provides a top-level `uninstall` command group that lists installed kits exposing an uninstall phase as subcommands, runs a kit's uninstall phase, and removes its local directory on success.
+
+## Requirements
 
 ### Requirement: Top-level uninstall command group exists
 The CLI SHALL expose a top-level `uninstall` command group that is always present in the help output, even when no kits are installed.

--- a/openspec/specs/live-stream-metrics/spec.md
+++ b/openspec/specs/live-stream-metrics/spec.md
@@ -1,5 +1,7 @@
 # Live Stream Metrics
 
+## Purpose
+
 Real-time cluster metrics streaming via Redis pub/sub, queried from VictoriaMetrics using dashboard-consistent PromQL expressions.
 
 ## Requirements

--- a/openspec/specs/log-investigation-dashboard/spec.md
+++ b/openspec/specs/log-investigation-dashboard/spec.md
@@ -1,5 +1,7 @@
 # Log Investigation Dashboard
 
+## Purpose
+
 Grafana dashboard for interactive log investigation with filtering by node role, host, source, level, and free-text search.
 
 ## Requirements

--- a/openspec/specs/multi-cluster-dashboards/spec.md
+++ b/openspec/specs/multi-cluster-dashboards/spec.md
@@ -1,3 +1,9 @@
+# Multi Cluster Dashboards
+
+## Purpose
+
+Ensures every Grafana dashboard can scope its data to one or more clusters through a shared `cluster` multi-select variable, cluster-scoped panel queries, and an ad hoc filters variable, all backed by the VictoriaMetrics datasource.
+
 ## Requirements
 
 ### Requirement: All dashboards have a cluster multi-select variable

--- a/openspec/specs/networking/spec.md
+++ b/openspec/specs/networking/spec.md
@@ -1,6 +1,8 @@
 # Networking
 
-Manages access methods for reaching cluster nodes: SSH aliases and Tailscale VPN.
+## Purpose
+
+Manages access methods for reaching cluster nodes: SSH aliases, remote command execution, Tailscale VPN, a SOCKS5 proxy, and host discovery.
 
 ## Requirements
 
@@ -8,55 +10,112 @@ Manages access methods for reaching cluster nodes: SSH aliases and Tailscale VPN
 
 The system MUST provide SSH access to all nodes with convenient shell aliases.
 
-**Scenarios:**
+#### Scenario: Aliases available after sourcing environment
 
-- **GIVEN** a running cluster, **WHEN** the user sources the environment file, **THEN** shell aliases are available for each node (e.g., c0, c1, s0).
-- **GIVEN** SSH aliases, **WHEN** the user invokes an alias, **THEN** an SSH session opens to the corresponding node using cluster-specific configuration.
+- **GIVEN** a running cluster
+- **WHEN** the user sources the environment file
+- **THEN** shell aliases are available for each node (e.g., c0, c1, s0).
+
+#### Scenario: Invoking an alias opens a session
+
+- **GIVEN** SSH aliases
+- **WHEN** the user invokes an alias
+- **THEN** an SSH session opens to the corresponding node using cluster-specific configuration.
 
 ### REQ-NET-002: SSH Key Distribution
 
 The system MUST allow uploading additional authorized SSH keys to cluster nodes.
 
-**Scenarios:**
+#### Scenario: Upload authorized keys
 
-- **GIVEN** authorized key files in the local keys directory, **WHEN** the user uploads keys, **THEN** the keys are added to all cluster nodes for shared access.
+- **GIVEN** authorized key files in the local keys directory
+- **WHEN** the user uploads keys
+- **THEN** the keys are added to all cluster nodes for shared access.
 
 ### REQ-NET-003: Remote Command Execution
 
 The system MUST allow executing arbitrary commands on cluster nodes via SSH.
 
-**Scenarios:**
+#### Scenario: Run a command on targeted nodes
 
-- **GIVEN** a running cluster, **WHEN** the user executes a remote command with host filtering, **THEN** the command runs on the targeted nodes and output is displayed.
-- **GIVEN** multiple target nodes, **WHEN** a command is executed, **THEN** output from each node is distinguished (e.g., color-coded).
+- **GIVEN** a running cluster
+- **WHEN** the user executes a remote command with host filtering
+- **THEN** the command runs on the targeted nodes and output is displayed.
+
+#### Scenario: Per-node output is distinguished
+
+- **GIVEN** multiple target nodes
+- **WHEN** a command is executed
+- **THEN** output from each node is distinguished (e.g., color-coded).
 
 ### REQ-NET-004: Tailscale VPN
 
 The system MUST support Tailscale mesh VPN for secure access to cluster nodes.
 
-**Scenarios:**
+#### Scenario: Start Tailscale
 
-- **GIVEN** Tailscale credentials configured in the user profile, **WHEN** the user starts Tailscale, **THEN** the VPN daemon starts on cluster nodes with authentication and subnet route advertising.
-- **GIVEN** a running Tailscale connection, **WHEN** the user checks status, **THEN** the VPN state is displayed.
-- **GIVEN** a running Tailscale connection, **WHEN** the user stops it, **THEN** the VPN daemon is stopped on all nodes.
+- **GIVEN** Tailscale credentials configured in the user profile
+- **WHEN** the user starts Tailscale
+- **THEN** the VPN daemon starts on cluster nodes with authentication and subnet route advertising.
+
+#### Scenario: Check Tailscale status
+
+- **GIVEN** a running Tailscale connection
+- **WHEN** the user checks status
+- **THEN** the VPN state is displayed.
+
+#### Scenario: Stop Tailscale
+
+- **GIVEN** a running Tailscale connection
+- **WHEN** the user stops it
+- **THEN** the VPN daemon is stopped on all nodes.
 
 ### REQ-NET-005: SOCKS Proxy
 
 The system MUST support a SOCKS5 proxy via SSH dynamic port forwarding as an alternative to Tailscale for routing traffic to internal cluster services.
 
-**Scenarios:**
+#### Scenario: Proxy starts before command logic
 
-- **GIVEN** a provisioned cluster with infrastructure UP and Tailscale not enabled, **WHEN** any CLI command is invoked, **THEN** the SOCKS5 proxy is started (or reused if already running) before any command logic executes.
-- **GIVEN** the SOCKS5 proxy OS process has been killed since the last invocation, **WHEN** any CLI command is invoked next, **THEN** the proxy is automatically restarted without user intervention.
-- **GIVEN** the REPL or server is running, **WHEN** the proxy is needed, **THEN** it persists for the lifetime of the session rather than per-command.
-- **GIVEN** Tailscale is enabled for the cluster, **WHEN** any CLI command is invoked, **THEN** the SOCKS5 proxy is not started and connections use direct private IP access.
-- **GIVEN** a running cluster, **WHEN** the user sources `env.sh`, **THEN** `SOCKS5_PROXY_PORT` is populated from the state file written by the CLI so shell wrappers (kubectl, helm, curl) use the correct port.
+- **GIVEN** a provisioned cluster with infrastructure UP and Tailscale not enabled
+- **WHEN** any CLI command is invoked
+- **THEN** the SOCKS5 proxy is started (or reused if already running) before any command logic executes.
+
+#### Scenario: Proxy auto-restarts after being killed
+
+- **GIVEN** the SOCKS5 proxy OS process has been killed since the last invocation
+- **WHEN** any CLI command is invoked next
+- **THEN** the proxy is automatically restarted without user intervention.
+
+#### Scenario: Proxy persists for session lifetime
+
+- **GIVEN** the REPL or server is running
+- **WHEN** the proxy is needed
+- **THEN** it persists for the lifetime of the session rather than per-command.
+
+#### Scenario: Tailscale enabled bypasses the proxy
+
+- **GIVEN** Tailscale is enabled for the cluster
+- **WHEN** any CLI command is invoked
+- **THEN** the SOCKS5 proxy is not started and connections use direct private IP access.
+
+#### Scenario: Proxy port exported to shell wrappers
+
+- **GIVEN** a running cluster
+- **WHEN** the user sources `env.sh`
+- **THEN** `SOCKS5_PROXY_PORT` is populated from the state file written by the CLI so shell wrappers (kubectl, helm, curl) use the correct port.
 
 ### REQ-NET-006: Host Discovery
 
 The system MUST provide commands to list cluster hosts and retrieve IP addresses.
 
-**Scenarios:**
+#### Scenario: List hosts
 
-- **GIVEN** a running cluster, **WHEN** the user lists hosts, **THEN** all nodes are displayed with their roles and addresses.
-- **GIVEN** a host alias, **WHEN** the user requests its IP, **THEN** the public or private IP is returned.
+- **GIVEN** a running cluster
+- **WHEN** the user lists hosts
+- **THEN** all nodes are displayed with their roles and addresses.
+
+#### Scenario: Retrieve host IP
+
+- **GIVEN** a host alias
+- **WHEN** the user requests its IP
+- **THEN** the public or private IP is returned.

--- a/openspec/specs/observability/spec.md
+++ b/openspec/specs/observability/spec.md
@@ -1,4 +1,10 @@
-## MODIFIED Requirements
+# Observability
+
+## Purpose
+
+Provides the cluster's metrics, logging, and tracing stack: dynamically generated OTel Collector scrape configuration, Grafana dashboards backed by VictoriaMetrics, Cilium/Hubble network visibility, hostPort-based metrics exposure, and a ClusterIP Service for pushing OTLP traces.
+
+## Requirements
 
 ### Requirement: OTel Collector scrapes workload metrics dynamically
 The OTel Collector ConfigMap SHALL be generated dynamically by `OtelManifestBuilder`, combining a fixed set of static scrape jobs for host processes with a dynamic set of per-workload scrape jobs read from the K8s metrics registry (`easydblab-metrics-*` ConfigMaps). The static ClickHouse scrape job previously hardcoded in `otel-collector-config.yaml` SHALL be removed.
@@ -64,8 +70,6 @@ All dashboards SHALL include a `cluster` multi-select variable and an ad hoc fil
 - **AND** the dashboard SHALL be mounted at `/var/lib/grafana/dashboards/cluster-comparison`
 - **AND** the volume mount SHALL use `optional: true` so absence of the file does not block Grafana startup
 
-## ADDED Requirements
-
 ### Requirement: Cilium replaces Flannel as the K3s CNI
 The K3s cluster SHALL use Cilium as its CNI plugin with `kube-proxy` replacement enabled. K3s SHALL be started with `--flannel-backend=none --disable-network-policy`. Cilium SHALL be installed via helm before any workloads are deployed. Hubble SHALL be enabled with Prometheus metrics export.
 
@@ -94,8 +98,6 @@ K8s workloads installed via `config.yaml` SHALL use standard pod networking (not
 - **WHEN** a workload exposes metrics on `hostPort: 9180`
 - **THEN** the OTel DaemonSet (hostNetwork) can scrape `localhost:9180` on the same node
 - **AND** this is identical to how MAAC metrics are scraped at `localhost:9000`
-
-## ADDED Requirements
 
 ### Requirement: OTel Collector is reachable via ClusterIP Service
 

--- a/openspec/specs/opensearch/spec.md
+++ b/openspec/specs/opensearch/spec.md
@@ -1,5 +1,7 @@
 # OpenSearch
 
+## Purpose
+
 Manages AWS-managed OpenSearch domain deployment within the cluster VPC.
 
 ## Requirements
@@ -8,8 +10,20 @@ Manages AWS-managed OpenSearch domain deployment within the cluster VPC.
 
 The system MUST support deploying an AWS-managed OpenSearch domain in the cluster's VPC.
 
-**Scenarios:**
+#### Scenario: Start OpenSearch domain
 
-- **GIVEN** a running cluster, **WHEN** the user starts OpenSearch with instance type and count options, **THEN** an OpenSearch domain is created in the cluster VPC.
-- **GIVEN** a deployed OpenSearch domain, **WHEN** the user stops it, **THEN** the domain is deleted.
-- **GIVEN** a running OpenSearch domain, **WHEN** the user checks status, **THEN** the domain state is displayed.
+- **GIVEN** a running cluster
+- **WHEN** the user starts OpenSearch with instance type and count options
+- **THEN** an OpenSearch domain is created in the cluster VPC.
+
+#### Scenario: Stop OpenSearch domain
+
+- **GIVEN** a deployed OpenSearch domain
+- **WHEN** the user stops it
+- **THEN** the domain is deleted.
+
+#### Scenario: Check OpenSearch status
+
+- **GIVEN** a running OpenSearch domain
+- **WHEN** the user checks status
+- **THEN** the domain state is displayed.

--- a/openspec/specs/platform-substrate/spec.md
+++ b/openspec/specs/platform-substrate/spec.md
@@ -1,12 +1,14 @@
 # Platform Substrate Spec
 
-## Overview
+## Purpose
 
 The platform substrate is the set of K8s primitives that easy-db-lab provisions on every cluster, allowing any kit to be deployed without a bespoke Kotlin manifest builder.
 
-## StorageClasses
+## Requirements
 
-Two StorageClasses are provisioned at `up` time:
+### Requirement: StorageClasses
+
+The system SHALL provision two StorageClasses at `up` time:
 
 | Name | Binding Mode | Reclaim Policy | Use |
 |---|---|---|---|
@@ -15,9 +17,14 @@ Two StorageClasses are provisioned at `up` time:
 
 `local-storage-wfc` is required for StatefulSet kits because Kubernetes must know which node the pod schedules on before binding the PV.
 
-## Node Labels
+#### Scenario: StorageClasses provisioned at up time
+- **WHEN** a cluster is brought up
+- **THEN** the `local-storage` and `local-storage-wfc` StorageClasses are provisioned
+- **AND** `local-storage-wfc` uses `WaitForFirstConsumer` binding so StatefulSet kits bind PVs only after the pod's node is known
 
-All cluster nodes are labeled at `up` time:
+### Requirement: Node Labels
+
+The system SHALL label all cluster nodes at `up` time:
 
 | Label | Values | Applied to |
 |---|---|---|
@@ -26,18 +33,30 @@ All cluster nodes are labeled at `up` time:
 
 Kits use `nodeSelector: type: db` (or `app`) to constrain placement, and PVs use `easydblab.com/node-ordinal` for pre-binding.
 
-## Persistent Volumes
+#### Scenario: Nodes labeled at up time
+- **WHEN** a cluster is brought up
+- **THEN** all nodes carry a `type` label of `db`, `app`, or `control`
+- **AND** `db` and `app` nodes carry an `easydblab.com/node-ordinal` label starting at `0`
 
-Per-kit PVs are created lazily at install time, not at cluster-up time. One PV per db node is created by `platform create-pvs`:
+### Requirement: Persistent Volumes
+
+Per-kit PVs SHALL be created lazily at install time, not at cluster-up time. One PV per db node is created by `platform create-pvs`:
 
 - **Path**: `/mnt/db1/<kit>` on each host
 - **StorageClass**: `local-storage-wfc`
 - **Affinity**: `easydblab.com/node-ordinal=N` matches ordinal N
 - **ClaimRef**: pre-bound to `<volumeClaimTemplateName>-<kit>-N` so StatefulSets bind deterministically
 
-## `platform` Commands
+#### Scenario: PVs created lazily at install time
+- **WHEN** `platform create-pvs` runs for a kit
+- **THEN** one PV per db node is created at `/mnt/db1/<kit>` with StorageClass `local-storage-wfc`
+- **AND** each PV has affinity `easydblab.com/node-ordinal=N` and a claimRef pre-bound to `<volumeClaimTemplateName>-<kit>-N`
 
-### `platform create-pvs`
+### Requirement: `platform` Commands
+
+The `platform` command group SHALL provide `create-pvs` and `info` subcommands.
+
+#### `platform create-pvs`
 
 ```
 platform create-pvs --kit <name> --size <Gi> [--node-type db|app]
@@ -45,13 +64,21 @@ platform create-pvs --kit <name> --size <Gi> [--node-type db|app]
 
 Creates one PV per node of the specified type. Safe to re-run: if the PV exists with a stale claimRef UID (the PVC was deleted), the UID is cleared and the PV is returned to `Available`.
 
-### `platform info`
+#### `platform info`
 
 Displays StorageClasses, available PV counts per node pool, node selector labels, and ordinal key. Used to verify substrate readiness before deploying a kit.
 
-## Template Variable Contract
+#### Scenario: create-pvs is safe to re-run
+- **WHEN** `platform create-pvs` runs against a PV that exists with a stale claimRef UID because the PVC was deleted
+- **THEN** the UID is cleared and the PV is returned to `Available`
 
-All install templates receive these standard variables from cluster state:
+#### Scenario: platform info reports substrate readiness
+- **WHEN** the user runs `platform info`
+- **THEN** the output displays StorageClasses, available PV counts per node pool, node selector labels, and the ordinal key
+
+### Requirement: Template Variable Contract
+
+All install templates SHALL receive these standard variables from cluster state:
 
 | Variable | Source |
 |---|---|
@@ -69,3 +96,8 @@ All install templates receive these standard variables from cluster state:
 | `__KUBECONFIG__` | Path to local kubeconfig |
 
 Kit-specific subcommands add extra variables (e.g. `__REPLICAS__`, `__WORKERS__`). Unresolved `__VAR__` placeholders emit a warning but do not fail the render.
+
+#### Scenario: Standard variables substituted into templates
+- **WHEN** an install template is rendered
+- **THEN** the standard variables are substituted from cluster state
+- **AND** an unresolved `__VAR__` placeholder emits a warning but does not fail the render

--- a/openspec/specs/postgres/spec.md
+++ b/openspec/specs/postgres/spec.md
@@ -1,5 +1,7 @@
 # PostgreSQL
 
+## Purpose
+
 Manages the PostgreSQL kit lifecycle via the CloudNativePG operator and provides SQL execution against a running PostgreSQL cluster.
 
 ## Requirements
@@ -8,29 +10,42 @@ Manages the PostgreSQL kit lifecycle via the CloudNativePG operator and provides
 
 The system MUST deploy PostgreSQL clusters on K8s db nodes via the CloudNativePG (CNPG) operator. The operator SHALL be installed via Helm (`cloudnative-pg/cloudnative-pg` chart into the `cnpg-system` namespace). The PostgreSQL cluster SHALL be defined as a CNPG `Cluster` custom resource named `postgres`.
 
-**Scenarios:**
+#### Scenario: Operator installed and cluster deployed
+- **GIVEN** a running cluster with K3s
+- **WHEN** the user runs `kit install postgres` and `postgres start`
+- **THEN** the CNPG operator is installed and a PostgreSQL Cluster CR is deployed on db nodes.
 
-- **GIVEN** a running cluster with K3s, **WHEN** the user runs `kit install postgres` and `postgres start`, **THEN** the CNPG operator is installed and a PostgreSQL Cluster CR is deployed on db nodes.
-- **WHEN** the user runs `kit install postgres` on a cluster where CNPG is already installed, **THEN** the install succeeds without error.
+#### Scenario: Re-install when CNPG already present
+- **WHEN** the user runs `kit install postgres` on a cluster where CNPG is already installed
+- **THEN** the install succeeds without error.
 
 ### REQ-PG-002: Configurable Instance Count
 
 The `postgres start` command SHALL accept a `--instances` argument (default: `1`) controlling how many PostgreSQL instances CNPG deploys. When `--instances` is greater than 1, CNPG deploys a primary and read replicas.
 
-**Scenarios:**
+#### Scenario: Default single instance
+- **WHEN** the user runs `postgres start` with no flags
+- **THEN** a single PostgreSQL instance is deployed.
 
-- **WHEN** the user runs `postgres start` with no flags, **THEN** a single PostgreSQL instance is deployed.
-- **WHEN** the user runs `postgres start --instances 3`, **THEN** CNPG deploys 1 primary and 2 read replicas.
+#### Scenario: Multiple instances deploy replicas
+- **WHEN** the user runs `postgres start --instances 3`
+- **THEN** CNPG deploys 1 primary and 2 read replicas.
 
 ### REQ-PG-003: Data Lifecycle
 
 Stop MUST preserve data; data is only deleted on uninstall. Starting after a stop MUST resume the existing dataset without any additional user steps.
 
-**Scenarios:**
+#### Scenario: Data survives stop and start
+- **WHEN** data is written to PostgreSQL, `postgres stop` is run, and then `postgres start` is run again
+- **THEN** the previously written data is accessible without any restore step.
 
-- **WHEN** data is written to PostgreSQL, `postgres stop` is run, and then `postgres start` is run again, **THEN** the previously written data is accessible without any restore step.
-- **WHEN** the user runs `postgres uninstall`, **THEN** the CNPG operator is removed and all PersistentVolumes for db nodes are deleted.
-- **WHEN** `postgres start` is run after a fresh install with no prior starts, **THEN** PVs are created via `platform-pvs` and the Cluster CR is deployed successfully.
+#### Scenario: Uninstall deletes data
+- **WHEN** the user runs `postgres uninstall`
+- **THEN** the CNPG operator is removed and all PersistentVolumes for db nodes are deleted.
+
+#### Scenario: First start after fresh install
+- **WHEN** `postgres start` is run after a fresh install with no prior starts
+- **THEN** PVs are created via `platform-pvs` and the Cluster CR is deployed successfully.
 
 ### REQ-PG-004: SQL Execution
 
@@ -38,17 +53,27 @@ The `postgres sql` command SHALL execute SQL statements against a running Postgr
 
 The PostgreSQL JDBC driver (`org.postgresql:postgresql`) auto-registers via ServiceLoader. The `driver-class` field in the `sql` capability SHALL be left empty.
 
-**Scenarios:**
+#### Scenario: Inline query returns tabular results
+- **WHEN** the user runs `postgres sql "SELECT version()"`
+- **THEN** the query is submitted via JDBC and results are displayed in tabular format.
 
-- **WHEN** the user runs `postgres sql "SELECT version()"`, **THEN** the query is submitted via JDBC and results are displayed in tabular format.
-- **WHEN** the user runs `postgres sql --file query.sql`, **THEN** the SQL from the file is executed.
-- **WHEN** no db nodes exist in cluster state, **THEN** an error is emitted before any connection is made.
+#### Scenario: Query from file
+- **WHEN** the user runs `postgres sql --file query.sql`
+- **THEN** the SQL from the file is executed.
+
+#### Scenario: Error when no db nodes
+- **WHEN** no db nodes exist in cluster state
+- **THEN** an error is emitted before any connection is made.
 
 ### REQ-PG-005: Presto Integration
 
 When both the `postgres` and `presto` kits are running, Presto SHALL automatically expose a `postgres` catalog using the `postgresql` connector, pointing to the CNPG primary service (`postgres-rw.default.svc.cluster.local:5432`).
 
-**Scenarios:**
+#### Scenario: Postgres catalog exposed in Presto
+- **GIVEN** both `postgres start` and `presto start` have been run
+- **WHEN** Presto's `update-catalogs.sh` hook executes
+- **THEN** a `postgres` catalog is present in Presto and `SHOW CATALOGS` includes `postgres`.
 
-- **GIVEN** both `postgres start` and `presto start` have been run, **WHEN** Presto's `update-catalogs.sh` hook executes, **THEN** a `postgres` catalog is present in Presto and `SHOW CATALOGS` includes `postgres`.
-- **WHEN** only presto is running (no postgres kit), **THEN** no `postgres` catalog appears in Presto.
+#### Scenario: No catalog without postgres kit
+- **WHEN** only presto is running (no postgres kit)
+- **THEN** no `postgres` catalog appears in Presto.

--- a/openspec/specs/presto/spec.md
+++ b/openspec/specs/presto/spec.md
@@ -1,5 +1,7 @@
 # Presto
 
+## Purpose
+
 Manages the Presto kit lifecycle and provides SQL execution against a running Presto cluster.
 
 ## Requirements
@@ -8,11 +10,18 @@ Manages the Presto kit lifecycle and provides SQL execution against a running Pr
 
 The system MUST support installing, starting, stopping, and uninstalling Presto via the kit mechanism.
 
-**Scenarios:**
+#### Scenario: Install and start deploys Presto
+- **GIVEN** a running cluster
+- **WHEN** the user runs `kit install presto` and `presto start`
+- **THEN** Presto is deployed via Helm on app nodes with the requested worker count.
 
-- **GIVEN** a running cluster, **WHEN** the user runs `kit install presto` and `presto start`, **THEN** Presto is deployed via Helm on app nodes with the requested worker count.
-- **WHEN** the user runs `presto stop`, **THEN** the Presto Helm release is removed.
-- **WHEN** the user runs `presto start` after a stop, **THEN** Presto is re-deployed without requiring re-installation.
+#### Scenario: Stop removes Helm release
+- **WHEN** the user runs `presto stop`
+- **THEN** the Presto Helm release is removed.
+
+#### Scenario: Restart without reinstall
+- **WHEN** the user runs `presto start` after a stop
+- **THEN** Presto is re-deployed without requiring re-installation.
 
 ### REQ-PRS-002: SQL Execution
 
@@ -23,12 +32,17 @@ The Presto JDBC driver (`com.facebook.presto:presto-jdbc`) does not auto-registe
 ServiceLoader in fat-JAR environments. The `driver-class` field in the `sql` capability
 SHALL be set to `com.facebook.presto.jdbc.PrestoDriver` to force-load it.
 
-**Scenarios:**
+#### Scenario: Inline query returns tabular results
+- **WHEN** the user runs `presto sql "SELECT count(*) FROM cassandra.keyspace.table"`
+- **THEN** the query is submitted via JDBC and results are displayed in tabular format.
 
-- **WHEN** the user runs `presto sql "SELECT count(*) FROM cassandra.keyspace.table"`,
-  **THEN** the query is submitted via JDBC and results are displayed in tabular format.
-- **WHEN** the user runs `presto sql --file query.sql`, **THEN** the SQL from the file is executed.
-- **WHEN** no app nodes exist in cluster state, **THEN** an error is emitted before any connection is made.
+#### Scenario: Query from file
+- **WHEN** the user runs `presto sql --file query.sql`
+- **THEN** the SQL from the file is executed.
+
+#### Scenario: Error when no app nodes
+- **WHEN** no app nodes exist in cluster state
+- **THEN** an error is emitted before any connection is made.
 
 ### REQ-PRS-003: Catalog Sources
 
@@ -36,9 +50,21 @@ The system SHALL support automatic catalog injection for the following database 
 
 A catalog properties file MUST exist in `kits/presto/catalogs/<kit-name>.properties.template` for each supported database kit. The `update-catalogs.sh` hook reads `RUNNING_KITS` and injects catalogs for any kit that has a matching properties file.
 
-**Scenarios:**
+#### Scenario: Cassandra catalog injected
+- **GIVEN** both `cassandra` and `presto` are running
+- **WHEN** `update-catalogs.sh` executes
+- **THEN** a `cassandra` catalog is present in Presto.
 
-- **GIVEN** both `cassandra` and `presto` are running, **WHEN** `update-catalogs.sh` executes, **THEN** a `cassandra` catalog is present in Presto.
-- **GIVEN** both `clickhouse` and `presto` are running, **WHEN** `update-catalogs.sh` executes, **THEN** a `clickhouse` catalog is present in Presto.
-- **GIVEN** both `postgres` and `presto` are running, **WHEN** `update-catalogs.sh` executes, **THEN** a `postgres` catalog is present in Presto using the `postgresql` connector pointed at `postgres-rw.default.svc.cluster.local:5432`.
-- **WHEN** a database kit is not running, **THEN** its catalog is not injected into Presto.
+#### Scenario: ClickHouse catalog injected
+- **GIVEN** both `clickhouse` and `presto` are running
+- **WHEN** `update-catalogs.sh` executes
+- **THEN** a `clickhouse` catalog is present in Presto.
+
+#### Scenario: Postgres catalog injected
+- **GIVEN** both `postgres` and `presto` are running
+- **WHEN** `update-catalogs.sh` executes
+- **THEN** a `postgres` catalog is present in Presto using the `postgresql` connector pointed at `postgres-rw.default.svc.cluster.local:5432`.
+
+#### Scenario: Catalog omitted when kit not running
+- **WHEN** a database kit is not running
+- **THEN** its catalog is not injected into Presto.

--- a/openspec/specs/server-infra-watchdog/spec.md
+++ b/openspec/specs/server-infra-watchdog/spec.md
@@ -1,5 +1,7 @@
 # Server Infrastructure Watchdog
 
+## Purpose
+
 A background service that monitors whether the cluster's AWS VPC still exists while the server is running, and triggers a clean shutdown if the infrastructure has been removed.
 
 ## Requirements

--- a/openspec/specs/server/spec.md
+++ b/openspec/specs/server/spec.md
@@ -48,14 +48,11 @@ The server MUST expose REST HTTP endpoints for programmatic access to cluster st
 - **WHEN** a client sends GET /status?live=true
 - **THEN** the server bypasses the cache and fetches fresh data before responding.
 
-#### Scenario: Observability object includes Tempo and Pyroscope fields
+#### Scenario: Observability object includes Tempo and Pyroscope
 - **GIVEN** a running cluster with a reachable control node
 - **WHEN** a client sends GET /status
-- **THEN** the `accessInfo.observability` object SHALL include `tempo` and `pyroscope` URL fields alongside `grafana`, `victoriaMetrics`, and `victoriaLogs`.
-
-#### Scenario: Observability URLs include Tempo and Pyroscope
-- **WHEN** a client requests GET /status on a cluster with a reachable control node
-- **THEN** the response `accessInfo.observability` object contains `tempo` at `http://<controlPrivateIp>:3200` and `pyroscope` at `http://<controlPrivateIp>:4040`
+- **THEN** the `accessInfo.observability` object SHALL include `tempo` and `pyroscope` URL fields alongside `grafana`, `victoriaMetrics`, and `victoriaLogs`
+- **AND** `tempo` is `http://<controlPrivateIp>:3200` and `pyroscope` is `http://<controlPrivateIp>:4040`
 
 ### REQ-SERVER-004: Background Status Cache
 

--- a/openspec/specs/server/spec.md
+++ b/openspec/specs/server/spec.md
@@ -1,5 +1,7 @@
 # Server
 
+## Purpose
+
 The server command (`easy-db-lab server`) provides a hybrid HTTP server exposing cluster management capabilities via MCP (Model Context Protocol) for AI assistants, REST endpoints for programmatic access, and background services for status caching and metrics collection.
 
 ## Requirements
@@ -8,29 +10,48 @@ The server command (`easy-db-lab server`) provides a hybrid HTTP server exposing
 
 The system MUST provide a server that AI assistants and HTTP clients can connect to for cluster management.
 
-**Scenarios:**
+#### Scenario: Server accepts MCP and REST connections
+- **GIVEN** a running cluster
+- **WHEN** the user starts the server on a specified port
+- **THEN** the server accepts SSE connections from MCP clients and HTTP requests on REST endpoints.
 
-- **GIVEN** a running cluster, **WHEN** the user starts the server on a specified port, **THEN** the server accepts SSE connections from MCP clients and HTTP requests on REST endpoints.
-- **GIVEN** a running server, **WHEN** an AI assistant connects via MCP, **THEN** cluster management tools are available for invocation.
+#### Scenario: MCP tools available on connect
+- **GIVEN** a running server
+- **WHEN** an AI assistant connects via MCP
+- **THEN** cluster management tools are available for invocation.
 
 ### REQ-SERVER-002: Structured Event Streaming
 
 The system MUST stream structured events to connected MCP clients.
 
-**Scenarios:**
-
-- **GIVEN** a connected MCP client, **WHEN** cluster operations produce events, **THEN** the client receives structured event data with type information and metadata.
+#### Scenario: Structured events streamed to client
+- **GIVEN** a connected MCP client
+- **WHEN** cluster operations produce events
+- **THEN** the client receives structured event data with type information and metadata.
 
 ### REQ-SERVER-003: REST Status Endpoints
 
 The server MUST expose REST HTTP endpoints for programmatic access to cluster status, independent of the MCP protocol.
 
-**Scenarios:**
+#### Scenario: GET /status returns full JSON
+- **GIVEN** a running server
+- **WHEN** a client sends GET /status
+- **THEN** the server returns JSON with cluster info, EC2 instances, K8s pods, networking, security groups, EMR, OpenSearch, S3, Cassandra version, and access URLs.
 
-- **GIVEN** a running server, **WHEN** a client sends GET /status, **THEN** the server returns JSON with cluster info, EC2 instances, K8s pods, networking, security groups, EMR, OpenSearch, S3, Cassandra version, and access URLs.
-- **GIVEN** a running server, **WHEN** a client sends GET /status?section=nodes, **THEN** the server returns only the nodes section of the status response.
-- **GIVEN** a running server, **WHEN** a client sends GET /status?live=true, **THEN** the server bypasses the cache and fetches fresh data before responding.
-- **GIVEN** a running cluster with a reachable control node, **WHEN** a client sends GET /status, **THEN** the `accessInfo.observability` object SHALL include `tempo` and `pyroscope` URL fields alongside `grafana`, `victoriaMetrics`, and `victoriaLogs`.
+#### Scenario: Section filter returns single section
+- **GIVEN** a running server
+- **WHEN** a client sends GET /status?section=nodes
+- **THEN** the server returns only the nodes section of the status response.
+
+#### Scenario: Live query bypasses cache
+- **GIVEN** a running server
+- **WHEN** a client sends GET /status?live=true
+- **THEN** the server bypasses the cache and fetches fresh data before responding.
+
+#### Scenario: Observability object includes Tempo and Pyroscope fields
+- **GIVEN** a running cluster with a reachable control node
+- **WHEN** a client sends GET /status
+- **THEN** the `accessInfo.observability` object SHALL include `tempo` and `pyroscope` URL fields alongside `grafana`, `victoriaMetrics`, and `victoriaLogs`.
 
 #### Scenario: Observability URLs include Tempo and Pyroscope
 - **WHEN** a client requests GET /status on a cluster with a reachable control node
@@ -40,19 +61,29 @@ The server MUST expose REST HTTP endpoints for programmatic access to cluster st
 
 The server MUST maintain a background cache of cluster status that refreshes periodically.
 
-**Scenarios:**
+#### Scenario: Cache refreshes on interval
+- **GIVEN** a running server
+- **WHEN** the refresh interval elapses
+- **THEN** the StatusCache refreshes cluster data from EC2, K3s, EMR, and other sources.
 
-- **GIVEN** a running server, **WHEN** the refresh interval elapses, **THEN** the StatusCache refreshes cluster data from EC2, K3s, EMR, and other sources.
-- **GIVEN** a running server, **WHEN** a client queries /status without ?live=true, **THEN** the server responds immediately from the in-memory cache.
+#### Scenario: Cached response served immediately
+- **GIVEN** a running server
+- **WHEN** a client queries /status without ?live=true
+- **THEN** the server responds immediately from the in-memory cache.
 
 ### REQ-SERVER-005: Optional Metrics Collection
 
 The server MUST optionally collect and publish live metrics when a Redis connection is configured.
 
-**Scenarios:**
+#### Scenario: Metrics collected when Redis configured
+- **GIVEN** the EASY_DB_LAB_REDIS_URL environment variable is set
+- **WHEN** the server starts
+- **THEN** the MetricsCollector polls VictoriaMetrics and publishes metric events to Redis pub/sub.
 
-- **GIVEN** the EASY_DB_LAB_REDIS_URL environment variable is set, **WHEN** the server starts, **THEN** the MetricsCollector polls VictoriaMetrics and publishes metric events to Redis pub/sub.
-- **GIVEN** the EASY_DB_LAB_REDIS_URL environment variable is not set, **WHEN** the server starts, **THEN** the server runs normally without metrics collection.
+#### Scenario: Server runs without Redis
+- **GIVEN** the EASY_DB_LAB_REDIS_URL environment variable is not set
+- **WHEN** the server starts
+- **THEN** the server runs normally without metrics collection.
 
 ### Requirement: Auto-shutdown CLI option
 The server command SHALL accept an `--auto-shutdown` flag that enables infrastructure watchdog behavior.

--- a/openspec/specs/setup/spec.md
+++ b/openspec/specs/setup/spec.md
@@ -1,5 +1,7 @@
 # Setup
 
+## Purpose
+
 Manages user profile creation, AWS credential configuration, and IAM resource initialization required before cluster provisioning.
 
 ## Requirements
@@ -8,32 +10,50 @@ Manages user profile creation, AWS credential configuration, and IAM resource in
 
 The system MUST provide an interactive workflow to create a user profile with AWS credentials, region, and key pair configuration.
 
-**Scenarios:**
+#### Scenario: First-time user runs setup
 
-- **GIVEN** a first-time user, **WHEN** they run the setup workflow, **THEN** they are prompted for AWS profile or credentials, region, and key pair selection.
-- **GIVEN** a completed profile, **WHEN** the user runs setup again, **THEN** existing settings are available for review and modification.
+- **GIVEN** a first-time user
+- **WHEN** they run the setup workflow
+- **THEN** they are prompted for AWS profile or credentials, region, and key pair selection.
+
+#### Scenario: Existing profile reviewed on re-run
+
+- **GIVEN** a completed profile
+- **WHEN** the user runs setup again
+- **THEN** existing settings are available for review and modification.
 
 ### REQ-SU-002: AWS Resource Initialization
 
 The system MUST initialize required AWS resources (IAM roles, S3 bucket, VPC) as part of setup.
 
-**Scenarios:**
+#### Scenario: Resources created on setup completion
 
-- **GIVEN** valid AWS credentials, **WHEN** the user completes setup, **THEN** IAM roles, an S3 bucket, and networking resources are created or verified.
-- **GIVEN** partially configured AWS resources, **WHEN** setup runs, **THEN** missing resources are created and existing ones are reused.
+- **GIVEN** valid AWS credentials
+- **WHEN** the user completes setup
+- **THEN** IAM roles, an S3 bucket, and networking resources are created or verified.
+
+#### Scenario: Missing resources created and existing ones reused
+
+- **GIVEN** partially configured AWS resources
+- **WHEN** setup runs
+- **THEN** missing resources are created and existing ones are reused.
 
 ### REQ-SU-003: IAM Policy Visibility
 
 The system MUST allow users to view the IAM policies required for operation.
 
-**Scenarios:**
+#### Scenario: User views required IAM policies
 
-- **GIVEN** a user troubleshooting permissions, **WHEN** they request IAM policy display, **THEN** the required policies are shown with account-specific values substituted.
+- **GIVEN** a user troubleshooting permissions
+- **WHEN** they request IAM policy display
+- **THEN** the required policies are shown with account-specific values substituted.
 
 ### REQ-SU-004: AWS Reconfiguration
 
 The system MUST allow reconfiguring AWS resources without full profile re-setup.
 
-**Scenarios:**
+#### Scenario: Reconfigure without changing credentials
 
-- **GIVEN** an existing profile, **WHEN** the user reconfigures AWS resources, **THEN** IAM roles and infrastructure are updated without modifying credential settings.
+- **GIVEN** an existing profile
+- **WHEN** the user reconfigures AWS resources
+- **THEN** IAM roles and infrastructure are updated without modifying credential settings.

--- a/openspec/specs/sidecar-otel/spec.md
+++ b/openspec/specs/sidecar-otel/spec.md
@@ -1,3 +1,11 @@
+# Sidecar OTel
+
+## Purpose
+
+Instruments the Cassandra Sidecar with OpenTelemetry and Pyroscope Java agents so that traces, JVM metrics, logs, and continuous profiles flow to the cluster observability stack.
+
+## Requirements
+
 ### Requirement: OTel Java agent installed on Cassandra nodes
 
 The OTel Java agent JAR SHALL be downloaded and installed to `/usr/local/otel/opentelemetry-javaagent.jar` during the Packer AMI build.

--- a/openspec/specs/spark-emr/spec.md
+++ b/openspec/specs/spark-emr/spec.md
@@ -1,5 +1,7 @@
 # Spark EMR
 
+## Purpose
+
 Spark job submission, monitoring, and cancellation on AWS EMR clusters with full observability integration, including OTel and Pyroscope agent installation via bootstrap actions.
 
 ## Requirements

--- a/openspec/specs/stress-testing/spec.md
+++ b/openspec/specs/stress-testing/spec.md
@@ -1,5 +1,7 @@
 # Stress Testing
 
+## Purpose
+
 Manages Cassandra stress job lifecycle including starting, stopping, monitoring, and log collection.
 
 ## Requirements
@@ -8,25 +10,46 @@ Manages Cassandra stress job lifecycle including starting, stopping, monitoring,
 
 The system MUST support starting, stopping, and monitoring stress jobs against a Cassandra cluster.
 
-**Scenarios:**
+#### Scenario: Start a stress job
 
-- **GIVEN** a running Cassandra cluster, **WHEN** the user starts a stress job with parameters, **THEN** the job runs on designated stress nodes.
-- **GIVEN** a running stress job, **WHEN** the user stops it, **THEN** the job is terminated.
-- **GIVEN** active stress jobs, **WHEN** the user checks status, **THEN** running jobs and their states are displayed.
+- **GIVEN** a running Cassandra cluster
+- **WHEN** the user starts a stress job with parameters
+- **THEN** the job runs on designated stress nodes.
+
+#### Scenario: Stop a stress job
+
+- **GIVEN** a running stress job
+- **WHEN** the user stops it
+- **THEN** the job is terminated.
+
+#### Scenario: Check stress job status
+
+- **GIVEN** active stress jobs
+- **WHEN** the user checks status
+- **THEN** running jobs and their states are displayed.
 
 ### REQ-ST-002: Stress Job Monitoring
 
 The system MUST provide log access and job listing for stress operations.
 
-**Scenarios:**
+#### Scenario: List stress jobs
 
-- **GIVEN** completed or running stress jobs, **WHEN** the user lists jobs, **THEN** all jobs are shown with their status.
-- **GIVEN** a stress job, **WHEN** the user requests logs, **THEN** aggregated log output from the job is displayed.
+- **GIVEN** completed or running stress jobs
+- **WHEN** the user lists jobs
+- **THEN** all jobs are shown with their status.
+
+#### Scenario: Request stress job logs
+
+- **GIVEN** a stress job
+- **WHEN** the user requests logs
+- **THEN** aggregated log output from the job is displayed.
 
 ### REQ-ST-003: Observability Sidecars
 
 The system MUST deploy observability sidecars alongside long-running stress jobs to collect metrics.
 
-**Scenarios:**
+#### Scenario: OTel sidecar deployed with a long-running job
 
-- **GIVEN** a long-running stress job, **WHEN** the job starts, **THEN** an OTel sidecar is deployed to scrape stress metrics and forward them to the cluster's metrics pipeline.
+- **GIVEN** a long-running stress job
+- **WHEN** the job starts
+- **THEN** an OTel sidecar is deployed to scrape stress metrics and forward them to the cluster's metrics pipeline.

--- a/openspec/specs/template-subdirectory-support/spec.md
+++ b/openspec/specs/template-subdirectory-support/spec.md
@@ -1,4 +1,10 @@
-## ADDED Requirements
+# Template Subdirectory Support
+
+## Purpose
+
+Renders workload templates while preserving their relative subdirectory structure, creating parent directories as needed and making files rendered into `bin/` executable.
+
+## Requirements
 
 ### Requirement: Template renderer preserves relative subdirectory structure
 When rendering templates, the output path SHALL preserve the relative path from the template root. A template at `bin/start.sh.template` SHALL render to `<outputDir>/bin/start.sh`. Parent directories SHALL be created as needed.

--- a/openspec/specs/tidb/spec.md
+++ b/openspec/specs/tidb/spec.md
@@ -1,5 +1,7 @@
 # TiDB
 
+## Purpose
+
 Manages TiDB deployment on K3s using the TiDB Operator, with component placement, MySQL-compatible SQL access, and Prometheus metrics integration.
 
 ## Requirements
@@ -8,30 +10,53 @@ Manages TiDB deployment on K3s using the TiDB Operator, with component placement
 
 The TiDB kit SHALL deploy a `TidbCluster` custom resource managed by the TiDB Operator Helm chart. The operator SHALL be installed in the `tidb-admin` namespace. The cluster SHALL include PD, TiDB, TiKV, and TiFlash components.
 
-**Scenarios:**
+#### Scenario: Operator installed on install
 
-- **WHEN** the user runs `easy-db-lab tidb install`, **THEN** the TiDB Operator Helm chart is installed in the `tidb-admin` namespace.
-- **WHEN** the user runs `easy-db-lab tidb start`, **THEN** a `TidbCluster` CR is applied with PD, TiDB, TiKV, and TiFlash components, and the command waits for all component pods to reach `Ready` state before returning.
+- **WHEN** the user runs `easy-db-lab tidb install`
+- **THEN** the TiDB Operator Helm chart is installed in the `tidb-admin` namespace.
+
+#### Scenario: Cluster started with all components
+
+- **WHEN** the user runs `easy-db-lab tidb start`
+- **THEN** a `TidbCluster` CR is applied with PD, TiDB, TiKV, and TiFlash components, and the command waits for all component pods to reach `Ready` state before returning.
 
 ### REQ-TD-002: TiDB Kit Requires a Mixed Cluster
 
 The TiDB kit SHALL require at least one db node and at least one app node. If either count is zero, `start` SHALL fail immediately with a descriptive error message before applying any Kubernetes resources.
 
-**Scenarios:**
+#### Scenario: Mixed cluster proceeds
 
-- **WHEN** `DB_NODE_COUNT >= 1` and `APP_NODE_COUNT >= 1`, **THEN** the start sequence proceeds normally.
-- **WHEN** `DB_NODE_COUNT` is `0`, **THEN** `start` exits with a non-zero status and prints an error indicating db nodes are required for TiKV and TiFlash.
-- **WHEN** `APP_NODE_COUNT` is `0`, **THEN** `start` exits with a non-zero status and prints an error indicating app nodes are required for TiDB and PD.
+- **WHEN** `DB_NODE_COUNT >= 1` and `APP_NODE_COUNT >= 1`
+- **THEN** the start sequence proceeds normally.
+
+#### Scenario: Missing db nodes fails
+
+- **WHEN** `DB_NODE_COUNT` is `0`
+- **THEN** `start` exits with a non-zero status and prints an error indicating db nodes are required for TiKV and TiFlash.
+
+#### Scenario: Missing app nodes fails
+
+- **WHEN** `APP_NODE_COUNT` is `0`
+- **THEN** `start` exits with a non-zero status and prints an error indicating app nodes are required for TiDB and PD.
 
 ### REQ-TD-003: TiDB Kit Component Placement
 
 TiKV and TiFlash SHALL be scheduled on db nodes. TiDB SQL layer and PD SHALL be scheduled on app nodes. Scheduling SHALL be enforced via Kubernetes node selectors or affinity rules in the `TidbCluster` manifest.
 
-**Scenarios:**
+#### Scenario: TiKV scheduled on db nodes
 
-- **WHEN** the TidbCluster is applied, **THEN** TiKV pods are scheduled exclusively on nodes labelled as db nodes.
-- **WHEN** the TidbCluster is applied, **THEN** TiFlash pods are scheduled exclusively on nodes labelled as db nodes.
-- **WHEN** the TidbCluster is applied, **THEN** TiDB SQL layer pods and PD pods are scheduled exclusively on nodes labelled as app nodes.
+- **WHEN** the TidbCluster is applied
+- **THEN** TiKV pods are scheduled exclusively on nodes labelled as db nodes.
+
+#### Scenario: TiFlash scheduled on db nodes
+
+- **WHEN** the TidbCluster is applied
+- **THEN** TiFlash pods are scheduled exclusively on nodes labelled as db nodes.
+
+#### Scenario: TiDB and PD scheduled on app nodes
+
+- **WHEN** the TidbCluster is applied
+- **THEN** TiDB SQL layer pods and PD pods are scheduled exclusively on nodes labelled as app nodes.
 
 ### REQ-TD-004: TiDB Kit Args
 
@@ -42,32 +67,44 @@ The TiDB kit SHALL expose the following args:
 
 PD replicas SHALL be hardcoded to `1`. TiDB SQL replicas SHALL be derived from `${APP_NODE_COUNT}`.
 
-**Scenarios:**
+#### Scenario: Replicas default to db node count
 
-- **WHEN** the user runs `easy-db-lab tidb start` on a 3-db-node cluster without specifying `--replicas`, **THEN** TiKV is deployed with 3 replicas and TiFlash is deployed with 3 replicas.
-- **WHEN** the user runs `easy-db-lab tidb start --version v7.5.0`, **THEN** all TiDB components use image tag `v7.5.0`.
+- **WHEN** the user runs `easy-db-lab tidb start` on a 3-db-node cluster without specifying `--replicas`
+- **THEN** TiKV is deployed with 3 replicas and TiFlash is deployed with 3 replicas.
+
+#### Scenario: Version flag applied to all components
+
+- **WHEN** the user runs `easy-db-lab tidb start --version v7.5.0`
+- **THEN** all TiDB components use image tag `v7.5.0`.
 
 ### REQ-TD-005: TiDB Kit Exposes MySQL Endpoint on Port 4000
 
 The TiDB kit SHALL expose a NodePort service for the MySQL-compatible protocol on port 4000.
 
-**Scenarios:**
+#### Scenario: MySQL client connects on NodePort 4000
 
-- **WHEN** the TiDB cluster is running, **THEN** a MySQL-compatible client can connect to any db node on NodePort 4000.
+- **WHEN** the TiDB cluster is running
+- **THEN** a MySQL-compatible client can connect to any db node on NodePort 4000.
 
 ### REQ-TD-006: TiDB Kit Exposes Prometheus Metrics
 
 The TiDB kit SHALL configure metrics scraping from the TiDB SQL layer Prometheus endpoint via NodePort `31080` (container port `10080`), with path `/metrics`.
 
-**Scenarios:**
+#### Scenario: Metrics scrape job registered
 
-- **WHEN** the TiDB kit is started, **THEN** a metrics scrape job is registered targeting NodePort `31080` (TiDB SQL layer) with path `/metrics`.
+- **WHEN** the TiDB kit is started
+- **THEN** a metrics scrape job is registered targeting NodePort `31080` (TiDB SQL layer) with path `/metrics`.
 
 ### REQ-TD-007: TiDB Kit SQL Capability
 
 The TiDB kit SHALL declare a `sql` capability using `com.mysql.cj.jdbc.Driver` and user `root`, enabling the `easy-db-lab tidb sql` command.
 
-**Scenarios:**
+#### Scenario: SQL query executes against MySQL endpoint
 
-- **WHEN** the user runs `easy-db-lab tidb sql "SELECT tidb_version()"`, **THEN** the query executes against the TiDB MySQL endpoint and results are displayed in tabular format.
-- **WHEN** the user runs `easy-db-lab tidb sql "SELECT /*+ read_from_storage(tiflash[t]) */ count(*) FROM t"`, **THEN** the query is routed to TiFlash and results are returned.
+- **WHEN** the user runs `easy-db-lab tidb sql "SELECT tidb_version()"`
+- **THEN** the query executes against the TiDB MySQL endpoint and results are displayed in tabular format.
+
+#### Scenario: Query routed to TiFlash
+
+- **WHEN** the user runs `easy-db-lab tidb sql "SELECT /*+ read_from_storage(tiflash[t]) */ count(*) FROM t"`
+- **THEN** the query is routed to TiFlash and results are returned.

--- a/openspec/specs/tool-execution/spec.md
+++ b/openspec/specs/tool-execution/spec.md
@@ -1,5 +1,7 @@
 # Tool Execution
 
+## Purpose
+
 Remote command execution framework with systemd integration and journald-based log collection.
 
 ## Requirements

--- a/openspec/specs/trino/spec.md
+++ b/openspec/specs/trino/spec.md
@@ -1,5 +1,7 @@
 # Trino
 
+## Purpose
+
 Manages the Trino kit lifecycle, catalog connector management, and SQL execution against a running Trino cluster.
 
 ## Requirements
@@ -8,32 +10,64 @@ Manages the Trino kit lifecycle, catalog connector management, and SQL execution
 
 The system MUST support installing, starting, stopping, and uninstalling Trino via the kit mechanism. Trino deploys via the `trinodb/trino` Helm chart onto app nodes.
 
-**Scenarios:**
+#### Scenario: Install and start deploys Trino
 
-- **GIVEN** a running cluster, **WHEN** the user runs `kit install trino` and then `trino start`, **THEN** Trino is deployed via Helm on app nodes with the requested worker count.
-- **WHEN** the user runs `trino stop`, **THEN** the Trino coordinator and worker deployments are scaled to zero replicas.
-- **WHEN** the user runs `trino start` after a prior stop, **THEN** Trino is re-deployed without requiring re-installation.
-- **WHEN** the user runs `kit install trino` on a cluster with no app nodes, **THEN** an error is emitted and installation is aborted.
+- **GIVEN** a running cluster
+- **WHEN** the user runs `kit install trino` and then `trino start`
+- **THEN** Trino is deployed via Helm on app nodes with the requested worker count.
+
+#### Scenario: Stop scales deployments to zero
+
+- **WHEN** the user runs `trino stop`
+- **THEN** the Trino coordinator and worker deployments are scaled to zero replicas.
+
+#### Scenario: Start after stop redeploys without reinstall
+
+- **WHEN** the user runs `trino start` after a prior stop
+- **THEN** Trino is re-deployed without requiring re-installation.
+
+#### Scenario: Install aborts without app nodes
+
+- **WHEN** the user runs `kit install trino` on a cluster with no app nodes
+- **THEN** an error is emitted and installation is aborted.
 
 ### REQ-TRN-002: Version Selection
 
 The Trino kit MUST accept a `--version` flag at install time to select the Trino release to deploy.
 
-**Scenarios:**
+#### Scenario: Explicit version deployed
 
-- **WHEN** the user runs `kit install trino --version 469`, **THEN** the deployed Trino image uses version 469.
-- **WHEN** the user runs `kit install trino` without `--version`, **THEN** the kit deploys the default pinned Trino version.
+- **WHEN** the user runs `kit install trino --version 469`
+- **THEN** the deployed Trino image uses version 469.
+
+#### Scenario: Default version deployed
+
+- **WHEN** the user runs `kit install trino` without `--version`
+- **THEN** the kit deploys the default pinned Trino version.
 
 ### REQ-TRN-003: Catalog Connector Management
 
 The Trino kit MUST automatically update its catalog configuration when other database kits start or stop, so Trino can query those databases without manual reconfiguration.
 
-**Scenarios:**
+#### Scenario: Cassandra catalog added
 
-- **WHEN** a Cassandra workload is running and Trino starts (or Trino is running and Cassandra starts), **THEN** Trino's Helm release is upgraded with a Cassandra catalog using `connector.name=cassandra`.
-- **WHEN** a ClickHouse workload is running and Trino starts (or Trino is running and ClickHouse starts), **THEN** Trino's Helm release is upgraded with a ClickHouse catalog using `connector.name=clickhouse`.
-- **WHEN** a database workload stops while Trino is running, **THEN** Trino's Helm release is upgraded removing that workload's catalog entry.
-- **WHEN** a custom workload directory contains a `trino-catalog.properties` file, **THEN** that file is included as a catalog entry in the next Helm upgrade.
+- **WHEN** a Cassandra workload is running and Trino starts (or Trino is running and Cassandra starts)
+- **THEN** Trino's Helm release is upgraded with a Cassandra catalog using `connector.name=cassandra`.
+
+#### Scenario: ClickHouse catalog added
+
+- **WHEN** a ClickHouse workload is running and Trino starts (or Trino is running and ClickHouse starts)
+- **THEN** Trino's Helm release is upgraded with a ClickHouse catalog using `connector.name=clickhouse`.
+
+#### Scenario: Catalog removed when workload stops
+
+- **WHEN** a database workload stops while Trino is running
+- **THEN** Trino's Helm release is upgraded removing that workload's catalog entry.
+
+#### Scenario: Custom catalog file included
+
+- **WHEN** a custom workload directory contains a `trino-catalog.properties` file
+- **THEN** that file is included as a catalog entry in the next Helm upgrade.
 
 ### REQ-TRN-004: SQL Execution
 
@@ -41,16 +75,26 @@ The `trino sql` command SHALL execute SQL statements against a running Trino clu
 
 The Trino JDBC driver (`io.trino:trino-jdbc`) MUST be declared as a Gradle dependency and force-loaded via `driver-class: io.trino.jdbc.TrinoDriver` in the capability declaration.
 
-**Scenarios:**
+#### Scenario: Query submitted via JDBC
 
-- **WHEN** the user runs `trino sql "SELECT count(*) FROM cassandra.keyspace.table"`, **THEN** the query is submitted via JDBC and results are displayed in tabular format.
-- **WHEN** the user runs `trino sql --file query.sql`, **THEN** the SQL from the file is executed against the Trino cluster.
-- **WHEN** no app nodes exist in cluster state, **THEN** an error is emitted before any connection is made.
+- **WHEN** the user runs `trino sql "SELECT count(*) FROM cassandra.keyspace.table"`
+- **THEN** the query is submitted via JDBC and results are displayed in tabular format.
+
+#### Scenario: SQL executed from file
+
+- **WHEN** the user runs `trino sql --file query.sql`
+- **THEN** the SQL from the file is executed against the Trino cluster.
+
+#### Scenario: Error when no app nodes exist
+
+- **WHEN** no app nodes exist in cluster state
+- **THEN** an error is emitted before any connection is made.
 
 ### REQ-TRN-005: Pyroscope Profiling
 
 Trino coordinator and worker deployments SHALL be patched after Helm install to attach the Pyroscope Java profiling agent.
 
-**Scenarios:**
+#### Scenario: Pyroscope agent injected
 
-- **WHEN** Trino starts successfully, **THEN** both coordinator and worker pods have the Pyroscope agent injected via `JAVA_TOOL_OPTIONS` and the `/usr/local/pyroscope` host-path volume is mounted.
+- **WHEN** Trino starts successfully
+- **THEN** both coordinator and worker pods have the Pyroscope agent injected via `JAVA_TOOL_OPTIONS` and the `/usr/local/pyroscope` host-path volume is mounted.

--- a/openspec/specs/typed-install-steps/spec.md
+++ b/openspec/specs/typed-install-steps/spec.md
@@ -1,4 +1,10 @@
-## ADDED Requirements
+# Typed Install Steps
+
+## Purpose
+
+Defines a declarative, typed step model for kit lifecycle phases (`install`, `start`, `stop`, `uninstall`) in `kit.yaml`, covering common Kubernetes installation patterns, cluster-state variable interpolation, per-phase collision detection, dashboard registration, and event-reported failure handling.
+
+## Requirements
 
 ### Requirement: kit.yaml declares lifecycle phases as typed step sequences
 `kit.yaml` SHALL support four optional top-level lifecycle keys (`install`, `start`, `stop`,

--- a/openspec/specs/uninstalled-kit-hint/spec.md
+++ b/openspec/specs/uninstalled-kit-hint/spec.md
@@ -1,6 +1,6 @@
 # Uninstalled Kit Hint
 
-## Overview
+## Purpose
 
 When the user types a top-level subcommand that is not installed but matches an available
 kit template, the CLI SHALL print an actionable error message instead of the generic
@@ -10,9 +10,7 @@ PicoCLI unmatched-argument error.
 
 ### Requirement: Hint for uninstalled available kit
 
-When an unrecognized top-level argument exactly matches the name of an available (installable)
-kit template, the CLI SHALL print a targeted message identifying the kit as not
-installed and providing the exact command to install it.
+When an unrecognized top-level argument exactly matches the name of an available (installable) kit template, the CLI SHALL print a targeted message identifying the kit as not installed and providing the exact command to install it.
 
 #### Scenario: User types an available but uninstalled kit name
 

--- a/openspec/specs/workload-arg-passthrough/spec.md
+++ b/openspec/specs/workload-arg-passthrough/spec.md
@@ -1,8 +1,10 @@
 # Workload Arg Passthrough
 
+## Purpose
+
 Defines how workload phase commands accept positional arguments and make them available to typed steps and shell scripts.
 
-## ADDED Requirements
+## Requirements
 
 ### Requirement: Workload phase commands accept positional arguments
 

--- a/openspec/specs/workload-install-config/spec.md
+++ b/openspec/specs/workload-install-config/spec.md
@@ -1,4 +1,10 @@
-## ADDED Requirements
+# Workload Install Config
+
+## Purpose
+
+Defines the optional `endpoints:` and `runtime:` sections of a workload's `install.yaml`, declaring connection metadata for the workload's services and K8s resource metadata for running-state detection.
+
+## Requirements
 
 ### Requirement: install.yaml supports endpoints section
 `install.yaml` SHALL support an optional `endpoints:` list declaring connection metadata for the workload's services.

--- a/openspec/specs/workload-runner/spec.md
+++ b/openspec/specs/workload-runner/spec.md
@@ -1,4 +1,10 @@
-## ADDED Requirements
+# Workload Runner
+
+## Purpose
+
+Discovers installed workload directories as top-level CLI subcommands, executes their `bin/` scripts with cluster state injected as environment variables, and installs their dashboards after a successful start.
+
+## Requirements
 
 ### Requirement: Installed workload dirs are discovered as top-level subcommands
 At startup, the CLI SHALL scan `context.workingDirectory` for subdirectories that contain a `bin/` directory. Each such directory SHALL be registered as a top-level PicoCLI subcommand whose sub-subcommands are the executable files found in `bin/`.

--- a/openspec/specs/workload-status-command/spec.md
+++ b/openspec/specs/workload-status-command/spec.md
@@ -1,4 +1,10 @@
-## ADDED Requirements
+# Workload Status Command
+
+## Purpose
+
+Synthesizes a `status` subcommand for every installed workload that reports its K8s running state and the connection endpoints declared in `install.yaml`, with private IPs resolved from cluster state.
+
+## Requirements
 
 ### Requirement: Status subcommand synthesized for every installed workload
 Every installed workload directory SHALL have a `status` subcommand registered automatically by `WorkloadRunnerCommandFactory`, regardless of whether `install.yaml` exists or contains typed phases.


### PR DESCRIPTION
Closes #742.

OpenSpec validation was completely broken: every spec and 6 of 20 active changes failed `openspec validate`, which blocked `openspec archive` (it validates rebuilt specs before writing). This restores the whole corpus to green so the OpenSpec workflow functions again.

## What changed

**49 specs** (`openspec/specs/`) — all failed `validate --specs`. Format-only repairs:
- Added missing `## Purpose` sections (schema-required)
- Converted old `**Scenarios:**` bullet lists to `#### Scenario:` level-4 blocks (schema requires >=1 per requirement)
- Reconstructed ~20 corrupted delta-dumps (no title, leading `## MODIFIED/ADDED Requirements`) into proper `# Title` + `## Requirements` specs

**6 changes** (`openspec/changes/`) — failed `validate --changes`:
- Authored missing spec deltas from each proposal (`kit-capabilities`, `kit-node-type-requirement`, `presto-sql-command`, `proxy-eager-startup`), sourcing requirement content from the canonical spec so the delta matches the change's intent
- Unwrapped normative sentences where SHALL/MUST had fallen onto a hard-wrapped second line (`kit-subcommand-restructure`, `sql-benchmarking-framework`) — the validator only inspects a requirement's first line

Requirement meaning is preserved throughout; changes are structural/schema compliance only.

## Result

`openspec validate --all` → **69 passed, 0 failed** (49 specs + 20 changes). The up-fail-fast archive that was previously blocked now succeeds.