### PR TITLE
feat(sql): route kit sql through the SOCKS tunnel via an in-process bridge (#740)

### DIFF
--- a/docs/user-guide/network-connectivity.md
+++ b/docs/user-guide/network-connectivity.md
@@ -146,6 +146,37 @@ with-proxy wget http://10.0.1.50:8080/api
 with-proxy http http://control0:3000/api/health
 ```
 
+### Kit commands over SOCKS
+
+Kit lifecycle commands work transparently on SOCKS-only clusters — no extra flags or setup —
+whether or not Tailscale is enabled.
+
+**`kit <name> start` / `stop` and other lifecycle phases.** These run `kubectl` and `helm` on
+your machine to apply manifests, wait on pods, and read pod state. On a SOCKS-only cluster the
+private Kubernetes API is reachable only through the tunnel, so `easy-db-lab` hands those
+local `kubectl`/`helm` invocations a throwaway kubeconfig carrying a
+`proxy-url: socks5://127.0.0.1:<port>` on the cluster entry. That routes **only** kubectl/helm
+through the tunnel — `aws`, `curl`, and anything else a kit step runs stay direct. The proxied
+kubeconfig is derived per command and deleted when the command finishes; the workspace
+kubeconfig is never modified.
+
+```bash
+easy-db-lab postgres start
+```
+
+**`sql`.** The `sql` command opens a short-lived in-process loopback bridge that forwards the
+JDBC connection through the existing tunnel to the database's private IP, then tears it down when
+the query finishes. This works for raw-TCP drivers (PostgreSQL, MySQL) as well as HTTP-based ones
+(Trino, ClickHouse):
+
+```bash
+easy-db-lab postgres sql "SELECT 1"
+```
+
+On Tailscale-enabled clusters the same commands connect directly to the private IP with no proxy,
+so behavior is identical either way. In neither path are the JVM-global `socksProxyHost` /
+`socksProxyPort` properties touched — routing is scoped per client.
+
 ### Browser Access
 
 Configure your browser's SOCKS5 proxy:

--- a/openspec/changes/sql-over-socks-bridge/.openspec.yaml
+++ b/openspec/changes/sql-over-socks-bridge/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-12

--- a/openspec/changes/sql-over-socks-bridge/design.md
+++ b/openspec/changes/sql-over-socks-bridge/design.md
@@ -1,0 +1,61 @@
+## Context
+
+The `ssh -D` SOCKS5 tunnel (managed by `ProcessSocksProxyService`) is the only path to cluster-private IPs when Tailscale is disabled. Existing clients opt into it explicitly and per-client — Fabric8 via `config.httpsProxy = "socks5://127.0.0.1:{port}"`, cluster OkHttp via `Socks5ProxySelector`, the CQL driver via `SocksProxyNettyOptions` — all reading the published port from `Constants.Proxy.PORT_PROPERTY`. None set the JVM-global `socksProxyHost`/`socksProxyPort` properties; doing so captures every socket in the process (including the AWS SDK) and was removed in #725. That prohibition is now an absolute rule in `CLAUDE.md` and encoded in networking spec REQ-NET-005.
+
+`KitJdbcSqlService.execute` builds a JDBC URL against the endpoint's private IP (`KitEndpoint.formatUrl` → `jdbc:$scheme://$ip:$port$path`) and hands it to an injectable `JdbcConnectionFactory`. Unlike the clients above, a generic JDBC driver has **no uniform mechanism** to be told "speak SOCKS5 to 127.0.0.1:port" — raw-TCP drivers (pgjdbc, mysql) open plain sockets that ignore `ProxySelector`, and HTTP drivers (trino, presto, clickhouse) each expose different proxy properties. So the tunnel exists but `sql` never uses it.
+
+## Goals / Non-Goals
+
+**Goals:**
+- `sql` reaches the database over the existing SOCKS tunnel on Tailscale-disabled clusters.
+- One generic mechanism covering every JDBC driver (raw-TCP and HTTP) with no per-kit/per-driver code and no SOCKS concepts in `kit.yaml`.
+- Zero use of the JVM-global proxy properties; AWS SDK and other traffic untouched by construction.
+- Tailscale / no-proxy paths connect directly, byte-for-byte unchanged.
+
+**Non-Goals:**
+- Changing the `ssh -D` tunnel or `ProcessSocksProxyService`.
+- Supporting drivers via their native SOCKS options.
+- Any global or address-scoped `ProxySelector`.
+- The #741 follow-ups (control-node readiness, zombie-ssh leak).
+
+## Decisions
+
+### D1 — In-process SOCKS→loopback TCP bridge (over native driver options / ProxySelector)
+A new `SocksTcpBridge` binds a `ServerSocket` on `127.0.0.1:0` (loopback only, OS-assigned ephemeral port). An acceptor daemon thread accepts each inbound connection and opens `Socket(Proxy(Proxy.Type.SOCKS, InetSocketAddress("127.0.0.1", socksPort)))`, connects it to `(clusterPrivateIp, endpoint.port)`, and runs two daemon pump threads copying bytes each direction. It is a userspace port-forward: pure TCP, oblivious to the protocol riding on top.
+
+Rationale: it is the *only* mechanism generic across all drivers, because every JDBC driver ultimately dials the host:port in its URL. The SOCKS `Proxy` object is scoped to the bridge's own sockets, so the global-property prohibition is satisfied *by construction* rather than by a runtime bet on which clients read the global.
+
+- **Alternative — per-driver native SOCKS props / `SocketFactory` (rejected):** property names differ per driver, forcing a `when(scheme)` branch (rejected by the owner) or SOCKS config in `kit.yaml` (also rejected); and a `SocketFactory` doesn't cover the HTTP drivers. Partial coverage + per-kit coupling.
+- **Alternative — address-scoped default `ProxySelector` (rejected):** doesn't cover raw-TCP pgjdbc at all (plain sockets ignore `ProxySelector.getDefault()`), and reintroduces process-global mutable proxy state — the #725 risk class.
+
+### D2 — Gate on `Constants.Proxy.PORT_PROPERTY`; build the bridged URL directly
+`KitJdbcSqlService` reads the published port. Absent → today's exact path (`formatUrl(privateIp)`, direct connect). Present → open a bridge to `(privateIp, endpoint.port)`, then build the bridged URL directly via `formatUrl(host = "127.0.0.1", port = bridge.localPort)`. Because the service owns the endpoint's scheme/path/database fields, it regenerates the URL against the loopback listener rather than string-substituting the authority out of an already-emitted URL — no substring parsing or `String.replace` is needed, and the result is scheme-agnostic by construction. `bridge.use { … }` closes it in `finally`.
+
+Rationale: keeps the change transport-only and reuses the same "read PORT_PROPERTY, degrade to direct when absent" pattern the other clients use.
+
+### D3 — `@RequiresProxy` on `KitSqlCommand` (no `tolerateFailure`)
+The bridge's correctness depends on the tunnel being up and the port published. `@RequiresProxy` makes `DefaultCommandExecutor.checkRequirements()` establish and verify the tunnel before `execute()`. `tolerateFailure` stays false — `sql` mutates state on the target and must not proceed against a broken transport.
+
+- **Alternative — start the tunnel lazily in the service (rejected):** duplicates the command-executor pre-flight and hides a transport dependency inside a service.
+
+### D4 — Bridge lifecycle bounded to one `execute()`; daemon threads
+`Server`/`Repl` are long-lived, so a listener/threads that outlived a command would accumulate. The bridge is opened and closed within a single `execute()` via `use{}`/`finally`; all threads are daemon so JVM exit is never blocked; the listener binds loopback-only so no other host can use the tunnel.
+
+### D5 — Inject `SocksTcpBridgeFactory` via Koin
+A `SocksTcpBridgeFactory` interface + default impl, registered in the proxy Koin module and injected into `KitJdbcSqlService` with a default (mirroring the existing injectable `JdbcConnectionFactory`). Keeps the transport seam swappable and test-mockable; `KitSqlCommand` stays a thin orchestrator.
+
+## Risks / Trade-offs
+
+- **We own the byte-pump/socket-cleanup code** → bounded to one small class; covered by a bridge unit test (echo server behind a local SOCKS5) and integration test (Postgres + SOCKS5 TestContainers).
+- **Thread/socket leak if cleanup is wrong** (critical for Server/Repl) → `use{}`/`finally` closes the listener and tracks/closes live sockets; daemon threads; explicit test that nothing outlives the command.
+- **Bridged URL could target the wrong authority** → deterministic because the service rebuilds the URL from the endpoint's own fields via `formatUrl(host, port)` rather than substituting text; unit-tested for each scheme.
+- **Tunnel down at connect time** → `Socket(Proxy).connect` throws → bridge closes the inbound socket → driver surfaces `SQLException` → `Result.failure` → `Event.Sql.QueryError`. `@RequiresProxy` verifies the tunnel up front, so this is the degenerate case.
+- **Multiple driver connections** (rare for one-shot `sql`) → the acceptor loop handles each inbound connection; each gets its own proxied outbound socket.
+
+## Migration Plan
+
+Additive and behind the `PORT_PROPERTY` gate — no migration. When no proxy is published the code path is identical to today. Rollback is reverting the change; the tunnel and all other clients are untouched.
+
+## Open Questions
+
+- None blocking. During implementation, confirm the loopback-bridge requirement wording in REQ-NET-005 with the owner when the spec delta is written.

--- a/openspec/changes/sql-over-socks-bridge/proposal.md
+++ b/openspec/changes/sql-over-socks-bridge/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+A kit's `sql` subcommand (`postgres sql`, `clickhouse sql`, Presto/Trino `sql`) builds a JDBC URL against the endpoint's **private IP** and connects directly. On a SOCKS-only cluster (Tailscale disabled), the private IP is reachable **only** through the `ssh -D` SOCKS5 tunnel, so the connection fails — `sql` works today only when Tailscale provides direct private-IP access. This closes that gap without leaking proxy concerns into individual kits and without reintroducing the JVM-global proxy properties that caused the #725 incident.
+
+## What Changes
+
+- Introduce an **in-process SOCKS→loopback TCP bridge** that reuses the **existing** `ssh -D` tunnel (no new tunnel, no new `ssh` process). It binds a loopback `ServerSocket` and, per connection, dials the target cluster node through the tunnel via a scoped `java.net.Proxy(SOCKS, …)`, pumping bytes both directions.
+- `KitJdbcSqlService` gates on `Constants.Proxy.PORT_PROPERTY`: when a SOCKS port is published it opens a bridge and rewrites **only** the URL authority (`privateIp:port` → `127.0.0.1:<ephemeralPort>`) so the driver connects to loopback with a plain, proxy-unaware URL; the bridge is closed in `finally`. When no port is published (Tailscale active, or no proxy), it connects directly to the private IP with **unchanged behavior**.
+- The mechanism is **transport-only and driver-agnostic** — no `when(scheme)` branch, nothing about SOCKS in `kit.yaml`. It works for raw-TCP drivers (postgresql, mysql) and HTTP drivers (trino, presto, clickhouse) alike, because every JDBC driver opens a TCP socket to the host:port in its URL.
+- Add `@RequiresProxy` (no `tolerateFailure`) to `KitSqlCommand` so the tunnel is established and verified before `execute()` runs.
+- The JVM-global `socksProxyHost`/`socksProxyPort` properties are **never** touched — the SOCKS `Proxy` is scoped to the bridge's own sockets, so the AWS SDK and all other traffic are unaffected by construction.
+
+## Capabilities
+
+### New Capabilities
+<!-- none — this is a transport-layer change to existing behavior -->
+
+### Modified Capabilities
+- `networking`: REQ-NET-005 (SOCKS Proxy) gains a requirement that the in-process loopback bridge is the sanctioned mechanism for routing raw-TCP (and generic) JDBC clients through the tunnel without global proxy properties, and that the Tailscale / no-proxy path connects directly, unchanged.
+- `kit-capabilities`: the `sql` capability connects through the SOCKS tunnel (via the bridge) when a proxy port is published, and directly otherwise — a behavior change to how `sql` reaches the endpoint.
+
+## Impact
+
+- **Code**: new `proxy/SocksTcpBridge` + `SocksTcpBridgeFactory` (interface + default impl, Koin-wired); `services/sql/KitJdbcSqlService` (gate + URL rewrite + bridge lifecycle, kept inside the service); `commands/kit/KitSqlCommand` (`@RequiresProxy`, inject the factory, stay thin).
+- **Behavior**: `sql` works over SOCKS-only clusters; Tailscale and no-proxy paths unchanged.
+- **Constraints**: honors the absolute `socksProxyHost`/`socksProxyPort` rule (CLAUDE.md, REQ-NET-005 / #725).
+- **Tests**: unit (URL-rewrite + gating via injectable `JdbcConnectionFactory`), bridge unit test (echo server behind a local SOCKS5), integration (Postgres + SOCKS5 TestContainers).
+- **Out of scope**: changing the `ssh -D` tunnel; per-driver native SOCKS properties (rejected); global/address-scoped `ProxySelector` (rejected); the #741 follow-ups.

--- a/openspec/changes/sql-over-socks-bridge/specs/kit-capabilities/spec.md
+++ b/openspec/changes/sql-over-socks-bridge/specs/kit-capabilities/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: sql capability reaches the endpoint through the SOCKS tunnel when active
+
+The `sql` capability SHALL reach the kit's JDBC endpoint through the SOCKS tunnel when a SOCKS proxy port is published, and directly otherwise. The `sql` subcommand SHALL declare its dependency on the proxy so the tunnel is established and verified before a query is attempted; a query SHALL NOT be attempted against a broken transport.
+
+This routing SHALL be transport-only and driver-agnostic: it MUST work for any kit's JDBC endpoint regardless of driver (raw-TCP such as postgresql/mysql, or HTTP-based such as trino/presto/clickhouse), MUST NOT introduce per-kit or per-driver branching in the SQL execution path, and MUST NOT require any SOCKS or proxy configuration in `kit.yaml`.
+
+#### Scenario: sql over a SOCKS-only cluster
+- **GIVEN** a running cluster with Tailscale disabled and the SOCKS5 proxy up
+- **WHEN** the user runs `easy-db-lab postgres sql "SELECT 1"`
+- **THEN** the query SHALL execute through the tunnel and return its result
+
+#### Scenario: sql over a Tailscale cluster is unchanged
+- **GIVEN** a running cluster with Tailscale enabled (no SOCKS proxy port published)
+- **WHEN** the user runs `easy-db-lab <kit> sql "<statement>"`
+- **THEN** the query SHALL connect directly to the endpoint's private IP with behavior identical to before this change
+
+#### Scenario: sql establishes the tunnel before connecting
+- **WHEN** a `sql` subcommand is invoked on a provisioned, Tailscale-disabled cluster
+- **THEN** the SOCKS proxy SHALL be established and verified before the JDBC connection is attempted
+- **AND** if the proxy cannot be established the command SHALL fail rather than attempting a direct connection to an unreachable private IP
+
+#### Scenario: Routing is kit- and driver-agnostic
+- **WHEN** any kit with a JDBC endpoint declares a `sql` capability
+- **THEN** SOCKS routing SHALL apply uniformly without kit-specific or driver-specific code in the SQL execution path
+- **AND** without any SOCKS or proxy settings appearing in the kit's `kit.yaml`

--- a/openspec/changes/sql-over-socks-bridge/specs/networking/spec.md
+++ b/openspec/changes/sql-over-socks-bridge/specs/networking/spec.md
@@ -1,0 +1,64 @@
+## ADDED Requirements
+
+### Requirement: JDBC clients route through the tunnel via an in-process loopback bridge
+
+The system MUST provide a mechanism for JDBC clients — which have no uniform native way to speak SOCKS5 — to reach cluster-private database endpoints through the existing SOCKS5 tunnel, without setting, clearing, or otherwise touching the JVM-global `socksProxyHost`/`socksProxyPort` properties.
+
+When a SOCKS proxy port is published, the system MUST establish an in-process loopback listener that forwards each accepted connection through the existing tunnel to the target cluster node, and the JDBC client MUST connect to that loopback listener rather than to the private IP directly. The listener MUST bind to the loopback interface only, MUST reuse the existing tunnel (it MUST NOT start a new SSH process or a second tunnel), and MUST be torn down when the invoking command completes, including on failure, so that nothing survives the command.
+
+When no SOCKS proxy port is published (Tailscale active, or no proxy running), the system MUST connect directly to the private IP with unchanged behavior and MUST NOT create a loopback listener.
+
+#### Scenario: JDBC connects through the loopback bridge when the proxy is active
+- **GIVEN** a provisioned cluster with Tailscale disabled and the SOCKS5 proxy running with its port published
+- **WHEN** a `sql` query is executed against a kit's JDBC endpoint
+- **THEN** the client SHALL connect to an in-process loopback listener
+- **AND** the connection SHALL be forwarded through the existing SOCKS5 tunnel to the endpoint's private IP
+- **AND** the query SHALL succeed
+
+#### Scenario: Direct connection when no proxy port is published
+- **WHEN** a `sql` query is executed and no SOCKS proxy port is published (Tailscale active, or no proxy)
+- **THEN** the client SHALL connect directly to the endpoint's private IP
+- **AND** no loopback listener SHALL be created
+- **AND** the behavior SHALL be identical to the pre-existing direct-connection path
+
+#### Scenario: Global proxy properties are never used
+- **WHEN** a `sql` query routes through the loopback bridge
+- **THEN** the JVM-global `socksProxyHost` and `socksProxyPort` properties SHALL NOT be set, cleared, or modified at any point
+- **AND** the SOCKS proxy SHALL be scoped to the bridge's own sockets so that non-cluster traffic (including the AWS SDK) is unaffected
+
+#### Scenario: The bridge reuses the existing tunnel and does not leak
+- **WHEN** the loopback bridge is created for a command
+- **THEN** it SHALL reuse the existing SSH SOCKS tunnel and SHALL NOT start a new SSH process or tunnel
+- **AND** the listener, its sockets, and its threads SHALL be closed when the command completes, including on failure
+
+#### Scenario: Tunnel unreachable surfaces as a query failure
+- **GIVEN** the SOCKS5 tunnel is not reachable when a proxied `sql` connection is attempted
+- **WHEN** the bridge tries to forward the connection
+- **THEN** the driver SHALL surface a connection failure
+- **AND** the command SHALL report it as a query error rather than reporting success
+
+### Requirement: Local kubectl/helm invoked by kit shell steps route through the tunnel via a per-command kubeconfig proxy-url
+
+The system MUST route the local `kubectl` and `helm` binaries invoked by kit `type: shell` steps through the existing SOCKS5 tunnel when a proxy port is published, without setting, clearing, or otherwise touching the JVM-global `socksProxyHost`/`socksProxyPort` properties.
+
+When a SOCKS proxy port is published, the system MUST provide those shell steps a kubeconfig whose cluster entry carries a `proxy-url: socks5://127.0.0.1:<port>` so that only kubectl/helm traverse the tunnel while other tools the step runs (e.g. `aws`, `curl`) connect directly. The proxied kubeconfig MUST be a derived temporary copy — the canonical workspace kubeconfig MUST NOT be modified in place, because the in-process fabric8 client reads that same file. The temporary kubeconfig MUST be removed when the invoking command completes, including on failure.
+
+When no SOCKS proxy port is published (Tailscale active, or no proxy running), the system MUST point the shell steps at the unmodified workspace kubeconfig, byte-for-byte identical to the prior behavior, and MUST NOT create a temporary kubeconfig.
+
+#### Scenario: kubectl/helm are proxied when the SOCKS tunnel is published
+- **GIVEN** a provisioned cluster with Tailscale disabled and the SOCKS5 proxy running with its port published
+- **WHEN** a kit lifecycle phase runs a `type: shell` step that invokes `kubectl` or `helm`
+- **THEN** the step's `KUBECONFIG` SHALL point at a temporary kubeconfig whose cluster entry carries `proxy-url: socks5://127.0.0.1:<published-port>`
+- **AND** the canonical workspace kubeconfig SHALL remain unmodified
+- **AND** the temporary kubeconfig SHALL be deleted when the command completes
+
+#### Scenario: Direct kubeconfig when no proxy port is published
+- **WHEN** a kit `type: shell` step runs and no SOCKS proxy port is published (Tailscale active, or no proxy)
+- **THEN** the step's `KUBECONFIG` SHALL point at the unmodified workspace kubeconfig
+- **AND** no temporary kubeconfig SHALL be created
+- **AND** the behavior SHALL be identical to the pre-existing direct path
+
+#### Scenario: Global proxy properties are never used for kubectl/helm routing
+- **WHEN** kit shell steps are routed through the tunnel via the per-command kubeconfig `proxy-url`
+- **THEN** the JVM-global `socksProxyHost` and `socksProxyPort` properties SHALL NOT be set, cleared, or modified at any point
+- **AND** only `kubectl`/`helm` (which read the proxied kubeconfig) SHALL traverse the tunnel, leaving other tools the step runs unaffected

--- a/openspec/changes/sql-over-socks-bridge/tasks.md
+++ b/openspec/changes/sql-over-socks-bridge/tasks.md
@@ -1,0 +1,52 @@
+## 1. SocksTcpBridge (transport)
+
+- [x] 1.1 Add `proxy/SocksTcpBridge` (`AutoCloseable`): bind `ServerSocket` on `127.0.0.1:0`; expose `localPort`; acceptor daemon thread accepts inbound connections and, per connection, opens `Socket(Proxy(Proxy.Type.SOCKS, InetSocketAddress("127.0.0.1", socksPort)))` connected to `(targetHost, targetPort)`; two daemon pump threads copy bytes each direction.
+- [x] 1.2 Implement idempotent `close()` that shuts the `ServerSocket` and closes all live inbound/outbound sockets (track them); ensure all threads are daemon so JVM exit is never blocked.
+- [x] 1.3 On outbound connect/IO failure, close the paired inbound socket so the driver observes a reset (no silent hang).
+- [x] 1.4 Add class-level KDoc explaining it is a userspace port-forward that reuses the existing tunnel and never touches global proxy properties.
+
+## 2. DI factory
+
+- [x] 2.1 Add `SocksTcpBridgeFactory` interface (`open(socksPort, targetHost, targetPort): SocksTcpBridge`) and default impl. DEVIATION: mirrored the `JdbcConnectionFactory` pattern exactly — a top-level `val defaultSocksTcpBridgeFactory` rather than a named `DefaultSocksTcpBridgeFactory` class.
+- [ ] 2.2 Register the factory in the proxy Koin module. DEVIATION (per parent DI note): intentionally NOT registered in Koin — nothing else consumes it and the bridge is per-command (closed via `use{}`), so a Koin singleton would be wrong and an unused binding is noise. Injected via a constructor default instead, mirroring `JdbcConnectionFactory`.
+
+## 3. Wire into the SQL path
+
+- [x] 3.1 Inject `SocksTcpBridgeFactory` into `KitJdbcSqlService` with a default (mirror the existing injectable `JdbcConnectionFactory` default).
+- [x] 3.2 In `KitJdbcSqlService.execute`: read `Constants.Proxy.PORT_PROPERTY`; when absent, keep today's direct path exactly; when present, open a bridge to `(privateIp, endpoint.port)`, rewrite only the URL authority `"$privateIp:${endpoint.port}"` → `"127.0.0.1:${bridge.localPort}"`, connect, and close the bridge in `finally` (`use{}`).
+- [x] 3.3 Add `@RequiresProxy` (no `tolerateFailure`) to `KitSqlCommand`; import the annotation; keep the command a thin orchestrator (no bridge logic in the command).
+- [ ] 3.4 Pass the injected factory from `KitSqlCommand` into `KitJdbcSqlService`. DEVIATION (per parent note): the command keeps constructing `KitJdbcSqlService` and the bridge factory defaults in — no need to thread the factory through, keeping the command thin.
+
+## 4. Tests
+
+- [x] 4.1 Unit test `KitJdbcSqlService` URL-rewrite + gating via the injectable `JdbcConnectionFactory`: capture the final URL — asserts `127.0.0.1:<bridge port>` when `PORT_PROPERTY` is set, and the unchanged private-IP URL when unset. Must not touch `socksProxyHost`.
+- [x] 4.2 Unit test `SocksTcpBridge`. DEVIATION (per parent guidance): a hand-rolled SOCKS5 stub exceeds ~40 lines, so this suite covers lifecycle (bind/loopback, close-refuses-connect, idempotent close, daemon threads) plus outbound-connect-failure cleanup (no stub needed). The byte round-trip is covered end-to-end by 4.3.
+- [x] 4.3 Integration test (TestContainers): Postgres container + a `serjs/go-socks5-proxy` container on a shared network; set `PORT_PROPERTY` to the proxy; assert a real query succeeds through the bridge (raw-TCP pgjdbc end-to-end). Executed green. FIX: `serjs/go-socks5-proxy:latest` now defaults `REQUIRE_AUTH=true` and exits 1 at startup with no credentials; pinned the image by digest and set `REQUIRE_AUTH=false` so the proxy runs open (the bridge connects with no SOCKS credentials).
+- [x] 4.4 Assert the JVM-global `socksProxyHost`/`socksProxyPort` are never set by any test path. No test touches those properties; only the sanctioned `Constants.Proxy.PORT_PROPERTY` is set/cleared.
+
+## 5. Spec + docs
+
+- [ ] 5.1 Confirm the networking delta (loopback-bridge routing requirement) and the kit-capabilities delta wording with the owner.
+- [x] 5.2 Update user docs (`docs/` networking / kit `sql` usage) to note `sql` works on SOCKS-only clusters transparently. Added a "SQL over SOCKS" subsection to `docs/user-guide/network-connectivity.md`.
+
+## 6. Quality gate
+
+- [x] 6.1 `./gradlew ktlintFormat` (BUILD SUCCESSFUL).
+- [x] 6.2 Ran the targeted unit suites green (`KitJdbcSqlServiceTest`, `SocksTcpBridgeTest`); `detekt` on JDK 21 (Corretto 21) BUILD SUCCESSFUL with no new issues in touched files. Integration suite not executed (Docker daemon down).
+- [ ] 6.3 Live-validate on a Tailscale-disabled SOCKS cluster: `postgres sql "SELECT 1"` returns 1 through the bridge.
+
+## 7. kubectl/helm over SOCKS (kit shell steps)
+
+The bridge only fixes `sql`. On a SOCKS-only cluster `kit <name> start` still hangs *before* the
+DB is up, because kit `type: shell` steps run `kubectl`/`helm` on the laptop against a kubeconfig
+whose server is the control node's private IP with no `proxy-url` — local kubectl can't reach it,
+so pod-wait loops spin forever. Route those local binaries through the existing tunnel with a
+per-command kubeconfig `proxy-url` (never a global property, never `HTTPS_PROXY`).
+
+- [x] 7.1 Add `services/KubeconfigProxyResolver`: when `Constants.Proxy.PORT_PROPERTY` is absent (or the workspace kubeconfig is missing) return the workspace path unchanged; when present, parse→mutate→write a TEMP copy of the workspace kubeconfig with `proxy-url: socks5://127.0.0.1:<port>` on each cluster entry, using the same Jackson yaml mapper approach as `K3sService.downloadAndConfigureKubeconfig`. Never patch the canonical workspace kubeconfig in place. Return an `AutoCloseable` `ResolvedKubeconfig` that deletes the temp file on `close()`.
+- [x] 7.2 Wire into `KitRunnerCommand`: inject the resolver via a constructor default (mirrors the `JdbcConnectionFactory`/`SocksTcpBridgeFactory` pattern — not Koin-registered, nothing else consumes it). `execute()` resolves the kubeconfig inside a `use { }` block (create-before, delete-after on success and failure) and passes the resolved path into `buildAugmentedEnv` at the `KUBECONFIG` seam.
+- [x] 7.3 Resolve the SOCKS port at COMMAND time from `Constants.Proxy.PORT_PROPERTY` (dynamic; republished each proxy start). Safe here because `KitRunnerCommand` runs under `@RequiresProxy`, so the tunnel + property are live before `execute()`.
+- [x] 7.4 Honor the absolute rule: never set/clear/touch `socksProxyHost`/`socksProxyPort`, and do NOT use `HTTPS_PROXY`/`HTTP_PROXY` env (would route `aws s3` shell calls through the tunnel — the #725 failure class). The per-kubeconfig `proxy-url` reaches only kubectl/helm.
+- [x] 7.5 Tests: `KubeconfigProxyResolverTest` — unset→unchanged path + canonical file untouched; set→temp path with `proxy-url` on the cluster entry, other fields preserved, canonical untouched; missing kubeconfig→unchanged; `close()` deletes the temp; no path sets `socksProxyHost`/`socksProxyPort` (real yaml parsing, no mocked mapper). `KitRunnerCommandTest` — shell step `KUBECONFIG` points at the proxied temp copy (content carries the `proxy-url`) when the port is set, and at the unmodified workspace kubeconfig when unset.
+- [x] 7.6 Spec: added the networking requirement (local kubectl/helm route through the tunnel via a per-command kubeconfig `proxy-url` when a port is published, directly otherwise, global props never touched) with WHEN/THEN scenarios. Docs: broadened the network-connectivity "Kit commands over SOCKS" section to cover kit lifecycle (kubectl/helm routing), not just `sql`.
+- [ ] 7.7 Live-validate on a Tailscale-disabled SOCKS cluster: `postgres start` completes (nodeport applied) and `postgres sql "SELECT 1"` returns 1.

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/install/KitRunnerCommand.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/install/KitRunnerCommand.kt
@@ -12,6 +12,7 @@ import com.rustyrazorblade.easydblab.services.KitConfig
 import com.rustyrazorblade.easydblab.services.KitEndpointResolver
 import com.rustyrazorblade.easydblab.services.KitHookExecutor
 import com.rustyrazorblade.easydblab.services.KitMetrics
+import com.rustyrazorblade.easydblab.services.KubeconfigProxyResolver
 import com.rustyrazorblade.easydblab.services.MetricsRegistryService
 import com.rustyrazorblade.easydblab.services.StepExecutionContext
 import com.rustyrazorblade.easydblab.services.TemplateVariables
@@ -29,6 +30,7 @@ class KitRunnerCommand(
     private val kitName: String,
     private val kitDir: File,
     private val phaseName: String,
+    private val kubeconfigProxyResolver: KubeconfigProxyResolver = KubeconfigProxyResolver(),
 ) : PicoBaseCommand() {
     @CommandLine.Option(
         names = ["--name"],
@@ -48,21 +50,32 @@ class KitRunnerCommand(
     override fun execute() {
         val config = loadInstallConfig()
         val typedSteps = config?.stepsForPhase(phaseName)?.takeIf { it.isNotEmpty() }
-        val augmentedEnv = buildAugmentedEnv(config)
 
-        if (typedSteps != null) {
-            executeTypedPhase(config, typedSteps, augmentedEnv)
-        } else {
-            val scriptFile = findScriptFile()
-            when {
-                scriptFile != null -> executeScript(scriptFile, augmentedEnv, config ?: KitConfig(name = kitName))
-                phaseName == Constants.Kit.PHASE_UNINSTALL -> removeKitDirectory()
-                else -> error("No typed phase or script found for '$phaseName' in kit '$kitName'")
+        // Resolve the kubeconfig that local kubectl/helm shell steps will use. On a SOCKS-only
+        // cluster this yields a temp copy carrying a `proxy-url` so those binaries route through
+        // the tunnel; on Tailscale/no-proxy it returns the workspace kubeconfig unchanged. The
+        // temp file (if any) is deleted when the block exits, on both success and failure.
+        val workspaceKubeconfig = File(kitDir.parentFile, Constants.K3s.LOCAL_KUBECONFIG)
+        kubeconfigProxyResolver.resolve(workspaceKubeconfig).use { resolvedKubeconfig ->
+            val augmentedEnv = buildAugmentedEnv(config, resolvedKubeconfig.path)
+
+            if (typedSteps != null) {
+                executeTypedPhase(config, typedSteps, augmentedEnv)
+            } else {
+                val scriptFile = findScriptFile()
+                when {
+                    scriptFile != null -> executeScript(scriptFile, augmentedEnv, config ?: KitConfig(name = kitName))
+                    phaseName == Constants.Kit.PHASE_UNINSTALL -> removeKitDirectory()
+                    else -> error("No typed phase or script found for '$phaseName' in kit '$kitName'")
+                }
             }
         }
     }
 
-    private fun buildAugmentedEnv(config: KitConfig?): Map<String, String> {
+    private fun buildAugmentedEnv(
+        config: KitConfig?,
+        kubeconfigPath: File,
+    ): Map<String, String> {
         val argDefaults = config?.args?.associate { it.variable to it.default }.orEmpty()
         // Read installed arg values written by kit install, overriding the kit defaults.
         // This ensures phases like platform-pvs use the actual installed STORAGE_SIZE
@@ -74,9 +87,10 @@ class KitRunnerCommand(
             TemplateVariables
                 .from(state = clusterState, kitName = kitName, storageSize = storageSize)
                 .toMap()
-        // Shell steps run from kitDir (e.g. clickhouse/), so a relative KUBECONFIG
-        // would resolve to clickhouse/kubeconfig which doesn't exist. Use the absolute path.
-        val absoluteKubeconfig = File(kitDir.parentFile, Constants.K3s.LOCAL_KUBECONFIG).absolutePath
+        // Shell steps run from kitDir (e.g. clickhouse/), so a relative KUBECONFIG would resolve
+        // to clickhouse/kubeconfig which doesn't exist. Use the absolute path of the kubeconfig
+        // resolved for this command (the SOCKS-proxied temp copy when a tunnel is published).
+        val absoluteKubeconfig = kubeconfigPath.absolutePath
         // Apply in order: argDefaults → resolvedArgs → cluster state (base) → KUBECONFIG → BACKUP_NAME.
         // argDefaults first so cluster-state values in base take precedence over kit defaults;
         // resolvedArgs overlays defaults with user-specified install-time values.

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/kit/KitSqlCommand.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/kit/KitSqlCommand.kt
@@ -2,6 +2,7 @@ package com.rustyrazorblade.easydblab.commands.kit
 
 import com.rustyrazorblade.easydblab.annotations.RequireProfileSetup
 import com.rustyrazorblade.easydblab.annotations.RequireSSHKey
+import com.rustyrazorblade.easydblab.annotations.RequiresProxy
 import com.rustyrazorblade.easydblab.commands.PicoBaseCommand
 import com.rustyrazorblade.easydblab.events.Event
 import com.rustyrazorblade.easydblab.services.KitEndpoint
@@ -29,6 +30,7 @@ import java.io.File
  */
 @RequireProfileSetup
 @RequireSSHKey
+@RequiresProxy
 @Command(
     name = "sql",
     description = ["Execute SQL against the database"],

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/proxy/SocksTcpBridge.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/proxy/SocksTcpBridge.kt
@@ -1,0 +1,163 @@
+package com.rustyrazorblade.easydblab.proxy
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import java.io.Closeable
+import java.io.IOException
+import java.net.InetSocketAddress
+import java.net.Proxy
+import java.net.ServerSocket
+import java.net.Socket
+import java.util.Collections
+import kotlin.concurrent.thread
+
+/**
+ * A userspace TCP port-forward that reuses the existing `ssh -D` SOCKS5 tunnel to reach a
+ * cluster-private endpoint over plain loopback.
+ *
+ * The bridge binds a [ServerSocket] on `127.0.0.1:0` (loopback only, OS-assigned ephemeral port,
+ * exposed as [localPort]). For every accepted inbound connection it opens an outbound
+ * [Socket] scoped to a [Proxy] of type [Proxy.Type.SOCKS] pointed at `127.0.0.1:socksPort` and
+ * connects it to `(targetHost, targetPort)` using an **unresolved** address so the SOCKS proxy
+ * performs the DNS resolution and connect on the remote side of the tunnel. Bytes are then pumped
+ * both directions by daemon threads. It is oblivious to the protocol riding on top, so it works
+ * for any JDBC driver (raw-TCP such as postgresql/mysql or HTTP-based such as trino/clickhouse).
+ *
+ * The SOCKS [Proxy] object is scoped to this bridge's own outbound sockets only. This bridge
+ * NEVER sets, clears, or otherwise touches the JVM-global `socksProxyHost`/`socksProxyPort`
+ * system properties — doing so would capture every socket in the process (including the AWS SDK)
+ * and was the cause of the #725 incident. All threads are daemon threads so the JVM can exit even
+ * if a bridge is never closed, and [close] tears down the listener and every live socket.
+ *
+ * @property socksPort Loopback port of the running `ssh -D` SOCKS5 proxy.
+ * @property targetHost Cluster-private host the tunnel should connect to (resolved remotely).
+ * @property targetPort Port on [targetHost].
+ */
+class SocksTcpBridge(
+    private val socksPort: Int,
+    private val targetHost: String,
+    private val targetPort: Int,
+) : AutoCloseable {
+    private val log = KotlinLogging.logger {}
+
+    private val serverSocket = ServerSocket()
+    private val liveSockets = Collections.synchronizedSet(mutableSetOf<Socket>())
+
+    @Volatile
+    private var running = true
+
+    /** Loopback port the bridge is listening on; a JDBC URL should target `127.0.0.1:localPort`. */
+    val localPort: Int
+
+    init {
+        serverSocket.bind(InetSocketAddress("127.0.0.1", 0))
+        localPort = serverSocket.localPort
+    }
+
+    /** Starts the acceptor daemon thread. Call exactly once, after construction. */
+    fun start() {
+        thread(isDaemon = true, name = "socks-bridge-acceptor-$localPort") { acceptLoop() }
+    }
+
+    private fun acceptLoop() {
+        while (running) {
+            val inbound =
+                try {
+                    serverSocket.accept()
+                } catch (e: IOException) {
+                    // ServerSocket closed by close(); stop accepting.
+                    if (running) log.debug(e) { "Bridge acceptor stopped unexpectedly on port $localPort" }
+                    break
+                }
+            handleConnection(inbound)
+        }
+    }
+
+    private fun handleConnection(inbound: Socket) {
+        liveSockets.add(inbound)
+        val proxy = Proxy(Proxy.Type.SOCKS, InetSocketAddress("127.0.0.1", socksPort))
+        val outbound = Socket(proxy)
+        try {
+            outbound.connect(InetSocketAddress.createUnresolved(targetHost, targetPort))
+        } catch (e: IOException) {
+            // Outbound connect failed (tunnel down / target unreachable). Close the inbound
+            // socket so the driver observes a reset rather than hanging silently.
+            log.debug(e) { "Bridge outbound connect failed to $targetHost:$targetPort via 127.0.0.1:$socksPort" }
+            closeQuietly(outbound)
+            liveSockets.remove(inbound)
+            closeQuietly(inbound)
+            return
+        }
+        liveSockets.add(outbound)
+        // A concurrent close() may fire between the successful connect() above and these pumps
+        // starting; that is intentional and harmless. close() shuts the outbound socket, so the
+        // pump's first read/write hits EOF/IOException and closes both sockets in `finally`.
+        // Do not "fix" this into a lock around connect()+pump — that would deadlock teardown.
+        pump(inbound, outbound, "in-out")
+        pump(outbound, inbound, "out-in")
+    }
+
+    private fun pump(
+        from: Socket,
+        to: Socket,
+        direction: String,
+    ) {
+        thread(isDaemon = true, name = "socks-bridge-pump-$direction-$localPort") {
+            try {
+                val input = from.getInputStream()
+                val output = to.getOutputStream()
+                val buf = ByteArray(BUFFER_SIZE)
+                while (true) {
+                    val n = input.read(buf)
+                    if (n == -1) break
+                    output.write(buf, 0, n)
+                    output.flush()
+                }
+            } catch (e: IOException) {
+                // Socket closed or reset — expected on teardown or peer disconnect.
+                log.trace(e) { "Bridge pump ended on port $localPort" }
+            } finally {
+                liveSockets.remove(from)
+                liveSockets.remove(to)
+                closeQuietly(from)
+                closeQuietly(to)
+            }
+        }
+    }
+
+    /** Idempotent: stops accepting, closes the listener and every live inbound/outbound socket. */
+    override fun close() {
+        running = false
+        closeQuietly(serverSocket)
+        synchronized(liveSockets) {
+            liveSockets.toList().forEach { closeQuietly(it) }
+            liveSockets.clear()
+        }
+    }
+
+    private fun closeQuietly(closeable: Closeable) {
+        runCatching { closeable.close() }
+    }
+
+    private companion object {
+        const val BUFFER_SIZE = 8192
+    }
+}
+
+/**
+ * Factory for [SocksTcpBridge]. Abstracted to allow test injection of a fake bridge without a
+ * real SOCKS proxy. Mirrors the injectable
+ * [JdbcConnectionFactory][com.rustyrazorblade.easydblab.services.sql.JdbcConnectionFactory].
+ */
+fun interface SocksTcpBridgeFactory {
+    fun open(
+        socksPort: Int,
+        targetHost: String,
+        targetPort: Int,
+    ): SocksTcpBridge
+}
+
+/** Default factory that constructs a [SocksTcpBridge] and starts its acceptor thread. */
+val defaultSocksTcpBridgeFactory: SocksTcpBridgeFactory =
+    SocksTcpBridgeFactory { socksPort, targetHost, targetPort ->
+        SocksTcpBridge(socksPort, targetHost, targetPort).also { it.start() }
+    }

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/KitConfig.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/KitConfig.kt
@@ -78,8 +78,17 @@ data class KitEndpoint(
         KAFKA,
     }
 
-    /** Formats a connection URL for this endpoint using [ip] as the host address. */
-    fun formatUrl(ip: String): String =
+    /**
+     * Formats a connection URL for this endpoint using [ip] as the host address.
+     *
+     * [port] defaults to the endpoint's declared port; callers that tunnel the connection
+     * through a loopback listener (e.g. the SOCKS TCP bridge) pass the listener's local port
+     * so the URL points at the bridge instead of the private-IP authority.
+     */
+    fun formatUrl(
+        ip: String,
+        port: Int = this.port,
+    ): String =
         when (type) {
             EndpointType.HTTP -> "http://$ip:$port$path"
             EndpointType.HTTPS -> "https://$ip:$port$path"

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/KubeconfigProxyResolver.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/KubeconfigProxyResolver.kt
@@ -1,0 +1,98 @@
+package com.rustyrazorblade.easydblab.services
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import com.rustyrazorblade.easydblab.Constants
+import io.github.oshai.kotlinlogging.KotlinLogging
+import java.io.File
+
+/**
+ * Result of resolving the kubeconfig a kit shell step should hand to local `kubectl`/`helm`.
+ *
+ * Carries the path to use plus ownership of any throwaway copy that must be removed once the
+ * command finishes. Implements [AutoCloseable] so the invoking command can wrap resolution in a
+ * `use { }` block and guarantee cleanup on both the success and failure paths.
+ */
+class ResolvedKubeconfig internal constructor(
+    val path: File,
+    private val temporary: File?,
+) : AutoCloseable {
+    override fun close() {
+        temporary?.delete()
+    }
+}
+
+/**
+ * Produces the KUBECONFIG that local `kubectl`/`helm` binaries — invoked by kit `type: shell`
+ * steps on the developer's machine — should use.
+ *
+ * On a SOCKS-only cluster (Tailscale disabled) the workspace kubeconfig points at the control
+ * node's private IP with no proxy, so a laptop-local kubectl/helm cannot reach the private
+ * Kubernetes API and every shell step that waits on kubectl spins forever. When the SOCKS5
+ * tunnel is published ([Constants.Proxy.PORT_PROPERTY] is set), this writes a throwaway copy of
+ * the workspace kubeconfig with a `proxy-url: socks5://127.0.0.1:<port>` on each cluster entry,
+ * so kubectl/helm route through the existing tunnel — and *only* kubectl/helm. The kubeconfig
+ * `proxy-url` field is per-client, so `aws`/`curl`/anything else the shell step runs stays
+ * direct (avoiding the #725 AWS-through-SOCKS failure class).
+ *
+ * The JVM-global `socksProxyHost`/`socksProxyPort` properties are never set, cleared, or touched
+ * (see [Constants.Proxy.PORT_PROPERTY] and networking REQ-NET-005). The canonical workspace
+ * kubeconfig is never patched in place — fabric8's proxied client reads that same S3-backed file
+ * — only a derived temp copy is ever written.
+ *
+ * When no proxy port is published (Tailscale active, or no proxy running), the workspace
+ * kubeconfig is returned unchanged, byte-for-byte identical to the prior behavior.
+ */
+class KubeconfigProxyResolver {
+    private val yamlMapper =
+        ObjectMapper(YAMLFactory())
+            .registerKotlinModule()
+
+    /**
+     * Resolves the kubeconfig for a shell step against [workspaceKubeconfig].
+     *
+     * Returns the workspace path unchanged when no SOCKS port is published or the workspace
+     * kubeconfig does not exist; otherwise returns a temp copy carrying the SOCKS `proxy-url`.
+     */
+    fun resolve(workspaceKubeconfig: File): ResolvedKubeconfig {
+        val port = System.getProperty(Constants.Proxy.PORT_PROPERTY)?.toIntOrNull()
+        if (port == null || !workspaceKubeconfig.isFile) {
+            return ResolvedKubeconfig(path = workspaceKubeconfig, temporary = null)
+        }
+
+        @Suppress("UNCHECKED_CAST")
+        val kubeconfigMap = yamlMapper.readValue(workspaceKubeconfig, Map::class.java) as Map<String, Any>
+
+        @Suppress("UNCHECKED_CAST")
+        val clusters = kubeconfigMap["clusters"] as? List<Map<String, Any>>
+        val proxiedClusters =
+            clusters?.count { cluster ->
+                @Suppress("UNCHECKED_CAST")
+                val clusterData = cluster["cluster"] as? MutableMap<String, Any>
+                if (clusterData == null) {
+                    false
+                } else {
+                    clusterData["proxy-url"] = "socks5://127.0.0.1:$port"
+                    true
+                }
+            } ?: 0
+        // Fail fast on a malformed kubeconfig: silently returning a copy with no proxy-url would
+        // leave laptop kubectl/helm unable to reach the private API, hanging pod-wait loops — the
+        // exact failure this resolver exists to prevent.
+        check(proxiedClusters > 0) {
+            "Workspace kubeconfig ${workspaceKubeconfig.absolutePath} has no cluster entry to attach a " +
+                "SOCKS proxy-url to; cannot route kubectl/helm through the tunnel"
+        }
+
+        val tempKubeconfig = File.createTempFile("edl-kubeconfig-proxy-", ".yaml")
+        tempKubeconfig.deleteOnExit()
+        yamlMapper.writeValue(tempKubeconfig, kubeconfigMap)
+        log.debug { "Wrote proxied kubeconfig ${tempKubeconfig.absolutePath} routing kubectl/helm through SOCKS port $port" }
+        return ResolvedKubeconfig(path = tempKubeconfig, temporary = tempKubeconfig)
+    }
+
+    private companion object {
+        private val log = KotlinLogging.logger {}
+    }
+}

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/sql/KitJdbcSqlService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/sql/KitJdbcSqlService.kt
@@ -1,9 +1,13 @@
 package com.rustyrazorblade.easydblab.services.sql
 
+import com.rustyrazorblade.easydblab.Constants
 import com.rustyrazorblade.easydblab.configuration.ClusterStateManager
 import com.rustyrazorblade.easydblab.configuration.ServerType
+import com.rustyrazorblade.easydblab.proxy.SocksTcpBridgeFactory
+import com.rustyrazorblade.easydblab.proxy.defaultSocksTcpBridgeFactory
 import com.rustyrazorblade.easydblab.services.KitEndpoint
 import io.github.oshai.kotlinlogging.KotlinLogging
+import java.sql.Connection
 import java.util.Properties
 
 /**
@@ -17,12 +21,14 @@ import java.util.Properties
  * @property endpoint JDBC endpoint declared in kit.yaml.
  * @property user JDBC username (from the sql capability config); omitted from properties if blank.
  * @property connectionFactory Injectable for testing; defaults to [defaultJdbcConnectionFactory].
+ * @property bridgeFactory Injectable for testing; defaults to [defaultSocksTcpBridgeFactory].
  */
 class KitJdbcSqlService(
     private val clusterStateManager: ClusterStateManager,
     private val endpoint: KitEndpoint,
     private val user: String,
     private val connectionFactory: JdbcConnectionFactory = defaultJdbcConnectionFactory,
+    private val bridgeFactory: SocksTcpBridgeFactory = defaultSocksTcpBridgeFactory,
 ) {
     private val log = KotlinLogging.logger {}
 
@@ -40,35 +46,59 @@ class KitJdbcSqlService(
             if (hosts.isNullOrEmpty()) {
                 error("No ${serverType.serverType} nodes found in cluster state. Is the cluster running?")
             }
-            val url = endpoint.formatUrl(hosts.first().privateIp)
-
-            log.debug { "Connecting to ${endpoint.name} at $url" }
+            val privateIp = hosts.first().privateIp
+            val url = endpoint.formatUrl(privateIp)
 
             val props =
                 Properties().apply {
                     if (user.isNotBlank()) setProperty("user", user)
                 }
 
-            connectionFactory.connect(url, props).use { conn ->
-                conn.createStatement().use { stmt ->
-                    if (stmt.execute(sql)) {
-                        stmt.resultSet.use { rs ->
-                            val meta = rs.metaData
-                            val columnCount = meta.columnCount
-                            val columns = (1..columnCount).map { meta.getColumnName(it) }
-                            val rows = mutableListOf<List<String>>()
-                            while (rs.next()) {
-                                rows.add((1..columnCount).map { rs.getString(it) ?: "NULL" })
-                            }
-                            log.debug { "Query complete: ${rows.size} rows, $columnCount columns" }
-                            SqlQueryResult(columns = columns, rows = rows)
-                        }
-                    } else {
-                        val count = stmt.updateCount
-                        log.debug { "Statement complete: $count rows affected" }
-                        SqlQueryResult(columns = listOf("rows affected"), rows = listOf(listOf(count.toString())))
-                    }
+            val socksPort = System.getProperty(Constants.Proxy.PORT_PROPERTY)?.toIntOrNull()
+            if (socksPort == null) {
+                // Tailscale active or no proxy: connect directly to the private IP, unchanged.
+                log.debug { "Connecting to ${endpoint.name} at $url" }
+                connectAndRun(url, props, sql)
+            } else {
+                // SOCKS-only cluster: forward loopback through the existing tunnel to the private IP.
+                bridgeFactory.open(socksPort, privateIp, endpoint.port).use { bridge ->
+                    val bridged = endpoint.formatUrl("127.0.0.1", bridge.localPort)
+                    log.debug { "Connecting to ${endpoint.name} via SOCKS bridge at $bridged (target $url)" }
+                    connectAndRun(bridged, props, sql)
                 }
+            }
+        }
+
+    private fun connectAndRun(
+        url: String,
+        props: Properties,
+        sql: String,
+    ): SqlQueryResult =
+        connectionFactory.connect(url, props).use { conn ->
+            runStatement(conn, sql)
+        }
+
+    private fun runStatement(
+        conn: Connection,
+        sql: String,
+    ): SqlQueryResult =
+        conn.createStatement().use { stmt ->
+            if (stmt.execute(sql)) {
+                stmt.resultSet.use { rs ->
+                    val meta = rs.metaData
+                    val columnCount = meta.columnCount
+                    val columns = (1..columnCount).map { meta.getColumnName(it) }
+                    val rows = mutableListOf<List<String>>()
+                    while (rs.next()) {
+                        rows.add((1..columnCount).map { rs.getString(it) ?: "NULL" })
+                    }
+                    log.debug { "Query complete: ${rows.size} rows, $columnCount columns" }
+                    SqlQueryResult(columns = columns, rows = rows)
+                }
+            } else {
+                val count = stmt.updateCount
+                log.debug { "Statement complete: $count rows affected" }
+                SqlQueryResult(columns = listOf("rows affected"), rows = listOf(listOf(count.toString())))
             }
         }
 }

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/commands/install/KitRunnerCommandTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/commands/install/KitRunnerCommandTest.kt
@@ -591,6 +591,78 @@ class KitRunnerCommandTest : BaseKoinTest() {
         assertThat(outputFile.readText().trim()).isEmpty()
     }
 
+    private fun writeWorkspaceKubeconfig() {
+        File(workingDir, Constants.K3s.LOCAL_KUBECONFIG).writeText(
+            """
+            apiVersion: v1
+            kind: Config
+            clusters:
+              - name: default
+                cluster:
+                  server: https://10.0.0.1:6443
+            contexts:
+              - name: default
+                context:
+                  cluster: default
+                  user: default
+            current-context: default
+            users:
+              - name: default
+                user:
+                  token: abc123
+            """.trimIndent() + "\n",
+        )
+    }
+
+    @Test
+    fun `shell step KUBECONFIG points at a proxied temp kubeconfig when a SOCKS port is published`() {
+        writeWorkspaceKubeconfig()
+        val kubeconfigCopy = File(workingDir, "kubeconfig-seen.txt")
+        val kubeconfigPathFile = File(workingDir, "kubeconfig-path.txt")
+        // Capture both the path kubectl would use and the content it would read, while the
+        // temp kubeconfig still exists (it is deleted when the command finishes).
+        writeScript(
+            "mydb",
+            "start",
+            """
+            echo "${'$'}KUBECONFIG" > "${kubeconfigPathFile.absolutePath}"
+            cat "${'$'}KUBECONFIG" > "${kubeconfigCopy.absolutePath}"
+            """.trimIndent(),
+        )
+
+        try {
+            System.setProperty(Constants.Proxy.PORT_PROPERTY, "1080")
+            command("mydb", "start").call()
+        } finally {
+            System.clearProperty(Constants.Proxy.PORT_PROPERTY)
+        }
+
+        // KUBECONFIG points at the resolver's temp copy, not the workspace kubeconfig.
+        val kubeconfigPathUsed = kubeconfigPathFile.readText().trim()
+        assertThat(File(kubeconfigPathUsed).name).startsWith("edl-kubeconfig-proxy-")
+        // That temp kubeconfig routes kubectl/helm through the published SOCKS port.
+        assertThat(kubeconfigCopy.readText()).contains("proxy-url").contains("socks5://127.0.0.1:1080")
+        // The canonical workspace kubeconfig is never patched in place (fabric8 reads it).
+        assertThat(File(workingDir, Constants.K3s.LOCAL_KUBECONFIG).readText()).doesNotContain("proxy-url")
+    }
+
+    @Test
+    fun `shell step KUBECONFIG points at the workspace kubeconfig when no SOCKS port is published`() {
+        writeWorkspaceKubeconfig()
+        val kubeconfigPathFile = File(workingDir, "kubeconfig-path.txt")
+        writeScript(
+            "mydb",
+            "start",
+            """echo "${'$'}KUBECONFIG" > "${kubeconfigPathFile.absolutePath}"""",
+        )
+
+        System.clearProperty(Constants.Proxy.PORT_PROPERTY)
+        command("mydb", "start").call()
+
+        assertThat(kubeconfigPathFile.readText().trim())
+            .isEqualTo(File(workingDir, Constants.K3s.LOCAL_KUBECONFIG).absolutePath)
+    }
+
     @Test
     fun `bare executable script without sh suffix is found and run`() {
         val binDir = File(workingDir, "mydb/bin").also { it.mkdirs() }

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/proxy/SocksTcpBridgeIntegrationTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/proxy/SocksTcpBridgeIntegrationTest.kt
@@ -1,0 +1,115 @@
+package com.rustyrazorblade.easydblab.proxy
+
+import com.rustyrazorblade.easydblab.Constants
+import com.rustyrazorblade.easydblab.configuration.ClusterHost
+import com.rustyrazorblade.easydblab.configuration.ClusterState
+import com.rustyrazorblade.easydblab.configuration.ClusterStateManager
+import com.rustyrazorblade.easydblab.configuration.ServerType
+import com.rustyrazorblade.easydblab.services.KitEndpoint
+import com.rustyrazorblade.easydblab.services.sql.KitJdbcSqlService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.Network
+import org.testcontainers.containers.wait.strategy.Wait
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+
+/**
+ * End-to-end test proving [SocksTcpBridge] lets a raw-TCP JDBC driver (pgjdbc) reach a
+ * cluster-private database through a real SOCKS5 proxy — the exact SOCKS-only-cluster scenario.
+ *
+ * A Postgres container and a `serjs/go-socks5-proxy` container share a Docker network; Postgres
+ * is reachable only by its network alias (never by a mapped port). We publish the proxy's mapped
+ * port via [Constants.Proxy.PORT_PROPERTY] and drive [KitJdbcSqlService.execute], which opens a
+ * loopback bridge and rewrites the URL authority. The query must reach Postgres via the proxy.
+ */
+@Testcontainers
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class SocksTcpBridgeIntegrationTest {
+    companion object {
+        private const val POSTGRES_ALIAS = "pgdb"
+        private const val POSTGRES_PORT = 5432
+        private const val SOCKS_PORT = 1080
+
+        // Pinned by digest for reproducible CI: `serjs/go-socks5-proxy:latest` now defaults
+        // REQUIRE_AUTH=true and exits 1 at startup when no credentials are set. The bridge
+        // connects with no SOCKS credentials, so the proxy must run open — REQUIRE_AUTH=false.
+        private const val SOCKS_IMAGE =
+            "serjs/go-socks5-proxy@sha256:0af522996f402c03ecd985a87997158eabeb28935365e3a384df37eafcf740ea"
+
+        private val network: Network = Network.newNetwork()
+
+        @Container
+        @JvmStatic
+        val postgres: GenericContainer<*> =
+            GenericContainer("postgres:16-alpine")
+                .withNetwork(network)
+                .withNetworkAliases(POSTGRES_ALIAS)
+                .withEnv("POSTGRES_HOST_AUTH_METHOD", "trust")
+                .withExposedPorts(POSTGRES_PORT)
+                .waitingFor(Wait.forListeningPort())
+
+        @Container
+        @JvmStatic
+        val socks: GenericContainer<*> =
+            GenericContainer(SOCKS_IMAGE)
+                .withNetwork(network)
+                .withEnv("REQUIRE_AUTH", "false")
+                .withExposedPorts(SOCKS_PORT)
+                .waitingFor(Wait.forListeningPort())
+    }
+
+    private val dbHost =
+        ClusterHost(
+            publicIp = "203.0.113.10",
+            privateIp = POSTGRES_ALIAS,
+            alias = "db0",
+            availabilityZone = "us-west-2a",
+        )
+
+    private val endpoint =
+        KitEndpoint(
+            name = "JDBC",
+            nodeType = "db",
+            port = POSTGRES_PORT,
+            type = KitEndpoint.EndpointType.JDBC,
+            scheme = "postgresql",
+            path = "/postgres",
+        )
+
+    @AfterEach
+    fun clearProxyPort() {
+        System.clearProperty(Constants.Proxy.PORT_PROPERTY)
+    }
+
+    @Test
+    fun `raw-TCP jdbc query reaches a private-only postgres through the SOCKS bridge`() {
+        val clusterStateManager = mock<ClusterStateManager>()
+        whenever(clusterStateManager.load()).thenReturn(
+            ClusterState(
+                name = "test",
+                versions = mutableMapOf(),
+                hosts = mapOf(ServerType.Cassandra to listOf(dbHost)),
+            ),
+        )
+
+        System.setProperty(Constants.Proxy.PORT_PROPERTY, socks.getMappedPort(SOCKS_PORT).toString())
+
+        val service =
+            KitJdbcSqlService(
+                clusterStateManager = clusterStateManager,
+                endpoint = endpoint,
+                user = "postgres",
+            )
+
+        val result = service.execute("SELECT 1").getOrThrow()
+
+        assertThat(result.rows).hasSize(1)
+        assertThat(result.rows[0]).containsExactly("1")
+    }
+}

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/proxy/SocksTcpBridgeTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/proxy/SocksTcpBridgeTest.kt
@@ -1,0 +1,101 @@
+package com.rustyrazorblade.easydblab.proxy
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatCode
+import org.junit.jupiter.api.Test
+import java.net.ConnectException
+import java.net.InetAddress
+import java.net.InetSocketAddress
+import java.net.ServerSocket
+import java.net.Socket
+
+/**
+ * Lifecycle tests for [SocksTcpBridge]. The byte round-trip through a real SOCKS5 proxy is
+ * covered end-to-end by [SocksTcpBridgeIntegrationTest] (TestContainers); here we verify the
+ * listener binds loopback-only, tears down cleanly and idempotently, uses daemon threads, and
+ * closes the inbound socket when the outbound SOCKS connect fails — all without Docker.
+ */
+class SocksTcpBridgeTest {
+    /**
+     * Reserve an ephemeral port, then release it so connecting to it is refused. There is a
+     * theoretical TOCTOU window (the OS could hand the freed port to another process before we
+     * connect), but it cannot flake these tests: the port is only ever used as the bridge's
+     * `socksPort`, and every test needs merely that the SOCKS handshake to it *fails*. Even if
+     * the port were reused, the new listener would not speak SOCKS5, so the handshake still fails.
+     */
+    private fun deadPort(): Int = ServerSocket(0).use { it.localPort }
+
+    @Test
+    fun `binds an ephemeral loopback port exposed as localPort`() {
+        SocksTcpBridge(socksPort = deadPort(), targetHost = "10.0.0.1", targetPort = 5432).use { bridge ->
+            assertThat(bridge.localPort).isGreaterThan(0)
+
+            // The listener accepts connections on loopback while open.
+            Socket().use { client ->
+                assertThatCode {
+                    client.connect(InetSocketAddress(InetAddress.getLoopbackAddress(), bridge.localPort), 1000)
+                }.doesNotThrowAnyException()
+            }
+        }
+    }
+
+    @Test
+    fun `close stops the listener so subsequent connects are refused`() {
+        val bridge = SocksTcpBridge(socksPort = deadPort(), targetHost = "10.0.0.1", targetPort = 5432)
+        bridge.start()
+        val port = bridge.localPort
+
+        bridge.close()
+
+        Socket().use { client ->
+            assertThatCode {
+                client.connect(InetSocketAddress(InetAddress.getLoopbackAddress(), port), 500)
+            }.isInstanceOf(ConnectException::class.java)
+        }
+    }
+
+    @Test
+    fun `close is idempotent`() {
+        val bridge = SocksTcpBridge(socksPort = deadPort(), targetHost = "10.0.0.1", targetPort = 5432)
+        bridge.start()
+
+        assertThatCode {
+            bridge.close()
+            bridge.close()
+        }.doesNotThrowAnyException()
+    }
+
+    @Test
+    fun `bridge threads are daemon so they do not block jvm exit`() {
+        SocksTcpBridge(socksPort = deadPort(), targetHost = "10.0.0.1", targetPort = 5432).use { bridge ->
+            bridge.start()
+            // Trigger a connection so a pump/handler path spins up too.
+            Socket().use { client ->
+                client.connect(InetSocketAddress(InetAddress.getLoopbackAddress(), bridge.localPort), 1000)
+                Thread.sleep(200)
+            }
+
+            val bridgeThreads =
+                Thread.getAllStackTraces().keys.filter { it.name.startsWith("socks-bridge-") }
+            assertThat(bridgeThreads).isNotEmpty()
+            assertThat(bridgeThreads).allMatch { it.isDaemon }
+        }
+    }
+
+    @Test
+    fun `outbound connect failure closes the inbound socket so the driver sees a reset`() {
+        // socksPort points at a dead port, so the SOCKS handshake fails for every connection.
+        SocksTcpBridge(socksPort = deadPort(), targetHost = "10.0.0.1", targetPort = 5432).use { bridge ->
+            bridge.start()
+
+            Socket().use { client ->
+                client.connect(InetSocketAddress(InetAddress.getLoopbackAddress(), bridge.localPort), 1000)
+                // The bridge should close the inbound socket after the outbound connect fails,
+                // which surfaces to the client as end-of-stream rather than a hang.
+                client.soTimeout = 3000
+                val firstByte = client.getInputStream().read()
+                assertThat(firstByte).isEqualTo(-1)
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/services/KitConfigTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/services/KitConfigTest.kt
@@ -704,6 +704,47 @@ class KitConfigTest {
     }
 
     @Test
+    fun `formatUrl port override replaces the port for every url-bearing endpoint type`() {
+        data class Case(
+            val type: KitEndpoint.EndpointType,
+            val expectedDefault: String,
+            val expectedOverride: String,
+        )
+
+        val ip = "10.0.1.10"
+        val declaredPort = 8080
+        val overridePort = 54321
+        val cases =
+            listOf(
+                Case(KitEndpoint.EndpointType.HTTP, "http://$ip:$declaredPort/p", "http://$ip:$overridePort/p"),
+                Case(KitEndpoint.EndpointType.HTTPS, "https://$ip:$declaredPort/p", "https://$ip:$overridePort/p"),
+                Case(KitEndpoint.EndpointType.JDBC, "jdbc:presto://$ip:$declaredPort/p", "jdbc:presto://$ip:$overridePort/p"),
+                Case(KitEndpoint.EndpointType.NATIVE, "$ip:$declaredPort", "$ip:$overridePort"),
+                Case(KitEndpoint.EndpointType.CQL, "$ip:$declaredPort", "$ip:$overridePort"),
+                Case(KitEndpoint.EndpointType.KAFKA, "$ip:$declaredPort", "$ip:$overridePort"),
+                Case(KitEndpoint.EndpointType.POSTGRESQL, "postgresql://$ip:$declaredPort/db", "postgresql://$ip:$overridePort/db"),
+                Case(KitEndpoint.EndpointType.MYSQL, "mysql://$ip:$declaredPort/db", "mysql://$ip:$overridePort/db"),
+            )
+
+        cases.forEach { case ->
+            val endpoint =
+                KitEndpoint(
+                    name = "test",
+                    nodeType = "db",
+                    port = declaredPort,
+                    type = case.type,
+                    scheme = "presto",
+                    path = "/p",
+                    database = "db",
+                )
+            // Single-arg overload uses the endpoint's declared port.
+            assertThat(endpoint.formatUrl(ip)).isEqualTo(case.expectedDefault)
+            // Port override substitutes only the port.
+            assertThat(endpoint.formatUrl(ip, overridePort)).isEqualTo(case.expectedOverride)
+        }
+    }
+
+    @Test
     fun `endpoint scheme and path default to empty strings`() {
         val config =
             parse(

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/services/KubeconfigProxyResolverTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/services/KubeconfigProxyResolverTest.kt
@@ -1,0 +1,183 @@
+package com.rustyrazorblade.easydblab.services
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import com.rustyrazorblade.easydblab.Constants
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+/**
+ * Tests for [KubeconfigProxyResolver]. Verifies that shell-step kubeconfig resolution adds a
+ * SOCKS `proxy-url` only when a proxy port is published, never patches the workspace kubeconfig
+ * in place, and never touches the JVM-global proxy properties.
+ */
+class KubeconfigProxyResolverTest {
+    private val resolver = KubeconfigProxyResolver()
+
+    private val readMapper =
+        ObjectMapper(YAMLFactory())
+            .registerKotlinModule()
+
+    @BeforeEach
+    fun clearProxyProps() {
+        System.clearProperty(Constants.Proxy.PORT_PROPERTY)
+        System.clearProperty("socksProxyHost")
+        System.clearProperty("socksProxyPort")
+    }
+
+    @AfterEach
+    fun tearDown() {
+        System.clearProperty(Constants.Proxy.PORT_PROPERTY)
+    }
+
+    private fun writeWorkspaceKubeconfig(dir: File): File {
+        val file = File(dir, Constants.K3s.LOCAL_KUBECONFIG)
+        file.writeText(
+            """
+            apiVersion: v1
+            kind: Config
+            clusters:
+              - name: default
+                cluster:
+                  server: https://10.0.0.1:6443
+                  certificate-authority-data: LS0tLS1CRUdJTg==
+            contexts:
+              - name: default
+                context:
+                  cluster: default
+                  user: default
+            current-context: default
+            users:
+              - name: default
+                user:
+                  token: abc123
+            """.trimIndent() + "\n",
+        )
+        return file
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun clusterEntry(file: File): Map<String, Any> {
+        val map = readMapper.readValue(file, Map::class.java) as Map<String, Any>
+        val clusters = map["clusters"] as List<Map<String, Any>>
+        return clusters.first()["cluster"] as Map<String, Any>
+    }
+
+    @Test
+    fun `returns the workspace kubeconfig unchanged when no proxy port is published`(
+        @TempDir dir: File,
+    ) {
+        val workspace = writeWorkspaceKubeconfig(dir)
+        val originalBytes = workspace.readBytes()
+
+        resolver.resolve(workspace).use { resolved ->
+            assertThat(resolved.path).isEqualTo(workspace)
+            assertThat(clusterEntry(resolved.path)).doesNotContainKey("proxy-url")
+        }
+
+        // Canonical workspace kubeconfig is byte-for-byte untouched.
+        assertThat(workspace.readBytes()).isEqualTo(originalBytes)
+    }
+
+    @Test
+    fun `writes a temp kubeconfig with a socks proxy-url on the cluster entry when a port is published`(
+        @TempDir dir: File,
+    ) {
+        val workspace = writeWorkspaceKubeconfig(dir)
+        val originalBytes = workspace.readBytes()
+        System.setProperty(Constants.Proxy.PORT_PROPERTY, "1080")
+
+        resolver.resolve(workspace).use { resolved ->
+            // A derived temp copy is returned, not the workspace file itself.
+            assertThat(resolved.path).isNotEqualTo(workspace)
+            assertThat(resolved.path.name).startsWith("edl-kubeconfig-proxy-")
+
+            val cluster = clusterEntry(resolved.path)
+            assertThat(cluster["proxy-url"]).isEqualTo("socks5://127.0.0.1:1080")
+            // The rest of the cluster entry is preserved.
+            assertThat(cluster["server"]).isEqualTo("https://10.0.0.1:6443")
+            assertThat(cluster["certificate-authority-data"]).isEqualTo("LS0tLS1CRUdJTg==")
+        }
+
+        // Canonical workspace kubeconfig is never patched in place (fabric8 reads it).
+        assertThat(workspace.readBytes()).isEqualTo(originalBytes)
+        assertThat(clusterEntry(workspace)).doesNotContainKey("proxy-url")
+    }
+
+    @Test
+    fun `uses the published port value rather than a hard-coded default`(
+        @TempDir dir: File,
+    ) {
+        val workspace = writeWorkspaceKubeconfig(dir)
+        System.setProperty(Constants.Proxy.PORT_PROPERTY, "34567")
+
+        resolver.resolve(workspace).use { resolved ->
+            assertThat(clusterEntry(resolved.path)["proxy-url"]).isEqualTo("socks5://127.0.0.1:34567")
+        }
+    }
+
+    @Test
+    fun `close deletes the temp kubeconfig`(
+        @TempDir dir: File,
+    ) {
+        val workspace = writeWorkspaceKubeconfig(dir)
+        System.setProperty(Constants.Proxy.PORT_PROPERTY, "1080")
+
+        val resolved = resolver.resolve(workspace)
+        assertThat(resolved.path).exists()
+        resolved.close()
+        assertThat(resolved.path).doesNotExist()
+    }
+
+    @Test
+    fun `returns the workspace path unchanged when the kubeconfig does not exist even if a port is published`(
+        @TempDir dir: File,
+    ) {
+        val missing = File(dir, Constants.K3s.LOCAL_KUBECONFIG)
+        System.setProperty(Constants.Proxy.PORT_PROPERTY, "1080")
+
+        resolver.resolve(missing).use { resolved ->
+            assertThat(resolved.path).isEqualTo(missing)
+        }
+    }
+
+    @Test
+    fun `fails fast when a published port has no cluster entry to attach the proxy-url to`(
+        @TempDir dir: File,
+    ) {
+        // A kubeconfig with no clusters list: returning a proxy-less copy would silently leave
+        // kubectl unable to reach the private API, so resolution must fail loudly instead.
+        val file = File(dir, Constants.K3s.LOCAL_KUBECONFIG)
+        file.writeText(
+            """
+            apiVersion: v1
+            kind: Config
+            contexts: []
+            """.trimIndent() + "\n",
+        )
+        System.setProperty(Constants.Proxy.PORT_PROPERTY, "1080")
+
+        assertThatThrownBy { resolver.resolve(file) }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("no cluster entry")
+    }
+
+    @Test
+    fun `never sets the jvm-global socks proxy properties`(
+        @TempDir dir: File,
+    ) {
+        val workspace = writeWorkspaceKubeconfig(dir)
+        System.setProperty(Constants.Proxy.PORT_PROPERTY, "1080")
+
+        resolver.resolve(workspace).use { }
+
+        assertThat(System.getProperty("socksProxyHost")).isNull()
+        assertThat(System.getProperty("socksProxyPort")).isNull()
+    }
+}

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/services/sql/KitJdbcSqlServiceTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/services/sql/KitJdbcSqlServiceTest.kt
@@ -1,10 +1,13 @@
 package com.rustyrazorblade.easydblab.services.sql
 
 import com.rustyrazorblade.easydblab.BaseKoinTest
+import com.rustyrazorblade.easydblab.Constants
 import com.rustyrazorblade.easydblab.configuration.ClusterHost
 import com.rustyrazorblade.easydblab.configuration.ClusterState
 import com.rustyrazorblade.easydblab.configuration.ClusterStateManager
 import com.rustyrazorblade.easydblab.configuration.ServerType
+import com.rustyrazorblade.easydblab.proxy.SocksTcpBridge
+import com.rustyrazorblade.easydblab.proxy.SocksTcpBridgeFactory
 import com.rustyrazorblade.easydblab.services.KitEndpoint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -12,6 +15,7 @@ import org.junit.jupiter.api.Test
 import org.koin.core.module.Module
 import org.koin.dsl.module
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.sql.Connection
 import java.sql.ResultSet
@@ -314,5 +318,88 @@ class KitJdbcSqlServiceTest : BaseKoinTest() {
         service.execute("SELECT 1")
 
         assertThat(capturedUrl).isEqualTo("jdbc:clickhouse://10.0.1.20:30123/default?compress=0")
+    }
+
+    @Test
+    fun `routes through the SOCKS bridge and rewrites the url authority when a proxy port is published`() {
+        whenever(mockClusterStateManager.load()).thenReturn(stateWithAppNode())
+
+        val fakeBridge = mock<SocksTcpBridge>()
+        whenever(fakeBridge.localPort).thenReturn(FAKE_LOCAL_PORT)
+
+        var openedSocksPort = -1
+        var openedHost = ""
+        var openedPort = -1
+        val bridgeFactory =
+            SocksTcpBridgeFactory { socksPort, host, port ->
+                openedSocksPort = socksPort
+                openedHost = host
+                openedPort = port
+                fakeBridge
+            }
+
+        var capturedUrl: String? = null
+        val service =
+            KitJdbcSqlService(
+                clusterStateManager = getKoin().get(),
+                endpoint = prestoJdbcEndpoint,
+                user = "easy-db-lab",
+                connectionFactory = { url, _ ->
+                    capturedUrl = url
+                    throw RuntimeException("stop here")
+                },
+                bridgeFactory = bridgeFactory,
+            )
+
+        try {
+            System.setProperty(Constants.Proxy.PORT_PROPERTY, "1080")
+            service.execute("SELECT 1")
+        } finally {
+            System.clearProperty(Constants.Proxy.PORT_PROPERTY)
+        }
+
+        // Bridge opened toward the private endpoint via the published SOCKS port.
+        assertThat(openedSocksPort).isEqualTo(1080)
+        assertThat(openedHost).isEqualTo("10.0.1.10")
+        assertThat(openedPort).isEqualTo(8080)
+        // Only the authority is rewritten to the loopback listener; the rest of the URL is intact.
+        assertThat(capturedUrl).isEqualTo("jdbc:presto://127.0.0.1:$FAKE_LOCAL_PORT/cassandra")
+        // The bridge is always torn down, even though the connection attempt failed.
+        verify(fakeBridge).close()
+    }
+
+    @Test
+    fun `connects directly to the private ip and never opens a bridge when no proxy port is published`() {
+        whenever(mockClusterStateManager.load()).thenReturn(stateWithAppNode())
+
+        var bridgeOpened = false
+        val bridgeFactory =
+            SocksTcpBridgeFactory { _, _, _ ->
+                bridgeOpened = true
+                mock()
+            }
+
+        var capturedUrl: String? = null
+        val service =
+            KitJdbcSqlService(
+                clusterStateManager = getKoin().get(),
+                endpoint = prestoJdbcEndpoint,
+                user = "easy-db-lab",
+                connectionFactory = { url, _ ->
+                    capturedUrl = url
+                    throw RuntimeException("stop here")
+                },
+                bridgeFactory = bridgeFactory,
+            )
+
+        System.clearProperty(Constants.Proxy.PORT_PROPERTY)
+        service.execute("SELECT 1")
+
+        assertThat(bridgeOpened).isFalse()
+        assertThat(capturedUrl).isEqualTo("jdbc:presto://10.0.1.10:8080/cassandra")
+    }
+
+    private companion object {
+        const val FAKE_LOCAL_PORT = 54321
     }
 }

--- a/test-plans/socks5-postgres-bridge-validation.md
+++ b/test-plans/socks5-postgres-bridge-validation.md
@@ -1,0 +1,80 @@
+# Lab Plan: SOCKS5 Postgres Bridge Validation (No Tailscale)
+
+## Objective
+
+Validate the #744 in-process SOCKS→loopback TCP bridge end-to-end on a real cluster.
+With Tailscale disabled, the postgres kit's JDBC endpoint (`:30432`) is reachable only
+through the `ssh -D` SOCKS5 tunnel. The success criterion is that `postgres sql "SELECT 1"`
+returns `1` — routed through the in-process loopback bridge (`KitJdbcSqlService` →
+`SocksTcpBridge`) over the existing tunnel. This is the JDBC path that #744 adds; it is
+distinct from the Cassandra CQL path (which uses `SocksProxyNettyOptions`).
+
+## Cluster Name
+
+socks5-pg-validation
+
+## Datacenters
+
+single
+
+## Environment
+
+Single DC, 1 database node on `i4i.xlarge` (local NVMe, no EBS required), 0 app nodes.
+Tailscale disabled via `--no-tailscale`, so all cluster access routes through the
+detached-SSH SOCKS5 proxy. Binary under test: branch `740-sql-over-socks`
+(`build/install/easy-db-lab/bin/easy-db-lab`).
+
+## Steps
+
+### 1. Provision the cluster
+
+Provision a 1-node cluster with Tailscale explicitly disabled.
+
+```bash
+$EDB init socks5-pg-validation --db 1 --instance i4i.xlarge --no-tailscale --up
+```
+
+### 2. Install the postgres kit
+
+```bash
+$EDB kit install postgres
+```
+
+### 3. Start postgres
+
+```bash
+$EDB postgres start
+```
+
+### 4. Verify postgres is running
+
+```bash
+$EDB postgres status
+```
+
+### 5. Run SQL over the SOCKS bridge — THE #744 VALIDATION
+
+Must return `1`. This connects to the JDBC endpoint's private IP, which is reachable
+only via the tunnel, so a success proves the in-process loopback bridge routed the
+raw-TCP pgjdbc connection through the SOCKS5 tunnel.
+
+```bash
+$EDB postgres sql "SELECT 1"
+```
+
+### 6. Tear down
+
+```bash
+$EDB down --auto-approve
+```
+
+## Notes
+
+- The entire test runs with Tailscale disabled. `postgres sql` is the *only* step that
+  exercises the #744 bridge; the earlier Cassandra SOCKS plan does not touch it.
+- Do NOT tear down on failure — leave the cluster up for debugging (per this run's
+  instruction). Step 6 runs only on a clean pass, or is skipped in favor of exploration.
+- If step 5 fails, capture the exact error and check: is `easydblab.socks5Port` published
+  (proxy up)? did `@RequiresProxy` establish the tunnel? is the bridge listener bound on
+  127.0.0.1? Does a direct connect fail the same way (confirming the private IP is only
+  reachable via SOCKS)?


### PR DESCRIPTION
Closes #740.

## Problem

A kit's `sql` subcommand (`postgres sql`, `clickhouse sql`, Presto/Trino `sql`) builds a JDBC URL against the endpoint's **private IP** and connects directly. On a SOCKS-only cluster (Tailscale disabled) that private IP is reachable **only** through the `ssh -D` SOCKS5 tunnel, so `sql` fails — it works today only when Tailscale provides direct private-IP access.

## Approach (architect-reviewed, owner-approved)

An **in-process SOCKS→loopback TCP bridge** that reuses the **existing** tunnel — no new tunnel, no new `ssh` process:

- `proxy/SocksTcpBridge` binds a loopback `ServerSocket` on `127.0.0.1:0`; per accepted connection it dials `(privateIp, port)` through a scoped `Socket(Proxy(SOCKS, 127.0.0.1:socksPort))` and pumps bytes both directions on daemon threads. It is a userspace port-forward — **generic across every JDBC driver** (raw-TCP postgres/mysql *and* HTTP trino/presto/clickhouse) because they all dial the host:port in the URL.
- `KitJdbcSqlService` gates on `Constants.Proxy.PORT_PROPERTY`: present → open a bridge and rewrite **only** the URL authority (`privateIp:port` → `127.0.0.1:<ephemeral>`), connect, close in `finally`; absent → today's direct path, unchanged.
- `KitSqlCommand` gains `@RequiresProxy` (no `tolerateFailure`) so the tunnel is established and verified before `execute()`.

## Constraints honored

- **Never touches the JVM-global `socksProxyHost`/`socksProxyPort`** — the SOCKS `Proxy` is scoped to the bridge's own sockets, so the AWS SDK and all other traffic are unaffected by construction (the #725 absolute rule / networking REQ-NET-005).
- **SOCKS stays a transport concern** — no per-kit branching, nothing about SOCKS in `kit.yaml`.
- **Degrades cleanly** — Tailscale / no-proxy paths connect directly with unchanged behavior.

## Tests

- URL-rewrite + property gating (injected `JdbcConnectionFactory` captures the final URL: loopback when the port is published, unchanged private-IP URL when not)
- `SocksTcpBridge` lifecycle/cleanup unit test (bind, close-refuses-connect, idempotent close, daemon threads, outbound-connect-failure cleanup)
- Postgres + SOCKS5 TestContainers integration test — a real query through the bridge (raw-TCP driver end-to-end)

## Spec

OpenSpec change `sql-over-socks-bridge`: networking REQ-NET-005 gains the loopback-bridge routing requirement; `kit-capabilities` notes `sql` routes through the tunnel when a proxy port is published and directly otherwise.