### PR TITLE
build(deps): batch small dependency bumps

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,10 +20,10 @@ kotlinx-serialization = "1.10.0"
 kaml = "0.104.0"
 
 # Kotlinx Coroutines
-kotlinx-coroutines = "1.10.2"
+kotlinx-coroutines = "1.11.0"
 
 # Testing
-archunit = "1.3.0"
+archunit = "1.4.2"
 jupiter = "5.10.2"
 assertj = "3.27.7"
 mockito-kotlin = "6.3.0"
@@ -36,24 +36,24 @@ jline = "3.30.6"
 mordant = "1.2.1"
 
 # Ktor
-ktor = "3.4.2"
+ktor = "3.5.1"
 
 # Koin DI
 koin = "4.2.1"
 
 # AWS SDK
-awssdk = "2.42.33"
+awssdk = "2.47.5"
 awssdk-kotlin = "1.4.92"
 
 # Docker
-docker-java = "3.7.0"
+docker-java = "3.7.1"
 
 # HTTP Client
-okhttp = "5.3.2"
+okhttp = "5.4.0"
 
 # Apache
 sshd = "2.18.0"
-commons-io = "2.21.0"
+commons-io = "2.22.0"
 commons-text = "1.15.0"
 
 # Cassandra


### PR DESCRIPTION
Batches several Dependabot dependency bumps into one branch so they can be cleared with a single merge.

## Version bumps
- ktor: 3.4.2 -> 3.5.1
- kotlinx-coroutines: 1.10.2 -> 1.11.0
- commons-io: 2.21.0 -> 2.22.0
- okhttp: 5.3.2 -> 5.4.0
- archunit: 1.3.0 -> 1.4.2
- awssdk: 2.42.33 -> 2.47.5
- docker-java: 3.7.0 -> 3.7.1

Merging this auto-closes #712, #714, #715, #716, #717, #723, #611.

## Intentionally NOT included
- #482 (spark) — obsolete; edits the extracted `spark-examples` dirs.
- #540 / #623 — JUnit 6 major migration.