### PR TITLE
test: share one LocalStack across the AWS integration tests

### DIFF
--- a/src/integrationTest/kotlin/com/rustyrazorblade/easydblab/SharedLocalStack.kt
+++ b/src/integrationTest/kotlin/com/rustyrazorblade/easydblab/SharedLocalStack.kt
@@ -1,0 +1,104 @@
+package com.rustyrazorblade.easydblab
+
+import org.testcontainers.containers.localstack.LocalStackContainer
+import org.testcontainers.containers.localstack.LocalStackContainer.Service
+import org.testcontainers.containers.wait.strategy.Wait
+import org.testcontainers.utility.DockerImageName
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.ec2.Ec2Client
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.BucketAlreadyOwnedByYouException
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest
+import software.amazon.awssdk.services.sts.StsClient
+
+/**
+ * Single, JVM-wide LocalStack container shared by every AWS integration test.
+ *
+ * Historically each AWS integration test class started its own
+ * `localstack/localstack:3.0` container in a `@Container` companion field, which
+ * meant up to six LocalStack startups per integration-test run — slow and wasteful.
+ * This object applies the Testcontainers "singleton container" pattern: the
+ * container is constructed and started exactly once (lazily, on first access) and
+ * reused across all test classes in the JVM.
+ *
+ * It is deliberately NOT annotated with `@Testcontainers`/`@Container`. That
+ * machinery stops the container at the end of the owning test class, which would
+ * defeat sharing. Instead we rely on the Testcontainers Ryuk sidecar and the JVM
+ * shutdown hook to reap the container when the JVM exits — so this object never
+ * calls `.stop()`.
+ *
+ * The container enables the union of services the six tests need — S3, STS, and
+ * EC2 — and exposes ready-to-use AWS SDK clients (each pointed at the matching
+ * LocalStack endpoint with the container's credentials). Because one EC2 and one
+ * S3 backend are now shared across classes, tests must scope their assertions to
+ * the resources they create rather than asserting on global container state.
+ */
+object SharedLocalStack {
+    private val container: LocalStackContainer by lazy {
+        LocalStackContainer(DockerImageName.parse("localstack/localstack:3.0"))
+            .withServices(Service.S3, Service.STS, Service.EC2)
+            .waitingFor(Wait.forHttp("/_localstack/health").forStatusCode(200))
+            .apply { start() }
+    }
+
+    /**
+     * Credentials provider backed by the shared container's access/secret keys.
+     */
+    fun credentialsProvider(): StaticCredentialsProvider =
+        StaticCredentialsProvider.create(
+            AwsBasicCredentials.create(container.accessKey, container.secretKey),
+        )
+
+    /**
+     * S3 client pointed at the shared container. Path-style access is forced so
+     * bucket names resolve without DNS-style virtual hosting against LocalStack.
+     */
+    fun s3Client(): S3Client =
+        S3Client
+            .builder()
+            .endpointOverride(container.getEndpointOverride(Service.S3))
+            .region(Region.of(container.region))
+            .credentialsProvider(credentialsProvider())
+            .forcePathStyle(true)
+            .build()
+
+    /**
+     * STS client pointed at the shared container.
+     */
+    fun stsClient(): StsClient =
+        StsClient
+            .builder()
+            .endpointOverride(container.getEndpointOverride(Service.STS))
+            .region(Region.of(container.region))
+            .credentialsProvider(credentialsProvider())
+            .build()
+
+    /**
+     * EC2 client pointed at the shared container.
+     */
+    fun ec2Client(): Ec2Client =
+        Ec2Client
+            .builder()
+            .endpointOverride(container.getEndpointOverride(Service.EC2))
+            .region(Region.of(container.region))
+            .credentialsProvider(credentialsProvider())
+            .build()
+
+    /**
+     * Creates the given bucket, tolerating the case where a co-tenant test class
+     * already created it in the shared S3 backend. Use a class-unique bucket name
+     * to avoid cross-class interference on bucket contents.
+     */
+    fun createBucketIfMissing(
+        s3Client: S3Client,
+        bucket: String,
+    ) {
+        try {
+            s3Client.createBucket(CreateBucketRequest.builder().bucket(bucket).build())
+        } catch (_: BucketAlreadyOwnedByYouException) {
+            // Bucket already exists from an earlier call in this JVM; nothing to do.
+        }
+    }
+}

