### PR TITLE
test: make hardcoded production delays injectable to de-slow the unit tier

### DIFF
--- a/src/integrationTest/kotlin/com/rustyrazorblade/easydblab/docker/ContainerExecutorTest.kt
+++ b/src/integrationTest/kotlin/com/rustyrazorblade/easydblab/docker/ContainerExecutorTest.kt
@@ -25,6 +25,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.io.IOException
+import java.time.Duration
 
 class ContainerExecutorTest :
     BaseKoinTest(),
@@ -38,7 +39,8 @@ class ContainerExecutorTest :
         mockDockerClient = mock()
         // Get the OutputHandler from Koin and cast it to BufferedOutputHandler
         bufferedOutputHandler = get<OutputHandler>() as BufferedOutputHandler
-        containerExecutor = ContainerExecutor(mockDockerClient)
+        // Zero poll interval so the completion-wait loop does not sleep between mock inspections.
+        containerExecutor = ContainerExecutor(mockDockerClient, pollInterval = Duration.ZERO)
     }
 
     @Test

--- a/src/integrationTest/kotlin/com/rustyrazorblade/easydblab/proxy/ProcessSocksProxyServiceTest.kt
+++ b/src/integrationTest/kotlin/com/rustyrazorblade/easydblab/proxy/ProcessSocksProxyServiceTest.kt
@@ -22,6 +22,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.io.File
 import java.net.ServerSocket
+import java.time.Duration
 import java.time.Instant
 
 @ResourceLock(Constants.Proxy.PORT_PROPERTY)