--- a/src/integrationTest/kotlin/com/rustyrazorblade/easydblab/commands/SetupProfileIntegrationTest.kt
+++ b/src/integrationTest/kotlin/com/rustyrazorblade/easydblab/commands/SetupProfileIntegrationTest.kt
@@ -2,6 +2,7 @@ package com.rustyrazorblade.easydblab.commands
 
 import com.rustyrazorblade.easydblab.BaseKoinTest
 import com.rustyrazorblade.easydblab.Prompter
+import com.rustyrazorblade.easydblab.SharedLocalStack
 import com.rustyrazorblade.easydblab.TestPrompter
 import com.rustyrazorblade.easydblab.configuration.UserConfigProvider
 import com.rustyrazorblade.easydblab.output.BufferedOutputHandler
@@ -19,15 +20,6 @@ import org.junit.jupiter.api.TestInstance
 import org.koin.core.module.Module
 import org.koin.dsl.module
 import org.mockito.kotlin.mock
-import org.testcontainers.containers.localstack.LocalStackContainer
-import org.testcontainers.containers.localstack.LocalStackContainer.Service
-import org.testcontainers.containers.wait.strategy.Wait
-import org.testcontainers.junit.jupiter.Container
-import org.testcontainers.junit.jupiter.Testcontainers
-import org.testcontainers.utility.DockerImageName
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
-import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.iam.IamClient
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model.HeadBucketRequest
@@ -41,20 +33,13 @@ import software.amazon.awssdk.services.sts.model.GetCallerIdentityRequest
  * These tests verify actual AWS operations (S3 bucket creation, etc.)
  * against a real S3-compatible storage backend.
  *
+ * Uses the JVM-wide [SharedLocalStack] container. Bucket names are made unique
+ * per test so co-tenant S3 tests in the same container cannot interfere.
+ *
  * Note: LocalStack IAM support is limited, so IAM operations are mocked.
  */
-@Testcontainers
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class SetupProfileIntegrationTest : BaseKoinTest() {
-    companion object {
-        @Container
-        @JvmStatic
-        val localStack: LocalStackContainer =
-            LocalStackContainer(DockerImageName.parse("localstack/localstack:3.0"))
-                .withServices(Service.S3, Service.STS)
-                .waitingFor(Wait.forHttp("/_localstack/health").forStatusCode(200))
-    }
-
     private lateinit var s3Client: S3Client
     private lateinit var stsClient: StsClient
     private lateinit var iamClient: IamClient
@@ -70,30 +55,8 @@ class SetupProfileIntegrationTest : BaseKoinTest() {
 
     @BeforeAll
     fun setupLocalStackClients() {
-        val credentials =
-            StaticCredentialsProvider.create(
-                AwsBasicCredentials.create(
-                    localStack.accessKey,
-                    localStack.secretKey,
-                ),
-            )
-
-        s3Client =
-            S3Client
-                .builder()
-                .endpointOverride(localStack.getEndpointOverride(Service.S3))
-                .region(Region.of(localStack.region))
-                .credentialsProvider(credentials)
-                .forcePathStyle(true)
-                .build()
-
-        stsClient =
-            StsClient
-                .builder()
-                .endpointOverride(localStack.getEndpointOverride(Service.STS))
-                .region(Region.of(localStack.region))
-                .credentialsProvider(credentials)
-                .build()
+        s3Client = SharedLocalStack.s3Client()
+        stsClient = SharedLocalStack.stsClient()
 
         // IAM client - LocalStack IAM is limited, so we mock it
         iamClient = mock()

--- a/src/integrationTest/kotlin/com/rustyrazorblade/easydblab/services/ClusterBackupServiceS3IntegrationTest.kt
+++ b/src/integrationTest/kotlin/com/rustyrazorblade/easydblab/services/ClusterBackupServiceS3IntegrationTest.kt
@@ -1,5 +1,6 @@
 package com.rustyrazorblade.easydblab.services
 
+import com.rustyrazorblade.easydblab.SharedLocalStack
 import com.rustyrazorblade.easydblab.configuration.ClusterState
 import com.rustyrazorblade.easydblab.services.aws.S3ObjectStore
 import org.assertj.core.api.Assertions.assertThat
@@ -9,17 +10,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.io.TempDir
-import org.testcontainers.containers.localstack.LocalStackContainer
-import org.testcontainers.containers.localstack.LocalStackContainer.Service
-import org.testcontainers.containers.wait.strategy.Wait
-import org.testcontainers.junit.jupiter.Container
-import org.testcontainers.junit.jupiter.Testcontainers
-import org.testcontainers.utility.DockerImageName
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
-import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.s3.S3Client
-import software.amazon.awssdk.services.s3.model.CreateBucketRequest
 import java.io.File
 
 /**
@@ -27,19 +18,14 @@ import java.io.File
  *
  * These tests verify actual S3 operations including upload, download, and incremental backup
  * functionality against a real S3-compatible storage backend.
+ *
+ * Uses the JVM-wide [SharedLocalStack] S3 backend. This class owns a dedicated,
+ * class-unique bucket so co-tenant S3 test classes cannot see or clobber its objects.
  */
-@Testcontainers
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class ClusterBackupServiceS3IntegrationTest {
-    companion object {
-        private const val TEST_BUCKET = "easy-db-lab-test-bucket"
-
-        @Container
-        @JvmStatic
-        val localStack: LocalStackContainer =
-            LocalStackContainer(DockerImageName.parse("localstack/localstack:3.0"))
-                .withServices(Service.S3)
-                .waitingFor(Wait.forHttp("/_localstack/health").forStatusCode(200))
+    private companion object {
+        private const val TEST_BUCKET = "clusterbackup-test-bucket"
     }
 
     private lateinit var s3Client: S3Client
@@ -51,28 +37,8 @@ class ClusterBackupServiceS3IntegrationTest {
 
     @BeforeAll
     fun setupS3Client() {
-        s3Client =
-            S3Client
-                .builder()
-                .endpointOverride(localStack.getEndpointOverride(Service.S3))
-                .region(Region.of(localStack.region))
-                .credentialsProvider(
-                    StaticCredentialsProvider.create(
-                        AwsBasicCredentials.create(
-                            localStack.accessKey,
-                            localStack.secretKey,
-                        ),
-                    ),
-                ).forcePathStyle(true)
-                .build()
-
-        // Create test bucket
-        s3Client.createBucket(
-            CreateBucketRequest
-                .builder()
-                .bucket(TEST_BUCKET)
-                .build(),
-        )
+        s3Client = SharedLocalStack.s3Client()
+        SharedLocalStack.createBucketIfMissing(s3Client, TEST_BUCKET)
     }
 
     @BeforeEach

--- a/src/integrationTest/kotlin/com/rustyrazorblade/easydblab/services/aws/AMIServiceIntegrationTest.kt
+++ b/src/integrationTest/kotlin/com/rustyrazorblade/easydblab/services/aws/AMIServiceIntegrationTest.kt
@@ -1,5 +1,6 @@
 package com.rustyrazorblade.easydblab.services.aws
 
+import com.rustyrazorblade.easydblab.SharedLocalStack
 import com.rustyrazorblade.easydblab.events.EventBus
 import com.rustyrazorblade.easydblab.providers.aws.AWS
 import org.assertj.core.api.Assertions.assertThat
@@ -9,15 +10,6 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.mockito.kotlin.mock
-import org.testcontainers.containers.localstack.LocalStackContainer
-import org.testcontainers.containers.localstack.LocalStackContainer.Service
-import org.testcontainers.containers.wait.strategy.Wait
-import org.testcontainers.junit.jupiter.Container
-import org.testcontainers.junit.jupiter.Testcontainers
-import org.testcontainers.utility.DockerImageName
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
-import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.ec2.Ec2Client
 import software.amazon.awssdk.services.ec2.model.BlockDeviceMapping
 import software.amazon.awssdk.services.ec2.model.EbsBlockDevice
@@ -29,42 +21,23 @@ import software.amazon.awssdk.services.ec2.model.RegisterImageRequest
  * Tests verify that AWS SDK request construction, filter handling, and response
  * parsing work correctly against a real EC2-compatible API.
  *
+ * Uses the JVM-wide [SharedLocalStack] EC2 backend, shared with the other EC2
+ * integration tests. AMI names registered here are unique to this class, and
+ * every assertion filters by this class's own name patterns, so co-tenant EC2
+ * resources (e.g. VPCs from other test classes) cannot affect these results.
+ *
  * Note: LocalStack Community Edition does not faithfully implement all AMI fields
  * (e.g., architecture returns null). Architecture normalization is covered in unit tests.
  */
-@Testcontainers
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class AMIServiceIntegrationTest {
-    companion object {
-        @Container
-        @JvmStatic
-        val localStack: LocalStackContainer =
-            LocalStackContainer(DockerImageName.parse("localstack/localstack:3.0"))
-                .withServices(Service.EC2)
-                .waitingFor(Wait.forHttp("/_localstack/health").forStatusCode(200))
-    }
-
     private lateinit var ec2Client: Ec2Client
     private lateinit var eventBus: EventBus
     private lateinit var amiService: AMIService
 
     @BeforeAll
     fun setupClients() {
-        val credentials =
-            StaticCredentialsProvider.create(
-                AwsBasicCredentials.create(
-                    localStack.accessKey,
-                    localStack.secretKey,
-                ),
-            )
-
-        ec2Client =
-            Ec2Client
-                .builder()
-                .endpointOverride(localStack.getEndpointOverride(Service.EC2))
-                .region(Region.of(localStack.region))
-                .credentialsProvider(credentials)
-                .build()
+        ec2Client = SharedLocalStack.ec2Client()
     }
 
     @BeforeEach

--- a/src/integrationTest/kotlin/com/rustyrazorblade/easydblab/services/aws/AwsInfrastructureServiceIntegrationTest.kt
+++ b/src/integrationTest/kotlin/com/rustyrazorblade/easydblab/services/aws/AwsInfrastructureServiceIntegrationTest.kt
@@ -1,5 +1,6 @@
 package com.rustyrazorblade.easydblab.services.aws
 
+import com.rustyrazorblade.easydblab.SharedLocalStack
 import com.rustyrazorblade.easydblab.services.aws.AwsInfrastructureService
 import com.rustyrazorblade.easydblab.services.aws.EC2VpcService
 import com.rustyrazorblade.easydblab.services.aws.EMRService
@@ -13,15 +14,6 @@ import org.junit.jupiter.api.TestInstance
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
-import org.testcontainers.containers.localstack.LocalStackContainer
-import org.testcontainers.containers.localstack.LocalStackContainer.Service
-import org.testcontainers.containers.wait.strategy.Wait
-import org.testcontainers.junit.jupiter.Container
-import org.testcontainers.junit.jupiter.Testcontainers
-import org.testcontainers.utility.DockerImageName
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
-import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.ec2.Ec2Client
 import software.amazon.awssdk.services.ec2.model.AttachInternetGatewayRequest
 import software.amazon.awssdk.services.ec2.model.AuthorizeSecurityGroupIngressRequest
@@ -42,19 +34,13 @@ import software.amazon.awssdk.services.ec2.model.ResourceType as Ec2ResourceType
  * real AWS SDK API calls against a LocalStack EC2 endpoint.
  *
  * EMR and OpenSearch are mocked since LocalStack Community Edition doesn't support them.
+ *
+ * Uses the JVM-wide [SharedLocalStack] EC2 backend. Every assertion is scoped to a
+ * single VPC id created by the test (via `discoverResources(vpcId)`), so VPCs created
+ * by co-tenant EC2 test classes cannot affect these results.
  */
-@Testcontainers
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class AwsInfrastructureServiceIntegrationTest {
-    companion object {
-        @Container
-        @JvmStatic
-        val localStack: LocalStackContainer =
-            LocalStackContainer(DockerImageName.parse("localstack/localstack:3.0"))
-                .withServices(Service.EC2)
-                .waitingFor(Wait.forHttp("/_localstack/health").forStatusCode(200))
-    }
-
     private lateinit var ec2Client: Ec2Client
     private lateinit var vpcService: EC2VpcService
     private lateinit var emrService: EMRService
@@ -63,21 +49,7 @@ class AwsInfrastructureServiceIntegrationTest {
 
     @BeforeAll
     fun setupClients() {
-        val credentials =
-            StaticCredentialsProvider.create(
-                AwsBasicCredentials.create(
-                    localStack.accessKey,
-                    localStack.secretKey,
-                ),
-            )
-
-        ec2Client =
-            Ec2Client
-                .builder()
-                .endpointOverride(localStack.getEndpointOverride(Service.EC2))
-                .region(Region.of(localStack.region))
-                .credentialsProvider(credentials)
-                .build()
+        ec2Client = SharedLocalStack.ec2Client()
     }
 
     @BeforeEach

--- a/src/integrationTest/kotlin/com/rustyrazorblade/easydblab/services/aws/EC2VpcServiceIntegrationTest.kt
+++ b/src/integrationTest/kotlin/com/rustyrazorblade/easydblab/services/aws/EC2VpcServiceIntegrationTest.kt
@@ -1,5 +1,6 @@
 package com.rustyrazorblade.easydblab.services.aws
 
+import com.rustyrazorblade.easydblab.SharedLocalStack
 import com.rustyrazorblade.easydblab.services.aws.EC2VpcService
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -8,15 +9,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
-import org.testcontainers.containers.localstack.LocalStackContainer
-import org.testcontainers.containers.localstack.LocalStackContainer.Service
-import org.testcontainers.containers.wait.strategy.Wait
-import org.testcontainers.junit.jupiter.Container
-import org.testcontainers.junit.jupiter.Testcontainers
-import org.testcontainers.utility.DockerImageName
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
-import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.ec2.Ec2Client
 
 /**
@@ -25,39 +17,22 @@ import software.amazon.awssdk.services.ec2.Ec2Client
  * Tests verify that VPC resource creation, idempotent find-or-create patterns,
  * security group ingress rules, route tables, and tag operations work correctly
  * through real AWS SDK API calls against a LocalStack EC2 endpoint.
+ *
+ * Uses the JVM-wide [SharedLocalStack] EC2 backend, shared with the other EC2
+ * integration tests. VPC names, tag values, and the CIDR blocks used by the
+ * whole-region queries ([EC2VpcService.listAllVpcCidrs], [EC2VpcService.findVpcByName],
+ * [EC2VpcService.findVpcsByTag]) are unique to this class, and those assertions use
+ * containment rather than exact global counts, so co-tenant EC2 resources cannot
+ * affect these results.
  */
-@Testcontainers
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class EC2VpcServiceIntegrationTest {
-    companion object {
-        @Container
-        @JvmStatic
-        val localStack: LocalStackContainer =
-            LocalStackContainer(DockerImageName.parse("localstack/localstack:3.0"))
-                .withServices(Service.EC2)
-                .waitingFor(Wait.forHttp("/_localstack/health").forStatusCode(200))
-    }
-
     private lateinit var ec2Client: Ec2Client
     private lateinit var vpcService: EC2VpcService
 
     @BeforeAll
     fun setupClients() {
-        val credentials =
-            StaticCredentialsProvider.create(
-                AwsBasicCredentials.create(
-                    localStack.accessKey,
-                    localStack.secretKey,
-                ),
-            )
-
-        ec2Client =
-            Ec2Client
-                .builder()
-                .endpointOverride(localStack.getEndpointOverride(Service.EC2))
-                .region(Region.of(localStack.region))
-                .credentialsProvider(credentials)
-                .build()
+        ec2Client = SharedLocalStack.ec2Client()
     }
 
     @BeforeEach

--- a/src/integrationTest/kotlin/com/rustyrazorblade/easydblab/services/aws/S3ObjectStoreIntegrationTest.kt
+++ b/src/integrationTest/kotlin/com/rustyrazorblade/easydblab/services/aws/S3ObjectStoreIntegrationTest.kt
@@ -1,5 +1,6 @@
 package com.rustyrazorblade.easydblab.services.aws
 
+import com.rustyrazorblade.easydblab.SharedLocalStack
 import com.rustyrazorblade.easydblab.configuration.ClusterS3Path
 import com.rustyrazorblade.easydblab.services.aws.S3ObjectStore
 import org.assertj.core.api.Assertions.assertThat
@@ -10,17 +11,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.io.TempDir
-import org.testcontainers.containers.localstack.LocalStackContainer
-import org.testcontainers.containers.localstack.LocalStackContainer.Service
-import org.testcontainers.containers.wait.strategy.Wait
-import org.testcontainers.junit.jupiter.Container
-import org.testcontainers.junit.jupiter.Testcontainers
-import org.testcontainers.utility.DockerImageName
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
-import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.s3.S3Client
-import software.amazon.awssdk.services.s3.model.CreateBucketRequest
 import java.io.File
 import java.nio.file.Path
 
@@ -29,19 +20,14 @@ import java.nio.file.Path
  *
  * Tests verify that S3 operations (upload, download, list, delete, exists, metadata)
  * work correctly through real AWS SDK API calls against a LocalStack S3 endpoint.
+ *
+ * Uses the JVM-wide [SharedLocalStack] S3 backend. This class owns a dedicated,
+ * class-unique bucket so co-tenant S3 test classes cannot see or clobber its objects.
  */
-@Testcontainers
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class S3ObjectStoreIntegrationTest {
-    companion object {
-        private const val TEST_BUCKET = "test-bucket"
-
-        @Container
-        @JvmStatic
-        val localStack: LocalStackContainer =
-            LocalStackContainer(DockerImageName.parse("localstack/localstack:3.0"))
-                .withServices(Service.S3)
-                .waitingFor(Wait.forHttp("/_localstack/health").forStatusCode(200))
+    private companion object {
+        private const val TEST_BUCKET = "s3objectstore-test-bucket"
     }
 
     private lateinit var s3Client: S3Client
@@ -49,24 +35,8 @@ class S3ObjectStoreIntegrationTest {
 
     @BeforeAll
     fun setupClients() {
-        val credentials =
-            StaticCredentialsProvider.create(
-                AwsBasicCredentials.create(
-                    localStack.accessKey,
-                    localStack.secretKey,
-                ),
-            )
-
-        s3Client =
-            S3Client
-                .builder()
-                .endpointOverride(localStack.getEndpointOverride(Service.S3))
-                .region(Region.of(localStack.region))
-                .credentialsProvider(credentials)
-                .forcePathStyle(true)
-                .build()
-
-        s3Client.createBucket(CreateBucketRequest.builder().bucket(TEST_BUCKET).build())
+        s3Client = SharedLocalStack.s3Client()
+        SharedLocalStack.createBucketIfMissing(s3Client, TEST_BUCKET)
     }
 
     @BeforeEach


### PR DESCRIPTION
Closes #748.

Replaces the six per-class `@Container` LocalStack instances with a single shared
`SharedLocalStack` object, cutting up to **six** LocalStack startups per integration run
down to **one** (one-per-fork under parallel forking, with full reuse within each fork).

## What changed
- **New `SharedLocalStack`** (an `object`, not a base class — so `SetupProfileIntegrationTest`
  keeps extending `BaseKoinTest`). Lazily starts one `LocalStackContainer` with services
  **S3 + STS + EC2** and never stops it; cleanup is left to the JVM-exit shutdown hook.
  Exposes ready-built `s3Client()` / `stsClient()` / `ec2Client()`, `credentialsProvider()`,
  and an idempotent `createBucketIfMissing()`.
- **All 6 AWS integration tests** drop their companion `@Container` block and build clients
  from the shared holder in `@BeforeAll`. Net **+148 / −225** lines.

## Isolation
Sharing one container makes co-tenant resources visible across classes, so scoping was
verified/tightened rather than assumed:
- **EC2** (`AMIService` / `AwsInfrastructure` / `EC2VpcService`): region-wide queries
  (`listAllVpcCidrs`, `findVpcByName`, `findVpcsByTag`) assert with **containment** on
  class-unique names/tags/CIDRs — never global counts — and AMIs vs VPCs are disjoint types.
- **S3** (`SetupProfile` / `S3ObjectStore` / `ClusterBackup`): the two fixed-bucket tests get
  distinct class-scoped bucket names via `createBucketIfMissing`.

No test was disabled, skipped, or had assertions loosened.

## Verification (local, JDK 21)
- `./gradlew integrationTest` — green; logs show exactly **1** LocalStack startup, **0**
  leftover containers afterward.
- `./gradlew test` — unaffected.
- `./gradlew ktlintCheck detekt` — green.

## Note
Automatic cleanup relies on the Testcontainers JVM-exit shutdown hook because Ryuk is
disabled (`build.gradle.kts:307`) — same behavior the per-class containers already had.
Re-enabling Ryuk is tracked separately in #757.