@@ -63,6 +64,8 @@ class ProcessSocksProxyServiceTest {
         ProcessSocksProxyService(
             Context.forCli(File(System.getProperty("user.home"), ".easy-db-lab")).copy(workingDirectory = tempDir),
             probe,
+            // Tiny verify delay so verification retries do not sleep 500ms per attempt.
+            verifyDelay = Duration.ofMillis(1),
         )
 
     private fun writeStateFile(

--- a/src/integrationTest/kotlin/com/rustyrazorblade/easydblab/services/aws/AwsInfrastructureServiceIntegrationTest.kt
+++ b/src/integrationTest/kotlin/com/rustyrazorblade/easydblab/services/aws/AwsInfrastructureServiceIntegrationTest.kt
@@ -25,6 +25,7 @@ import software.amazon.awssdk.services.ec2.model.IpPermission
 import software.amazon.awssdk.services.ec2.model.IpRange
 import software.amazon.awssdk.services.ec2.model.Tag
 import software.amazon.awssdk.services.ec2.model.TagSpecification
+import java.time.Duration
 import software.amazon.awssdk.services.ec2.model.ResourceType as Ec2ResourceType
 
 /**
@@ -59,6 +60,8 @@ class AwsInfrastructureServiceIntegrationTest {
                 ec2Client,
                 com.rustyrazorblade.easydblab.events
                     .EventBus(),
+                // Tiny poll interval so teardown/ENI waits do not busy-poll LocalStack at 5s steps.
+                pollInterval = Duration.ofMillis(1),
             )
         emrService = mock()
         openSearchService = mock()

--- a/src/integrationTest/kotlin/com/rustyrazorblade/easydblab/services/aws/EC2VpcServiceIntegrationTest.kt
+++ b/src/integrationTest/kotlin/com/rustyrazorblade/easydblab/services/aws/EC2VpcServiceIntegrationTest.kt
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import software.amazon.awssdk.services.ec2.Ec2Client
+import java.time.Duration
 
 /**
  * Integration tests for EC2VpcService using LocalStack.
@@ -42,6 +43,8 @@ class EC2VpcServiceIntegrationTest {
                 ec2Client,
                 com.rustyrazorblade.easydblab.events
                     .EventBus(),
+                // Tiny poll interval so teardown/ENI waits do not busy-poll LocalStack at 5s steps.
+                pollInterval = Duration.ofMillis(1),
             )
     }
 

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Up.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Up.kt
@@ -62,6 +62,10 @@ import java.time.Duration
  *
  * @see Init for cluster initialization (must be run first)
  * @see Down for tearing down infrastructure
+ *
+ * @param sshStartupDelay How long to pause before the first SSH readiness probe, giving freshly
+ *   booted instances a moment before we start dialing them. Defaults to [SSH_STARTUP_DELAY] so
+ *   production timing is unchanged; tests inject [java.time.Duration.ZERO] to run instantly.
  */
 @McpCommand
 @RequireProfileSetup
@@ -71,7 +75,9 @@ import java.time.Duration
     name = "up",
     description = ["Starts instances"],
 )
-class Up : PicoBaseCommand() {
+class Up(
+    private val sshStartupDelay: Duration = SSH_STARTUP_DELAY,
+) : PicoBaseCommand() {
     private val userConfig: User by inject()
     private val s3BucketService: AwsS3BucketService by inject()
     private val openSearchService: OpenSearchService by inject()
@@ -514,7 +520,7 @@ class Up : PicoBaseCommand() {
      */
     private fun waitForSshReady() {
         eventBus.emit(Event.Provision.SshWaiting)
-        Thread.sleep(SSH_STARTUP_DELAY.toMillis())
+        Thread.sleep(sshStartupDelay.toMillis())
 
         val retryConfig = RetryUtil.createSshConnectionRetryConfig()
         val retry =

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/docker/ContainerExecutor.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/docker/ContainerExecutor.kt
@@ -21,9 +21,14 @@ import kotlin.concurrent.thread
 
 /**
  * Manages the execution lifecycle of a Docker container.
+ *
+ * @param pollInterval How long to wait between container-state polls while waiting for completion.
+ *   Defaults to [CONTAINER_POLLING_INTERVAL] so production timing is unchanged; tests inject a tiny
+ *   value so they do not busy-wait a real container at 1s granularity.
  */
 class ContainerExecutor(
     private val dockerClient: DockerClientInterface,
+    private val pollInterval: Duration = CONTAINER_POLLING_INTERVAL,
 ) : KoinComponent {
     private val eventBus: EventBus by inject()
 
@@ -91,7 +96,7 @@ class ContainerExecutor(
                 error("Container $containerId did not complete within $maxWaitTime")
             }
 
-            Thread.sleep(CONTAINER_POLLING_INTERVAL.toMillis())
+            Thread.sleep(pollInterval.toMillis())
             containerState = dockerClient.inspectContainer(containerId).state
         } while (containerState.running == true)
 

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/mcp/ChannelMessageBuffer.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/mcp/ChannelMessageBuffer.kt
@@ -4,6 +4,7 @@ import com.rustyrazorblade.easydblab.Constants
 import com.rustyrazorblade.easydblab.output.OutputEvent
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.channels.Channel
+import java.time.Duration
 import java.time.LocalTime
 import java.util.Collections
 import kotlin.concurrent.thread
@@ -13,9 +14,14 @@ import kotlin.concurrent.thread
  *
  * This class processes OutputEvent messages from a channel and stores them in a thread-safe buffer
  * with timestamps. It manages its own consumer thread internally.
+ *
+ * @param pollInterval How long the consumer sleeps between channel polls to avoid busy-waiting.
+ *   Defaults to [Constants.Time.THREAD_SLEEP_DELAY_MS] so production behavior is unchanged; tests
+ *   inject [Duration.ZERO] so high-volume cases drain without the per-message throttle.
  */
 class ChannelMessageBuffer(
     private val outputChannel: Channel<OutputEvent>,
+    private val pollInterval: Duration = Duration.ofMillis(Constants.Time.THREAD_SLEEP_DELAY_MS),
 ) {
     companion object {
         private val log = KotlinLogging.logger {}
@@ -58,7 +64,7 @@ class ChannelMessageBuffer(
                         } else if (result.isClosed) {
                             // do nothing
                         }
-                        Thread.sleep(Constants.Time.THREAD_SLEEP_DELAY_MS) // Small delay to avoid busy-waiting
+                        Thread.sleep(pollInterval.toMillis()) // Small delay to avoid busy-waiting
                     }
                 } catch (e: InterruptedException) {
                     log.info { "Message buffer consumer thread interrupted" }

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/proxy/ProcessSocksProxyService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/proxy/ProcessSocksProxyService.kt
@@ -10,6 +10,7 @@ import java.io.File
 import java.net.BindException
 import java.net.InetSocketAddress
 import java.net.ServerSocket
+import java.time.Duration
 import java.time.Instant
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
@@ -61,6 +62,7 @@ internal fun stripSshDebugNoise(
 class ProcessSocksProxyService(
     private val context: Context,
     private val reachabilityProbe: TunnelReachabilityProbe,
+    private val verifyDelay: Duration = Duration.ofMillis(VERIFY_DELAY_MS),
 ) : SocksProxyService {
     companion object {
         private const val VERIFY_RETRIES = 10
@@ -323,7 +325,7 @@ class ProcessSocksProxyService(
             }
             log.debug { "SOCKS5 tunnel not reachable yet (attempt ${attempt + 1}/$VERIFY_RETRIES)" }
             if (attempt < VERIFY_RETRIES - 1) {
-                Thread.sleep(VERIFY_DELAY_MS)
+                Thread.sleep(verifyDelay.toMillis())
             }
         }
         val exitCode = if (process.isAlive) null else process.exitValue()

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/DefaultK8sNamespaceOperations.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/DefaultK8sNamespaceOperations.kt
@@ -7,6 +7,7 @@ import com.rustyrazorblade.easydblab.events.EventBus
 import io.fabric8.kubernetes.api.model.HasMetadata
 import io.fabric8.kubernetes.client.KubernetesClient
 import io.github.oshai.kotlinlogging.KotlinLogging
+import java.time.Duration
 import java.time.Instant
 
 private val log = KotlinLogging.logger {}
@@ -14,10 +15,15 @@ private val log = KotlinLogging.logger {}
 /**
  * Implementation of namespace-related K8s operations: observability status,
  * pod readiness, namespace deletion, resource deletion by label, and rollout restarts.
+ *
+ * @param podPollInterval How long to wait between pod-readiness polls. Defaults to
+ *   [POD_POLL_INTERVAL_MS] so production timing is unchanged; integration tests inject a tiny
+ *   value so they do not busy-wait a live cluster at 5s granularity.
  */
 class DefaultK8sNamespaceOperations(
     private val clientProvider: K8sClientProvider,
     private val eventBus: EventBus,
+    private val podPollInterval: Duration = Duration.ofMillis(POD_POLL_INTERVAL_MS),
 ) : K8sNamespaceOperations {
     override fun getObservabilityStatus(controlHost: ClusterHost): Result<String> =
         runCatching {
@@ -274,7 +280,7 @@ class DefaultK8sNamespaceOperations(
                     )
                 }
 
-                Thread.sleep(POD_POLL_INTERVAL_MS)
+                Thread.sleep(podPollInterval.toMillis())
             }
         }
     }

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/ServicesModule.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/ServicesModule.kt
@@ -50,7 +50,9 @@ val servicesModule =
         factory<CiliumService> { DefaultCiliumService(get(), get()) }
         factory<HelmService> { DefaultHelmService(get()) }
         factory<KubectlService> { DefaultKubectlService(get()) }
-        factoryOf(::DefaultTailscaleService) bind TailscaleService::class
+        // Explicit factory (not factoryOf) so the daemonStartupDelay constructor default applies
+        // instead of Koin trying to resolve a Duration binding.
+        factory<TailscaleService> { DefaultTailscaleService(get(), get()) }
 
         // CQL session factory and service - singleton for session caching in REPL/Server mode
         singleOf(::DefaultCqlSessionFactory) bind CqlSessionFactory::class

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/StressJobService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/StressJobService.kt
@@ -17,6 +17,7 @@ import io.fabric8.kubernetes.api.model.batch.v1.JobBuilder
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.github.resilience4j.retry.Retry
 import io.github.resilience4j.retry.RetryConfig
+import java.time.Duration
 
 /**
  * Configuration for starting a stress job.
@@ -123,12 +124,16 @@ interface StressJobService {
 
 /**
  * Default implementation of StressJobService.
+ *
+ * @param jobPollInterval How long to wait between job-completion polls. Defaults to
+ *   [JOB_POLL_INTERVAL_MS] so production timing is unchanged; tests inject [Duration.ZERO].
  */
 class DefaultStressJobService(
     private val k8sService: K8sService,
     private val clusterStateManager: ClusterStateManager,
     private val eventBus: EventBus,
     private val templateService: TemplateService,
+    private val jobPollInterval: Duration = Duration.ofMillis(JOB_POLL_INTERVAL_MS),
 ) : StressJobService {
     private val log = KotlinLogging.logger {}
 
@@ -336,7 +341,7 @@ class DefaultStressJobService(
                 break
             }
 
-            Thread.sleep(JOB_POLL_INTERVAL_MS)
+            Thread.sleep(jobPollInterval.toMillis())
         }
 
         return ""

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/TailscaleService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/TailscaleService.kt
@@ -15,6 +15,7 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
+import java.time.Duration
 import java.util.concurrent.TimeUnit
 
 private val log = KotlinLogging.logger {}
@@ -128,10 +129,15 @@ interface TailscaleService : AutoCloseable {
 /**
  * Default implementation of TailscaleService using OkHttp for API calls
  * and RemoteOperationsService for SSH commands.
+ *
+ * @param daemonStartupDelay Pause after starting `tailscaled` before authenticating, giving the
+ *   daemon a moment to initialize. Defaults to [Constants.Tailscale.DAEMON_STARTUP_DELAY_MS] so
+ *   production timing is unchanged; tests inject [Duration.ZERO] to run instantly.
  */
 class DefaultTailscaleService(
     private val remoteOps: RemoteOperationsService,
     private val eventBus: EventBus,
+    private val daemonStartupDelay: Duration = Duration.ofMillis(Constants.Tailscale.DAEMON_STARTUP_DELAY_MS),
 ) : TailscaleService {
     private val httpClient: OkHttpClient =
         OkHttpClient
@@ -295,7 +301,7 @@ class DefaultTailscaleService(
             )
 
             // Give the daemon a moment to initialize
-            Thread.sleep(Constants.Tailscale.DAEMON_STARTUP_DELAY_MS)
+            Thread.sleep(daemonStartupDelay.toMillis())
 
             eventBus.emit(Event.Tailscale.Authenticating(host.alias))
 

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/VictoriaBackupService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/VictoriaBackupService.kt
@@ -7,6 +7,7 @@ import com.rustyrazorblade.easydblab.configuration.victoria.VictoriaBackupJobBui
 import com.rustyrazorblade.easydblab.events.Event
 import com.rustyrazorblade.easydblab.events.EventBus
 import io.github.oshai.kotlinlogging.KotlinLogging
+import java.time.Duration
 import java.time.Instant
 import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
@@ -70,11 +71,14 @@ interface VictoriaBackupService {
  * Uses Kubernetes Jobs to run backup operations on the control node.
  *
  * @property k8sService Service for Kubernetes operations
+ * @param jobPollInterval How long to wait between backup-job status polls. Defaults to
+ *   [JOB_POLL_INTERVAL_MS] so production timing is unchanged; tests inject [Duration.ZERO].
  */
 class DefaultVictoriaBackupService(
     private val k8sService: K8sService,
     private val eventBus: EventBus,
     private val jobBuilder: VictoriaBackupJobBuilder = VictoriaBackupJobBuilder(),
+    private val jobPollInterval: Duration = Duration.ofMillis(JOB_POLL_INTERVAL_MS),
 ) : VictoriaBackupService {
     private val log = KotlinLogging.logger {}
 
@@ -255,7 +259,7 @@ class DefaultVictoriaBackupService(
                 }
             }
 
-            Thread.sleep(JOB_POLL_INTERVAL_MS)
+            Thread.sleep(jobPollInterval.toMillis())
             eventBus.emit(Event.Backup.Waiting)
         }
 

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/aws/AMIService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/aws/AMIService.kt
@@ -16,6 +16,7 @@ import software.amazon.awssdk.services.ec2.model.DescribeImagesRequest
 import software.amazon.awssdk.services.ec2.model.DescribeSnapshotsRequest
 import software.amazon.awssdk.services.ec2.model.Ec2Exception
 import software.amazon.awssdk.services.ec2.model.Filter
+import java.time.Duration
 import java.time.Instant
 
 /**
@@ -44,20 +45,25 @@ class AMIService(
         // AMI pattern template - architecture is injected at runtime
         const val DEFAULT_AMI_PATTERN_TEMPLATE = "rustyrazorblade/images/easy-db-lab-cassandra-%s-*"
 
+        /** Base backoff for the default validation retry policy (2s, doubling per attempt). */
+        private val DEFAULT_VALIDATION_BACKOFF: Duration = Duration.ofSeconds(2)
+
         /**
-         * Default retry configuration for AMI validation:
+         * Builds a retry configuration for AMI validation with a configurable base backoff:
          * - Max 3 attempts
-         * - 2 second initial wait with exponential backoff
+         * - Exponential backoff off [baseBackoff] (baseBackoff, 2×, 4×)
          * - Retries on transient AWS errors (429, 5xx)
          * - Does NOT retry on permission errors (403)
+         *
+         * Production uses [defaultValidationRetryConfig]; tests inject a near-zero [baseBackoff]
+         * so the retry-path tests do not sit through real wall-clock backoff.
          */
-        val defaultValidationRetryConfig: RetryConfig =
+        fun buildValidationRetryConfig(baseBackoff: Duration): RetryConfig =
             RetryConfig
                 .custom<AMI>()
                 .maxAttempts(3)
                 .intervalFunction { attemptCount ->
-                    // Exponential backoff: 2s, 4s, 8s
-                    2000L * (1L shl (attemptCount - 1))
+                    baseBackoff.toMillis() * (1L shl (attemptCount - 1))
                 }.retryOnException { throwable ->
                     when {
                         throwable !is Ec2Exception -> false
@@ -76,6 +82,11 @@ class AMIService(
                         else -> false
                     }
                 }.build()
+
+        /**
+         * Default retry configuration for AMI validation: 3 attempts with 2s/4s/8s backoff.
+         */
+        val defaultValidationRetryConfig: RetryConfig = buildValidationRetryConfig(DEFAULT_VALIDATION_BACKOFF)
     }
 
     /**

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/aws/EC2InstanceService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/aws/EC2InstanceService.kt
@@ -41,6 +41,7 @@ import java.time.Duration
 class EC2InstanceService(
     private val ec2Client: Ec2Client,
     private val eventBus: EventBus,
+    private val pollInterval: Duration = Duration.ofMillis(POLL_INTERVAL_MS),
 ) {
     companion object {
         private val log = KotlinLogging.logger {}
@@ -254,7 +255,7 @@ class EC2InstanceService(
                 "Waiting: $running/${details.size} running, $withPublicIp/${details.size} with public IP"
             }
 
-            Thread.sleep(POLL_INTERVAL_MS)
+            Thread.sleep(pollInterval.toMillis())
         }
 
         error("Timeout waiting for instances to reach running state after ${timeoutMs}ms")

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/aws/EC2VpcService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/aws/EC2VpcService.kt
@@ -55,6 +55,7 @@ import software.amazon.awssdk.services.ec2.model.RevokeSecurityGroupEgressReques
 import software.amazon.awssdk.services.ec2.model.RevokeSecurityGroupIngressRequest
 import software.amazon.awssdk.services.ec2.model.Tag
 import software.amazon.awssdk.services.ec2.model.TerminateInstancesRequest
+import java.time.Duration
 
 /**
  * Implementation of VpcService using AWS EC2 SDK.
@@ -67,6 +68,7 @@ import software.amazon.awssdk.services.ec2.model.TerminateInstancesRequest
 class EC2VpcService(
     private val ec2Client: Ec2Client,
     private val eventBus: EventBus,
+    private val pollInterval: Duration = Duration.ofMillis(VpcService.POLL_INTERVAL_MS),
 ) : VpcService {
     companion object {
         private val log = KotlinLogging.logger {}
@@ -823,7 +825,7 @@ class EC2VpcService(
             }
 
             log.debug { "Still waiting for ${remaining.size} network interfaces to clear..." }
-            Thread.sleep(VpcService.POLL_INTERVAL_MS)
+            Thread.sleep(pollInterval.toMillis())
         }
 
         throw AwsTimeoutException(
@@ -889,7 +891,7 @@ class EC2VpcService(
             val pending = instances.count { it.state().name() != InstanceStateName.TERMINATED }
             log.debug { "Still waiting for $pending instances to terminate..." }
 
-            Thread.sleep(VpcService.POLL_INTERVAL_MS)
+            Thread.sleep(pollInterval.toMillis())
         }
 
         throw AwsTimeoutException("Timeout waiting for instances to terminate after ${timeoutMs}ms")
@@ -1061,7 +1063,7 @@ class EC2VpcService(
             val pending = natGateways.count { it.state() != NatGatewayState.DELETED }
             log.debug { "Still waiting for $pending NAT gateways to be deleted..." }
 
-            Thread.sleep(VpcService.POLL_INTERVAL_MS)
+            Thread.sleep(pollInterval.toMillis())
         }
 
         throw AwsTimeoutException("Timeout waiting for NAT gateways to be deleted after ${timeoutMs}ms")

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/aws/EMRService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/aws/EMRService.kt
@@ -30,6 +30,7 @@ import software.amazon.awssdk.services.emr.model.RunJobFlowRequest
 import software.amazon.awssdk.services.emr.model.ScriptBootstrapActionConfig
 import software.amazon.awssdk.services.emr.model.Tag
 import software.amazon.awssdk.services.emr.model.TerminateJobFlowsRequest
+import java.time.Duration
 
 /** Recursively converts an EMRConfiguration to the AWS SDK Configuration type. */
 private fun EMRConfiguration.toAwsConfiguration(): Configuration {
@@ -49,11 +50,18 @@ private fun EMRConfiguration.toAwsConfiguration(): Configuration {
  *
  * This service handles creation, status monitoring, discovery, and termination
  * of EMR clusters for Spark job execution.
+ *
+ * @param readyPollInterval Delay between cluster-state polls while waiting for a cluster to reach
+ *   its ready/terminated state. Defaults to [POLL_INTERVAL_MS]; tests inject a tiny value.
+ * @param terminationPollInterval Delay between polls while waiting for bulk cluster termination.
+ *   Defaults to [TERMINATION_POLL_INTERVAL_MS]; tests inject a tiny value.
  */
 @Suppress("TooManyFunctions")
 class EMRService(
     private val emrClient: EmrClient,
     private val eventBus: EventBus,
+    private val readyPollInterval: Duration = Duration.ofMillis(POLL_INTERVAL_MS),
+    private val terminationPollInterval: Duration = Duration.ofMillis(TERMINATION_POLL_INTERVAL_MS),
 ) {
     companion object {
         private val log = KotlinLogging.logger {}
@@ -253,7 +261,7 @@ class EMRService(
                 }
             }
 
-            Thread.sleep(POLL_INTERVAL_MS)
+            Thread.sleep(readyPollInterval.toMillis())
         }
 
         error("Timeout waiting for EMR cluster $clusterId to be ready after ${timeoutMs}ms")
@@ -352,7 +360,7 @@ class EMRService(
             }
 
             log.debug { "EMR cluster $clusterId state: ${status.state}" }
-            Thread.sleep(POLL_INTERVAL_MS)
+            Thread.sleep(readyPollInterval.toMillis())
         }
 
         error("Timeout waiting for EMR cluster $clusterId to terminate after ${timeoutMs}ms")
@@ -494,7 +502,7 @@ class EMRService(
                 }
             log.debug { "Still waiting for $pending EMR clusters to terminate..." }
 
-            Thread.sleep(TERMINATION_POLL_INTERVAL_MS)
+            Thread.sleep(terminationPollInterval.toMillis())
         }
 
         throw AwsTimeoutException("Timeout waiting for EMR clusters to terminate after ${timeoutMs}ms")

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/aws/EMRSparkService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/aws/EMRSparkService.kt
@@ -27,6 +27,7 @@ import software.amazon.awssdk.services.emr.model.StepState
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
+import java.time.Duration
 import java.util.zip.GZIPInputStream
 
 /**
@@ -49,6 +50,10 @@ import java.util.zip.GZIPInputStream
  *
  * @property emrClient AWS EMR client for API operations
  * @property clusterStateManager Manager for cluster state persistence
+ * @property pollInterval Delay between job-status polls. Defaults to [Constants.EMR.POLL_INTERVAL_MS]
+ *   so production timing is unchanged; tests inject [Duration.ZERO] to poll without waiting.
+ * @property logIngestionWait Pause before querying Victoria Logs on failure, allowing logs to be
+ *   ingested. Defaults to [Constants.EMR.LOG_INGESTION_WAIT_MS]; tests inject [Duration.ZERO].
  */
 class EMRSparkService(
     private val emrClient: EmrClient,
@@ -56,6 +61,8 @@ class EMRSparkService(
     private val clusterStateManager: ClusterStateManager,
     private val victoriaLogsService: VictoriaLogsService,
     private val eventBus: EventBus,
+    private val pollInterval: Duration = Duration.ofMillis(Constants.EMR.POLL_INTERVAL_MS),
+    private val logIngestionWait: Duration = Duration.ofMillis(Constants.EMR.LOG_INGESTION_WAIT_MS),
 ) : SparkService {
     private val log = KotlinLogging.logger {}
 
@@ -120,7 +127,7 @@ class EMRSparkService(
             var pollCount = 0
 
             do {
-                Thread.sleep(Constants.EMR.POLL_INTERVAL_MS)
+                Thread.sleep(pollInterval.toMillis())
                 pollCount++
 
                 // Check for timeout
@@ -201,7 +208,7 @@ class EMRSparkService(
     private fun queryVictoriaLogs(stepId: String) {
         println("\n=== Step Logs ===")
         try {
-            Thread.sleep(Constants.EMR.LOG_INGESTION_WAIT_MS)
+            Thread.sleep(logIngestionWait.toMillis())
 
             // Query using OTel Java agent log attributes (service.name) instead of defunct step_id tag
             // The Java agent tags logs with service.name=spark-<job-name>

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/commands/UpTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/commands/UpTest.kt
@@ -49,6 +49,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.io.File
 import java.nio.file.Path
+import java.time.Duration
 
 /**
  * Tests for [Up], the command that provisions and configures the complete cluster.
@@ -290,7 +291,7 @@ class UpTest : BaseKoinTest() {
 
     @Test
     fun `up provisions successfully when every step succeeds`() {
-        assertThatCode { Up().execute() }.doesNotThrowAnyException()
+        assertThatCode { newUp().execute() }.doesNotThrowAnyException()
 
         verify(mockClusterProvisioningService).provisionAll(any(), any(), any(), any())
         verify(mockK8sService).labelNode(eq(testControlHost), eq("control0"), any())
@@ -308,7 +309,7 @@ class UpTest : BaseKoinTest() {
     fun `up fails before any EC2 instance is launched when configuration produces no control node`() {
         whenever(mockClusterStateManager.load()).thenReturn(happyState(controlInstances = 0))
 
-        assertThatThrownBy { Up().execute() }
+        assertThatThrownBy { newUp().execute() }
             .isInstanceOf(IllegalStateException::class.java)
             .hasMessageContaining("control node is required")
 
@@ -320,7 +321,7 @@ class UpTest : BaseKoinTest() {
     fun `up fails before any EC2 instance is launched when no S3 bucket is configured`() {
         whenever(mockS3BucketService.ensureAccountBucket(any())).thenReturn("")
 
-        assertThatThrownBy { Up().execute() }
+        assertThatThrownBy { newUp().execute() }
             .isInstanceOf(IllegalStateException::class.java)
             .hasMessageContaining("S3 bucket is required")
 
@@ -337,7 +338,7 @@ class UpTest : BaseKoinTest() {
             ),
         )
 
-        assertThatCode { Up().execute() }.doesNotThrowAnyException()
+        assertThatCode { newUp().execute() }.doesNotThrowAnyException()
 
         assertThat(outputHandler.errors).isEmpty()
         verify(mockK8sService, never()).labelNode(any(), eq("db0"), any())
@@ -352,7 +353,7 @@ class UpTest : BaseKoinTest() {
     fun `up aborts when the nested WriteConfig command fails`() {
         nestedCommandExitCodes["WriteConfig"] = 1
 
-        assertThatThrownBy { Up().execute() }
+        assertThatThrownBy { newUp().execute() }
             .isInstanceOf(IllegalStateException::class.java)
             .hasMessageContaining("WriteConfig")
 
@@ -363,7 +364,7 @@ class UpTest : BaseKoinTest() {
     fun `up aborts when the nested SetupInstance command fails`() {
         nestedCommandExitCodes["SetupInstance"] = 1
 
-        assertThatThrownBy { Up().execute() }
+        assertThatThrownBy { newUp().execute() }
             .isInstanceOf(IllegalStateException::class.java)
             .hasMessageContaining("SetupInstance")
 
@@ -377,7 +378,7 @@ class UpTest : BaseKoinTest() {
         overrideUser(userWithAxonOps)
         nestedCommandExitCodes["ConfigureAxonOps"] = 1
 
-        assertThatThrownBy { Up().execute() }
+        assertThatThrownBy { newUp().execute() }
             .isInstanceOf(IllegalStateException::class.java)
             .hasMessageContaining("ConfigureAxonOps")
     }
@@ -386,7 +387,7 @@ class UpTest : BaseKoinTest() {
     fun `up aborts when the nested GrafanaUpdateConfig command fails`() {
         nestedCommandExitCodes["GrafanaUpdateConfig"] = 1
 
-        assertThatThrownBy { Up().execute() }
+        assertThatThrownBy { newUp().execute() }
             .isInstanceOf(IllegalStateException::class.java)
             .hasMessageContaining("GrafanaUpdateConfig")
     }
@@ -396,7 +397,7 @@ class UpTest : BaseKoinTest() {
         whenever(mockClusterConfigurationService.writeAllConfigurationFiles(any(), any(), any()))
             .thenReturn(Result.failure(RuntimeException("disk full")))
 
-        assertThatThrownBy { Up().execute() }
+        assertThatThrownBy { newUp().execute() }
             .isInstanceOf(RuntimeException::class.java)
             .hasMessageContaining("disk full")
 
@@ -409,7 +410,7 @@ class UpTest : BaseKoinTest() {
             K3sSetupResult(serverStarted = false, errors = mapOf("K3s server start" to Exception("connection refused"))),
         )
 
-        assertThatThrownBy { Up().execute() }
+        assertThatThrownBy { newUp().execute() }
             .isInstanceOf(IllegalStateException::class.java)
             .hasMessageContaining("K3s cluster setup failed")
 
@@ -420,7 +421,7 @@ class UpTest : BaseKoinTest() {
     fun `up aborts when ensureLocalStorageClass fails`() {
         whenever(mockK8sService.ensureLocalStorageClass(any())).thenReturn(Result.failure(RuntimeException("apply failed")))
 
-        assertThatThrownBy { Up().execute() }
+        assertThatThrownBy { newUp().execute() }
             .isInstanceOf(RuntimeException::class.java)
             .hasMessageContaining("apply failed")
 
@@ -432,7 +433,7 @@ class UpTest : BaseKoinTest() {
     fun `up aborts when ensureLocalStorageWfcClass fails`() {
         whenever(mockK8sService.ensureLocalStorageWfcClass(any())).thenReturn(Result.failure(RuntimeException("apply failed")))
 
-        assertThatThrownBy { Up().execute() }
+        assertThatThrownBy { newUp().execute() }
             .isInstanceOf(RuntimeException::class.java)
             .hasMessageContaining("apply failed")
     }
@@ -442,7 +443,7 @@ class UpTest : BaseKoinTest() {
         whenever(mockK8sService.labelNode(eq(testControlHost), eq("control0"), any()))
             .thenReturn(Result.failure(RuntimeException("k8s api unreachable")))
 
-        assertThatThrownBy { Up().execute() }
+        assertThatThrownBy { newUp().execute() }
             .isInstanceOf(RuntimeException::class.java)
             .hasMessageContaining("k8s api unreachable")
 
@@ -455,7 +456,7 @@ class UpTest : BaseKoinTest() {
         whenever(mockK8sService.labelNode(eq(testControlHost), eq("db0"), any()))
             .thenReturn(Result.failure(RuntimeException("db label failed")))
 
-        assertThatThrownBy { Up().execute() }
+        assertThatThrownBy { newUp().execute() }
             .isInstanceOf(RuntimeException::class.java)
             .hasMessageContaining("db label failed")
 
@@ -467,7 +468,7 @@ class UpTest : BaseKoinTest() {
         whenever(mockK8sService.labelNode(eq(testControlHost), eq("app0"), any()))
             .thenReturn(Result.failure(RuntimeException("app label failed")))
 
-        assertThatThrownBy { Up().execute() }
+        assertThatThrownBy { newUp().execute() }
             .isInstanceOf(RuntimeException::class.java)
             .hasMessageContaining("app label failed")
 
@@ -479,7 +480,7 @@ class UpTest : BaseKoinTest() {
     fun `up aborts before provisioning when reapplying the S3 policy fails`() {
         whenever(mockS3BucketService.attachS3Policy(any())).thenThrow(RuntimeException("access denied"))
 
-        assertThatThrownBy { Up().execute() }
+        assertThatThrownBy { newUp().execute() }
             .isInstanceOf(RuntimeException::class.java)
             .hasMessageContaining("access denied")
 
@@ -491,7 +492,7 @@ class UpTest : BaseKoinTest() {
         overrideUser(tailscaleUser())
         nestedCommandExitCodes["TailscaleStart"] = 1
 
-        assertThatThrownBy { Up().execute() }
+        assertThatThrownBy { newUp().execute() }
             .isInstanceOf(IllegalStateException::class.java)
             .hasMessageContaining("easy-db-lab tailscale start")
 
@@ -500,7 +501,7 @@ class UpTest : BaseKoinTest() {
 
     @Test
     fun `no-setup exits cleanly without touching K3s or nested setup commands`() {
-        val command = Up()
+        val command = newUp()
         command.noSetup = true
 
         assertThatCode { command.execute() }.doesNotThrowAnyException()
@@ -517,7 +518,7 @@ class UpTest : BaseKoinTest() {
 
     @Test
     fun `ssh readiness wait covers the control host, not only db hosts`() {
-        assertThatCode { Up().execute() }.doesNotThrowAnyException()
+        assertThatCode { newUp().execute() }.doesNotThrowAnyException()
 
         assertThat(sshCheckedAliases).contains("control0", "db0")
     }
@@ -532,12 +533,19 @@ class UpTest : BaseKoinTest() {
         // exercised either way; only the wait time differs.
         sshFailureException = IllegalStateException("connection refused")
 
-        assertThatThrownBy { Up().execute() }
+        assertThatThrownBy { newUp().execute() }
             .isInstanceOf(IllegalStateException::class.java)
             .hasMessageContaining("connection refused")
 
         verify(mockK3sClusterService, never()).setupCluster(any())
     }
+
+    /**
+     * Constructs an [Up] with a zero SSH startup delay so tests do not sit through the production
+     * [Up.SSH_STARTUP_DELAY] pause. The delay's only effect is wall-clock timing, so removing it
+     * does not change any behavior under test.
+     */
+    private fun newUp(): Up = Up(sshStartupDelay = Duration.ZERO)
 
     private fun overrideUser(user: User) {
         whenever(mockClusterStateManager.load()).thenReturn(happyState())

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/mcp/ChannelMessageBufferTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/mcp/ChannelMessageBufferTest.kt
@@ -4,26 +4,43 @@ import com.github.dockerjava.api.model.Frame
 import com.github.dockerjava.api.model.StreamType
 import com.rustyrazorblade.easydblab.output.OutputEvent
 import kotlinx.coroutines.channels.Channel
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertFalse
-import org.junit.jupiter.api.Assertions.assertNotSame
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import java.time.Duration
 import java.util.Collections
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 
+/**
+ * Tests for [ChannelMessageBuffer].
+ *
+ * The buffer runs a background consumer that drains [channel] asynchronously, so these tests
+ * synchronize on observable buffer state (via [awaitBufferSize] / [awaitUntil]) rather than fixed
+ * `Thread.sleep` calls. Polling a condition removes the wall-clock cost of worst-case sleeps while
+ * being strictly more reliable than a fixed pause.
+ */
 class ChannelMessageBufferTest {
     private lateinit var channel: Channel<OutputEvent>
     private lateinit var buffer: ChannelMessageBuffer
 
+    companion object {
+        private const val TIMESTAMP_PREFIX = "\\[\\d{2}:\\d{2}:\\d{2}\\.\\d+\\] "
+
+        // Failure ceiling only: awaitUntil returns as soon as the condition holds. Generous so a
+        // loaded CI machine never flakes; the consumer (zero poll interval here) drains in ms.
+        private val AWAIT_TIMEOUT = Duration.ofSeconds(10)
+        private const val POLL_INTERVAL_MS = 5L
+    }
+
     @BeforeEach
     fun setup() {
         channel = Channel(Channel.UNLIMITED)
-        buffer = ChannelMessageBuffer(channel)
+        // Zero poll interval so the consumer drains without the production per-message throttle;
+        // only throughput changes, not the buffering behavior under test.
+        buffer = ChannelMessageBuffer(channel, pollInterval = Duration.ZERO)
     }
 
     @AfterEach
@@ -32,20 +49,35 @@ class ChannelMessageBufferTest {
         channel.close()
     }
 
-    // Helper method to send event to channel and wait for processing
-    private fun sendEvent(event: OutputEvent) {
-        val result = channel.trySend(event)
-        assertTrue(result.isSuccess, "Failed to send event")
-        Thread.sleep(50) // Give buffer time to process
+    /** Sends an event to the channel, asserting the send succeeded. */
+    private fun send(event: OutputEvent) {
+        assertThat(channel.trySend(event).isSuccess)
+            .describedAs("send $event to channel")
+            .isTrue()
     }
+
+    /** Polls [condition] on a short interval until it holds or the timeout elapses. */
+    private fun awaitUntil(
+        description: String,
+        condition: () -> Boolean,
+    ) {
+        val deadline = System.nanoTime() + AWAIT_TIMEOUT.toNanos()
+        while (!condition() && System.nanoTime() < deadline) {
+            Thread.sleep(POLL_INTERVAL_MS)
+        }
+        assertThat(condition()).describedAs(description).isTrue()
+    }
+
+    /** Waits until the buffer has exactly [expected] messages. */
+    private fun awaitBufferSize(expected: Int) = awaitUntil("buffer size reaches $expected") { buffer.size() == expected }
 
     // ========== Construction Tests ==========
 
     @Test
     fun `constructor initializes with empty buffer`() {
-        assertTrue(buffer.isEmpty())
-        assertEquals(0, buffer.size())
-        assertTrue(buffer.getMessages().isEmpty())
+        assertThat(buffer.isEmpty()).isTrue()
+        assertThat(buffer.size()).isZero()
+        assertThat(buffer.getMessages()).isEmpty()
     }
 
     // ========== Event Processing Tests ==========
@@ -53,94 +85,99 @@ class ChannelMessageBufferTest {
     @Test
     fun `processEvent handles MessageEvent and returns true`() {
         buffer.start()
-        sendEvent(OutputEvent.MessageEvent("Test message"))
+        send(OutputEvent.MessageEvent("Test message"))
+        awaitBufferSize(1)
 
-        assertEquals(1, buffer.size())
         val messages = buffer.getMessages()
-        assertEquals(1, messages.size)
-        assertTrue(messages[0].contains("Test message"))
-        assertTrue(messages[0].matches(Regex("\\[\\d{2}:\\d{2}:\\d{2}\\.\\d+\\] .*")))
+        assertThat(messages).hasSize(1)
+        assertThat(messages[0]).contains("Test message")
+        assertThat(messages[0]).matches("$TIMESTAMP_PREFIX.*")
     }
 
     @Test
     fun `processEvent handles ErrorEvent with ERROR prefix and returns true`() {
         buffer.start()
-        sendEvent(OutputEvent.ErrorEvent("Test error"))
+        send(OutputEvent.ErrorEvent("Test error"))
+        awaitBufferSize(1)
 
-        assertEquals(1, buffer.size())
         val messages = buffer.getMessages()
-        assertEquals(1, messages.size)
-        assertTrue(messages[0].contains("ERROR: Test error"))
-        assertTrue(messages[0].matches(Regex("\\[\\d{2}:\\d{2}:\\d{2}\\.\\d+\\] ERROR: .*")))
+        assertThat(messages).hasSize(1)
+        assertThat(messages[0]).contains("ERROR: Test error")
+        assertThat(messages[0]).matches("${TIMESTAMP_PREFIX}ERROR: .*")
     }
 
     @Test
     fun `processEvent handles ErrorEvent with throwable`() {
         buffer.start()
         val exception = RuntimeException("Test exception")
-        sendEvent(OutputEvent.ErrorEvent("Error with exception", exception))
+        send(OutputEvent.ErrorEvent("Error with exception", exception))
+        awaitBufferSize(1)
 
-        assertEquals(1, buffer.size())
-        val messages = buffer.getMessages()
-        assertTrue(messages[0].contains("ERROR: Error with exception"))
+        assertThat(buffer.getMessages()[0]).contains("ERROR: Error with exception")
     }
 
     @Test
     fun `processEvent handles FrameEvent without buffering and returns true`() {
         buffer.start()
         val frame = Frame(StreamType.STDOUT, "frame content".toByteArray())
-        sendEvent(OutputEvent.FrameEvent(frame))
+        send(OutputEvent.FrameEvent(frame))
+        // The consumer processes the channel FIFO, so once the sentinel is buffered the frame ahead
+        // of it has already been processed. A frame that contributed nothing leaves size at 1.
+        send(OutputEvent.MessageEvent("sentinel"))
+        awaitBufferSize(1)
 
-        assertTrue(buffer.isEmpty())
-        assertEquals(0, buffer.size())
+        val messages = buffer.getMessages()
+        assertThat(messages).hasSize(1)
+        assertThat(messages[0]).contains("sentinel")
     }
 
     @Test
-    fun `processEvent handles CloseEvent and stops consumer`() {
+    fun `processEvent handles CloseEvent without buffering`() {
         buffer.start()
-        sendEvent(OutputEvent.CloseEvent)
-        Thread.sleep(100) // Give time for thread to stop
+        send(OutputEvent.CloseEvent)
+        // CloseEvent is not buffered; the following sentinel proves the event was consumed and
+        // added nothing to the buffer.
+        send(OutputEvent.MessageEvent("sentinel"))
+        awaitBufferSize(1)
 
-        assertTrue(buffer.isEmpty())
-        // The consumer thread should stop after CloseEvent
+        assertThat(buffer.getMessages()[0]).contains("sentinel")
     }
 
     @Test
     fun `processEvent handles multiple message types in sequence`() {
         buffer.start()
-        sendEvent(OutputEvent.MessageEvent("Info message"))
-        sendEvent(OutputEvent.ErrorEvent("Error message"))
-        sendEvent(OutputEvent.FrameEvent(Frame(StreamType.STDOUT, "frame".toByteArray())))
-        sendEvent(OutputEvent.MessageEvent("Another info"))
+        send(OutputEvent.MessageEvent("Info message"))
+        send(OutputEvent.ErrorEvent("Error message"))
+        send(OutputEvent.FrameEvent(Frame(StreamType.STDOUT, "frame".toByteArray())))
+        send(OutputEvent.MessageEvent("Another info"))
+        awaitBufferSize(3)
 
         val messages = buffer.getMessages()
-        assertEquals(3, messages.size)
-        assertTrue(messages[0].contains("Info message"))
-        assertTrue(messages[1].contains("ERROR: Error message"))
-        assertTrue(messages[2].contains("Another info"))
+        assertThat(messages[0]).contains("Info message")
+        assertThat(messages[1]).contains("ERROR: Error message")
+        assertThat(messages[2]).contains("Another info")
     }
 
     @Test
     fun `processEvent handles empty message content`() {
         buffer.start()
-        sendEvent(OutputEvent.MessageEvent(""))
-        sendEvent(OutputEvent.ErrorEvent(""))
+        send(OutputEvent.MessageEvent(""))
+        send(OutputEvent.ErrorEvent(""))
+        awaitBufferSize(2)
 
         val messages = buffer.getMessages()
-        assertEquals(2, messages.size)
-        assertTrue(messages[0].matches(Regex("\\[\\d{2}:\\d{2}:\\d{2}\\.\\d+\\] $")))
-        assertTrue(messages[1].matches(Regex("\\[\\d{2}:\\d{2}:\\d{2}\\.\\d+\\] ERROR: $")))
+        assertThat(messages[0]).matches("$TIMESTAMP_PREFIX$")
+        assertThat(messages[1]).matches("${TIMESTAMP_PREFIX}ERROR: $")
     }
 
     @Test
     fun `processEvent handles very long messages`() {
         buffer.start()
         val longMessage = "x".repeat(10000)
-        sendEvent(OutputEvent.MessageEvent(longMessage))
+        send(OutputEvent.MessageEvent(longMessage))
+        awaitBufferSize(1)
 
-        val messages = buffer.getMessages()
-        assertEquals(1, messages.size)
-        assertTrue(messages[0].contains(longMessage))
+        assertThat(buffer.getMessages()[0]).contains(longMessage)
     }
 
     // ========== Buffer Operations Tests ==========
@@ -148,76 +185,81 @@ class ChannelMessageBufferTest {
     @Test
     fun `getMessages returns copy of buffer`() {
         buffer.start()
-        sendEvent(OutputEvent.MessageEvent("Message 1"))
+        send(OutputEvent.MessageEvent("Message 1"))
+        awaitBufferSize(1)
 
         val messages1 = buffer.getMessages()
         val messages2 = buffer.getMessages()
 
-        assertEquals(messages1, messages2)
-        assertNotSame(messages1, messages2) // Different instances
+        assertThat(messages1).isEqualTo(messages2)
+        assertThat(messages1).isNotSameAs(messages2)
 
-        // Modifying returned list doesn't affect buffer
-        messages1.toMutableList().clear()
-        assertEquals(1, buffer.size())
+        // The returned list is an independent copy, so the buffer is unaffected by consumers of it.
+        assertThat(buffer.size()).isEqualTo(1)
     }
 
     @Test
     fun `clearMessages empties buffer`() {
         buffer.start()
-        sendEvent(OutputEvent.MessageEvent("Message 1"))
-        sendEvent(OutputEvent.MessageEvent("Message 2"))
+        send(OutputEvent.MessageEvent("Message 1"))
+        send(OutputEvent.MessageEvent("Message 2"))
+        awaitBufferSize(2)
 
-        assertEquals(2, buffer.size())
-        assertFalse(buffer.isEmpty())
+        assertThat(buffer.isEmpty()).isFalse()
 
         buffer.clearMessages()
 
-        assertEquals(0, buffer.size())
-        assertTrue(buffer.isEmpty())
-        assertTrue(buffer.getMessages().isEmpty())
+        assertThat(buffer.size()).isZero()
+        assertThat(buffer.isEmpty()).isTrue()
+        assertThat(buffer.getMessages()).isEmpty()
     }
 
     @Test
     fun `getAndClearMessages atomically retrieves and clears`() {
         buffer.start()
-        sendEvent(OutputEvent.MessageEvent("Message 1"))
-        sendEvent(OutputEvent.MessageEvent("Message 2"))
+        send(OutputEvent.MessageEvent("Message 1"))
+        send(OutputEvent.MessageEvent("Message 2"))
+        awaitBufferSize(2)
 
         val messages = buffer.getAndClearMessages()
 
-        assertEquals(2, messages.size)
-        assertTrue(buffer.isEmpty())
-        assertEquals(0, buffer.size())
+        assertThat(messages).hasSize(2)
+        assertThat(buffer.isEmpty()).isTrue()
+        assertThat(buffer.size()).isZero()
     }
 
     @Test
     fun `size returns correct count`() {
         buffer.start()
-        assertEquals(0, buffer.size())
+        assertThat(buffer.size()).isZero()
 
-        sendEvent(OutputEvent.MessageEvent("Message 1"))
-        assertEquals(1, buffer.size())
+        send(OutputEvent.MessageEvent("Message 1"))
+        awaitBufferSize(1)
 
-        sendEvent(OutputEvent.MessageEvent("Message 2"))
-        assertEquals(2, buffer.size())
+        send(OutputEvent.MessageEvent("Message 2"))
+        awaitBufferSize(2)
 
-        sendEvent(OutputEvent.FrameEvent(Frame(StreamType.STDOUT, "frame".toByteArray())))
-        assertEquals(2, buffer.size()) // Frame not buffered
+        // Frame is not buffered: after the sentinel is buffered (size 3), the frame ahead of it in
+        // the FIFO has already been processed and added nothing.
+        send(OutputEvent.FrameEvent(Frame(StreamType.STDOUT, "frame".toByteArray())))
+        send(OutputEvent.MessageEvent("sentinel"))
+        awaitBufferSize(3)
 
         buffer.clearMessages()
-        assertEquals(0, buffer.size())
+        assertThat(buffer.size()).isZero()
     }
 
     @Test
     fun `isEmpty returns correct state`() {
         buffer.start()
-        assertTrue(buffer.isEmpty())
+        assertThat(buffer.isEmpty()).isTrue()
 
-        sendEvent(OutputEvent.MessageEvent("Message"))
-        assertFalse(buffer.isEmpty())
+        send(OutputEvent.MessageEvent("Message"))
+        awaitBufferSize(1)
+        assertThat(buffer.isEmpty()).isFalse()
 
         buffer.clearMessages()
-        assertTrue(buffer.isEmpty())
+        assertThat(buffer.isEmpty()).isTrue()
     }
 
     // ========== Thread Safety Tests ==========
@@ -226,47 +268,42 @@ class ChannelMessageBufferTest {
     fun `concurrent operations are thread-safe`() {
         buffer.start()
         val executor = Executors.newFixedThreadPool(10)
-        val iterations = 10 // Reduced from 100
-        val expectedTotal = 10 * iterations // 100 messages total
+        val iterations = 10
+        val expectedTotal = 10 * iterations
         val latch = CountDownLatch(expectedTotal)
 
         // Submit multiple threads writing messages
         repeat(10) { threadIndex ->
             executor.submit {
                 repeat(iterations) { i ->
-                    val result = channel.trySend(OutputEvent.MessageEvent("Thread $threadIndex - Message $i"))
-                    assertTrue(result.isSuccess)
+                    assertThat(channel.trySend(OutputEvent.MessageEvent("Thread $threadIndex - Message $i")).isSuccess).isTrue()
                     latch.countDown()
                 }
             }
         }
 
-        // Wait for all operations to complete
-        assertTrue(latch.await(10, TimeUnit.SECONDS))
+        // Wait for all sends to complete
+        assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue()
         executor.shutdown()
-        assertTrue(executor.awaitTermination(1, TimeUnit.SECONDS))
+        assertThat(executor.awaitTermination(1, TimeUnit.SECONDS)).isTrue()
 
-        // Give consumer time to process all messages (100 messages * 10ms + overhead)
-        Thread.sleep(2000)
-
-        // Verify all messages were buffered
-        val messages = buffer.getMessages()
-        assertEquals(expectedTotal, messages.size)
+        // Wait for the consumer to buffer every message
+        awaitBufferSize(expectedTotal)
+        assertThat(buffer.getMessages()).hasSize(expectedTotal)
     }
 
     @Test
     fun `getAndClearMessages is atomic under concurrent access`() {
         buffer.start()
         val executor = Executors.newFixedThreadPool(10)
-        val totalMessages = 100 // Reduced from 1000
+        val totalMessages = 100
         val collectedMessages = Collections.synchronizedList(mutableListOf<String>())
 
         // Add messages
         repeat(totalMessages) { i ->
-            val result = channel.trySend(OutputEvent.MessageEvent("Message $i"))
-            assertTrue(result.isSuccess)
+            send(OutputEvent.MessageEvent("Message $i"))
         }
-        Thread.sleep(1500) // Give consumer time to process (100 messages * 10ms + overhead)
+        awaitBufferSize(totalMessages)
 
         // Multiple threads trying to get and clear
         val futures =
@@ -280,11 +317,11 @@ class ChannelMessageBufferTest {
         // Wait for all threads
         futures.forEach { it.get() }
         executor.shutdown()
-        assertTrue(executor.awaitTermination(1, TimeUnit.SECONDS))
+        assertThat(executor.awaitTermination(1, TimeUnit.SECONDS)).isTrue()
 
         // All messages should be collected exactly once
-        assertEquals(totalMessages, collectedMessages.size)
-        assertTrue(buffer.isEmpty())
+        assertThat(collectedMessages).hasSize(totalMessages)
+        assertThat(buffer.isEmpty()).isTrue()
     }
 
     // ========== Message Order Tests ==========
@@ -293,146 +330,112 @@ class ChannelMessageBufferTest {
     fun `messages preserve insertion order`() {
         buffer.start()
         repeat(50) { i ->
-            // Reduced from 100
-            sendEvent(OutputEvent.MessageEvent("Message $i"))
+            send(OutputEvent.MessageEvent("Message $i"))
         }
-        Thread.sleep(200) // Give consumer time to process all
+        awaitBufferSize(50)
 
         val messages = buffer.getMessages()
-        assertEquals(50, messages.size)
-
         messages.forEachIndexed { index, message ->
-            assertTrue(message.contains("Message $index"))
+            assertThat(message).contains("Message $index")
         }
     }
 
     @Test
     fun `messages maintain chronological timestamps`() {
         buffer.start()
-        sendEvent(OutputEvent.MessageEvent("First"))
-        Thread.sleep(10) // Small delay to ensure different timestamps
-        sendEvent(OutputEvent.MessageEvent("Second"))
-        Thread.sleep(10)
-        sendEvent(OutputEvent.MessageEvent("Third"))
+        send(OutputEvent.MessageEvent("First"))
+        send(OutputEvent.MessageEvent("Second"))
+        send(OutputEvent.MessageEvent("Third"))
+        awaitBufferSize(3)
 
         val messages = buffer.getMessages()
-        assertEquals(3, messages.size)
 
-        // Extract timestamps (format: [HH:mm:ss.SSS])
+        // Every message carries a timestamp prefix
         val timestampRegex = Regex("\\[(\\d{2}:\\d{2}:\\d{2}\\.\\d+)\\]")
-        val timestamps =
-            messages.map {
-                timestampRegex.find(it)?.groupValues?.get(1) ?: ""
-            }
+        assertThat(messages).allMatch { timestampRegex.containsMatchIn(it) }
 
-        // Verify all timestamps were extracted
-        assertTrue(timestamps.all { it.isNotEmpty() })
-
-        // Verify chronological order
-        assertTrue(messages[0].contains("First"))
-        assertTrue(messages[1].contains("Second"))
-        assertTrue(messages[2].contains("Third"))
+        // FIFO insertion order is preserved
+        assertThat(messages[0]).contains("First")
+        assertThat(messages[1]).contains("Second")
+        assertThat(messages[2]).contains("Third")
     }
 
     // ========== Edge Cases ==========
 
     @Test
     fun `processEvent continues after exceptions`() {
-        // This test verifies exception handling in processEvent
-        // Since we can't easily trigger an exception in the when block,
-        // we verify the structure handles all cases properly
-
         buffer.start()
-        sendEvent(OutputEvent.MessageEvent("Before"))
-        sendEvent(OutputEvent.MessageEvent("After"))
+        send(OutputEvent.MessageEvent("Before"))
+        send(OutputEvent.MessageEvent("After"))
+        awaitBufferSize(2)
 
-        assertEquals(2, buffer.size())
+        assertThat(buffer.size()).isEqualTo(2)
     }
 
     @Test
     fun `getAndClearMessages on empty buffer returns empty list`() {
         val messages = buffer.getAndClearMessages()
 
-        assertTrue(messages.isEmpty())
-        assertTrue(buffer.isEmpty())
+        assertThat(messages).isEmpty()
+        assertThat(buffer.isEmpty()).isTrue()
     }
 
     @Test
     fun `clearMessages on empty buffer is safe`() {
         buffer.clearMessages() // Should not throw
-        assertTrue(buffer.isEmpty())
+        assertThat(buffer.isEmpty()).isTrue()
     }
 
     @Test
     fun `high message volume is handled correctly`() {
         buffer.start()
-        val messageCount = 1000 // Reduced from 10000
+        val messageCount = 1000
         repeat(messageCount) { i ->
-            val result = channel.trySend(OutputEvent.MessageEvent("Message $i"))
-            assertTrue(result.isSuccess)
+            send(OutputEvent.MessageEvent("Message $i"))
         }
 
-        // Wait for buffer to process all messages with periodic checks
-        var waitTime = 0
-        val maxWaitTime = 15000 // 15 seconds max
-        while (buffer.size() < messageCount && waitTime < maxWaitTime) {
-            Thread.sleep(100)
-            waitTime += 100
-        }
-
-        assertEquals(messageCount, buffer.size())
-        val messages = buffer.getMessages()
-        assertEquals(messageCount, messages.size)
+        awaitBufferSize(messageCount)
+        assertThat(buffer.getMessages()).hasSize(messageCount)
     }
+
     // ========== Start/Stop Tests ==========
 
     @Test
     fun `start initiates message consumption`() {
-        // Buffer should be empty before start
-        assertTrue(buffer.isEmpty())
+        assertThat(buffer.isEmpty()).isTrue()
 
-        // Start the buffer
         buffer.start()
 
-        // Now messages should be buffered
-        sendEvent(OutputEvent.MessageEvent("After start"))
-        assertEquals(1, buffer.size())
-        assertTrue(buffer.getMessages()[0].contains("After start"))
+        send(OutputEvent.MessageEvent("After start"))
+        awaitBufferSize(1)
+        assertThat(buffer.getMessages()[0]).contains("After start")
     }
 
     @Test
     fun `stop halts message consumption`() {
         buffer.start()
 
-        // Send and verify message is buffered
-        sendEvent(OutputEvent.MessageEvent("Message 1"))
-        assertEquals(1, buffer.size())
+        send(OutputEvent.MessageEvent("Message 1"))
+        awaitBufferSize(1)
 
-        // Stop the buffer
+        // stop() joins the consumer thread, so once it returns nothing will drain the channel.
         buffer.stop()
-        Thread.sleep(100) // Give thread time to stop
-
-        // Clear existing messages
         buffer.clearMessages()
 
-        // Send message after stopping - should not be buffered
-        channel.trySend(OutputEvent.MessageEvent("After stop"))
-        Thread.sleep(100)
-        assertTrue(buffer.isEmpty())
+        send(OutputEvent.MessageEvent("After stop"))
+        assertThat(buffer.isEmpty()).isTrue()
     }
 
     @Test
-    fun `channel closure stops consumer thread`() {
+    fun `channel closure retains already-buffered messages`() {
         buffer.start()
 
-        sendEvent(OutputEvent.MessageEvent("Before close"))
-        assertEquals(1, buffer.size())
+        send(OutputEvent.MessageEvent("Before close"))
+        awaitBufferSize(1)
 
-        // Close the channel
+        // Closing the channel stops new events from arriving but does not clear the buffer.
         channel.close()
-        Thread.sleep(100) // Give thread time to detect closure
 
-        // Buffer should still have the message from before close
-        assertEquals(1, buffer.size())
+        assertThat(buffer.size()).isEqualTo(1)
     }
 }

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/services/EMRSparkServiceTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/services/EMRSparkServiceTest.kt
@@ -34,6 +34,7 @@ import software.amazon.awssdk.services.emr.model.StepCancellationOption
 import software.amazon.awssdk.services.emr.model.StepState
 import software.amazon.awssdk.services.emr.model.StepStateChangeReason
 import software.amazon.awssdk.services.emr.model.StepStatus
+import java.time.Duration
 
 /**
  * Test suite for EMRSparkService following TDD principles.
@@ -76,7 +77,19 @@ class EMRSparkServiceTest : BaseKoinTest() {
                 single<ObjectStore> { mockObjectStore }
                 single<ClusterStateManager> { mockClusterStateManager }
                 single<VictoriaLogsService> { mockVictoriaLogsService }
-                factory<SparkService> { EMRSparkService(get(), get(), get(), get(), get()) }
+                // Zero delays so job-polling tests do not sit through the production poll interval
+                // or log-ingestion wait; only timing changes, not the behavior under test.
+                factory<SparkService> {
+                    EMRSparkService(
+                        get(),
+                        get(),
+                        get(),
+                        get(),
+                        get(),
+                        pollInterval = Duration.ZERO,
+                        logIngestionWait = Duration.ZERO,
+                    )
+                }
             },
         )
 

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/services/TailscaleServiceTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/services/TailscaleServiceTest.kt
@@ -15,6 +15,7 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import java.time.Duration
 
 /**
  * Test suite for TailscaleService.
@@ -41,7 +42,9 @@ class TailscaleServiceTest : BaseKoinTest() {
         listOf(
             module {
                 single<RemoteOperationsService> { mockRemoteOps }
-                factory<TailscaleService> { DefaultTailscaleService(get(), get()) }
+                // Zero daemon startup delay so startTailscale tests do not sit through the
+                // production pause; only timing changes, not the behavior under test.
+                factory<TailscaleService> { DefaultTailscaleService(get(), get(), daemonStartupDelay = Duration.ZERO) }
             },
         )
 

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/services/VictoriaBackupServiceTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/services/VictoriaBackupServiceTest.kt
@@ -19,6 +19,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.reset
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import java.time.Duration
 
 /**
  * Test suite for VictoriaBackupService.
@@ -57,7 +58,8 @@ class VictoriaBackupServiceTest : BaseKoinTest() {
             module {
                 single<K8sService> { mockK8sService }
                 factory<VictoriaBackupService> {
-                    DefaultVictoriaBackupService(get(), get())
+                    // Zero poll interval so the job-wait loop does not sleep between mock polls.
+                    DefaultVictoriaBackupService(get(), get(), jobPollInterval = Duration.ZERO)
                 }
             },
         )

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/services/aws/AMIValidationServiceTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/services/aws/AMIValidationServiceTest.kt
@@ -18,6 +18,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import software.amazon.awssdk.services.ec2.Ec2Client
 import software.amazon.awssdk.services.ec2.model.Ec2Exception
+import java.time.Duration
 import java.time.Instant
 
 class AMIValidationServiceTest {
@@ -44,6 +45,10 @@ class AMIValidationServiceTest {
                     ec2Client = mockEc2Client,
                     eventBus = eventBus,
                     aws = mockAWS,
+                    // Zero backoff so the retry-path tests do not sit through the production
+                    // 2s/4s/8s wall-clock backoff; the retry predicate (which decides what to
+                    // retry) is identical to production, only the wait is removed.
+                    validationRetryConfig = AMIService.buildValidationRetryConfig(Duration.ZERO),
                 ),
             )
     }


### PR DESCRIPTION
Closes #754.

Fixed `Thread.sleep`/backoff waits in production code forced the unit tier to sit through
real wall-clock delays. They're now **constructor-injected as `java.time.Duration`, defaulted
to the current `Constants` values** — production timing is byte-for-byte unchanged; tests pass
`Duration.ZERO`.

## Result — unit tier ~106s → ~38s
| Suite | Before | After |
|---|---|---|
| UpTest | 75.7s | 1.0s |
| EMRSparkServiceTest | 38.4s | 3.3s |
| ChannelMessageBufferTest | 21.1s | 0.5s |
| AMIValidationServiceTest | 9.6s | 3.0s |
| TailscaleServiceTest | 6.2s | 0.1s |

The remaining ~38s is fork/Koin-startup across 267 suites — no longer sleep-bound.

## Injection pattern
Each delay is a constructor param defaulting to its existing `Constants` value, so Koin/production
wiring keeps today's timing. `Constants.kt` is **not** touched. AMIService's resilience4j retry
backoff is now built via `buildValidationRetryConfig(baseBackoff)` (same predicate/attempts);
tests use a zero backoff.

## One judgment call for your review
Beyond the five offenders in the issue, I also injected the **`ChannelMessageBuffer` consumer
poll** (`Constants.Time.THREAD_SLEEP_DELAY_MS`, 10ms/msg — the 1000-message test alone cost
~10s). It's the same "hardcoded production `Thread.sleep` a test sits through" the issue targets,
and speeding it up honestly required injecting that delay rather than shrinking the test (kept at
1000 messages). If you'd rather keep this PR strictly to the five, say so and I'll pull it — the
38s tier time is unchanged either way (it wasn't on the critical path).

Production defaults verified unchanged; all 2242 unit tests + ktlintCheck + detekt green;
integrationTest sources compile.