### PR TITLE
fix(ci): pin cassandra-image base to a cqlsh-compatible Python + gate smoke test

### DIFF
--- a/.github/cassandra-image/Dockerfile
+++ b/.github/cassandra-image/Dockerfile
@@ -11,12 +11,17 @@
 # cassandra-branch-publish for the rationale (design decision D0).
 #
 # Build args:
-#   BASE_IMAGE     runtime JRE base image (default eclipse-temurin:17-jre).
+#   BASE_IMAGE     runtime JRE base image (default eclipse-temurin:17-jre-noble).
 #                  The workflow overrides this per resolved Cassandra version.
+#                  Pinned to a specific Ubuntu LTS variant (never the floating
+#                  `-jre` tag) so the apt-provided python3 stays inside cqlsh's
+#                  supported Python range — the floating tag drifted to Python
+#                  3.14 and broke cqlsh (issue #764). noble ships Python 3.12,
+#                  which is in the 3.6-3.13 range cqlsh 5.0+ supports.
 #   TARBALL        path (relative to build context) to the
 #                  apache-cassandra-<version>-bin.tar.gz to inject.
 
-ARG BASE_IMAGE=eclipse-temurin:17-jre
+ARG BASE_IMAGE=eclipse-temurin:17-jre-noble
 
 FROM ${BASE_IMAGE}
 

--- a/.github/cassandra-image/resolve-build-plan.sh
+++ b/.github/cassandra-image/resolve-build-plan.sh
@@ -48,11 +48,24 @@ compute_build_plan() {
   #           -Duse.jdk11=true to compile under 11 (matches cassandra_versions.yaml).
   #   5.0  -> JDK 17; no extra ant flags.
   #   5.1+/trunk (no tag yet) -> JDK 21; no extra ant flags.
+  #
+  # Each base image is pinned to a SPECIFIC Ubuntu LTS variant (never the floating
+  # `-jre` tag) whose apt-provided python3 is INSIDE that Cassandra major's
+  # cqlsh-supported Python range. cqlsh enforces the range with a sys.version_info
+  # check in bin/cqlsh.py; picking an out-of-range Python makes cqlsh die with
+  # "No appropriate Python interpreter found" (issue #764). Ranges (from source):
+  #   4.0/4.1: guard is only 3.6+ (lower bound), BUT cqlsh relies on the driver's
+  #            stdlib `asyncore` reactor with no `pyasyncore` backport, and Python
+  #            3.12 removed stdlib asyncore -> cqlsh breaks above 3.11. Newest LTS
+  #            still in range: jammy (Ubuntu 22.04, Python 3.10).
+  #   5.0    : guard is 3.6-3.13 and cqlsh vendors `pyasyncore` -> noble
+  #            (Ubuntu 24.04, Python 3.12) is in range.
+  #   5.1+/trunk (6.0): guard is 3.6-3.13, same as 5.0 -> noble (Python 3.12).
   local auto_jdk auto_base ant_flags
   case "$version" in
-    4.*)  auto_jdk=11; auto_base=eclipse-temurin:11-jre; ant_flags="-Duse.jdk11=true" ;;
-    5.0*) auto_jdk=17; auto_base=eclipse-temurin:17-jre; ant_flags="" ;;
-    *)    auto_jdk=21; auto_base=eclipse-temurin:21-jre; ant_flags="" ;;
+    4.*)  auto_jdk=11; auto_base=eclipse-temurin:11-jre-jammy; ant_flags="-Duse.jdk11=true" ;;
+    5.0*) auto_jdk=17; auto_base=eclipse-temurin:17-jre-noble; ant_flags="" ;;
+    *)    auto_jdk=21; auto_base=eclipse-temurin:21-jre-noble; ant_flags="" ;;
   esac
 
   local build_jdk="${jdk_override:-$auto_jdk}"

--- a/.github/cassandra-image/resolve-build-plan.test.sh
+++ b/.github/cassandra-image/resolve-build-plan.test.sh
@@ -67,19 +67,19 @@ BASE_ENV=(VERSION=5.0.3 SHORT_SHA=abc123def456 SOURCE_REF=cassandra-5.0
 assert_field "4.x auto-maps to JDK 11" build_jdk 11 \
   VERSION=4.0.12 SHORT_SHA=deadbeef0000 SOURCE_REF=cassandra-4.0 \
   JDK_OVERRIDE= BASE_IMAGE_OVERRIDE= REPO_OWNER=o REPO_NAME=r
-assert_field "4.x auto-maps to temurin 11 base" base_image eclipse-temurin:11-jre \
+assert_field "4.x auto-maps to pinned temurin 11 jammy base" base_image eclipse-temurin:11-jre-jammy \
   VERSION=4.1.5 SHORT_SHA=deadbeef0000 SOURCE_REF=cassandra-4.1 \
   JDK_OVERRIDE= BASE_IMAGE_OVERRIDE= REPO_OWNER=o REPO_NAME=r
 assert_field "5.0 auto-maps to JDK 17" build_jdk 17 \
   VERSION=5.0.3 SHORT_SHA=deadbeef0000 SOURCE_REF=cassandra-5.0 \
   JDK_OVERRIDE= BASE_IMAGE_OVERRIDE= REPO_OWNER=o REPO_NAME=r
-assert_field "5.0 auto-maps to temurin 17 base" base_image eclipse-temurin:17-jre \
+assert_field "5.0 auto-maps to pinned temurin 17 noble base" base_image eclipse-temurin:17-jre-noble \
   VERSION=5.0.3 SHORT_SHA=deadbeef0000 SOURCE_REF=cassandra-5.0 \
   JDK_OVERRIDE= BASE_IMAGE_OVERRIDE= REPO_OWNER=o REPO_NAME=r
 assert_field "trunk (5.1) auto-maps to JDK 21" build_jdk 21 \
   VERSION=5.1 SHORT_SHA=deadbeef0000 SOURCE_REF=trunk \
   JDK_OVERRIDE= BASE_IMAGE_OVERRIDE= REPO_OWNER=o REPO_NAME=r
-assert_field "trunk auto-maps to temurin 21 base" base_image eclipse-temurin:21-jre \
+assert_field "trunk auto-maps to pinned temurin 21 noble base" base_image eclipse-temurin:21-jre-noble \
   VERSION=5.1 SHORT_SHA=deadbeef0000 SOURCE_REF=trunk \
   JDK_OVERRIDE= BASE_IMAGE_OVERRIDE= REPO_OWNER=o REPO_NAME=r
 

--- a/.github/workflows/build-cassandra-ref.yml
+++ b/.github/workflows/build-cassandra-ref.yml
@@ -194,6 +194,83 @@ jobs:
           name: cassandra-tarball
           path: .github/cassandra-image
 
+      # Build the image LOCALLY (load into the daemon, do NOT push). The smoke
+      # test below runs against this local image so that a broken image never
+      # reaches GHCR or a release — publishing only happens after it passes.
+      - name: Build image locally
+        env:
+          IMAGE_REPO: ${{ needs.resolve.outputs.image_repo }}
+          SHA_TAG: ${{ needs.resolve.outputs.sha_tag }}
+          REF_TAG: ${{ needs.resolve.outputs.ref_tag }}
+          BASE_IMAGE: ${{ needs.resolve.outputs.base_image }}
+          TARBALL_NAME: ${{ needs.resolve.outputs.tarball_name }}
+        run: |
+          set -euo pipefail
+          docker build \
+            --build-arg BASE_IMAGE="$BASE_IMAGE" \
+            --build-arg TARBALL="$TARBALL_NAME" \
+            --tag "${IMAGE_REPO}:${SHA_TAG}" \
+            --tag "${IMAGE_REPO}:${REF_TAG}" \
+            .github/cassandra-image
+
+      # Gate the publish on a real smoke test against the locally-built image.
+      # This must run BEFORE the GHCR push and the release so a broken cqlsh
+      # (issue #764) or a server that never comes up prevents publishing.
+      - name: Smoke test — image serves CQL
+        env:
+          IMAGE_REPO: ${{ needs.resolve.outputs.image_repo }}
+          SHA_TAG: ${{ needs.resolve.outputs.sha_tag }}
+        run: |
+          set -euo pipefail
+          image="${IMAGE_REPO}:${SHA_TAG}"
+          cid="$(docker run -d -p 9042:9042 "$image")"
+          trap 'docker rm -f "$cid" >/dev/null 2>&1 || true' EXIT
+
+          echo "Waiting for the native transport to report running (bounded timeout)..."
+          ready=
+          for _ in $(seq 1 60); do
+            status="$(docker exec "$cid" nodetool statusbinary 2>/dev/null || true)"
+            if [[ "$status" == *running* ]]; then
+              ready=1
+              break
+            fi
+            sleep 5
+          done
+
+          if [[ -z "$ready" ]]; then
+            echo "::error::native transport did not report 'running' within the timeout"
+            docker logs "$cid" || true
+            exit 1
+          fi
+          echo "nodetool statusbinary: running"
+
+          # Real cqlsh run. NO 2>/dev/null — cqlsh's own error (e.g. the #764
+          # "No appropriate Python interpreter found") must be visible and must
+          # fail the job. --debug surfaces the interpreter/driver details.
+          echo "Running cqlsh query (errors visible)..."
+          docker exec "$cid" cqlsh --debug \
+            -e 'SELECT release_version FROM system.local;' | tee /tmp/cql.out
+          echo "CQL query succeeded."
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Push only after the smoke test passed.
+      - name: Push image
+        env:
+          IMAGE_REPO: ${{ needs.resolve.outputs.image_repo }}
+          SHA_TAG: ${{ needs.resolve.outputs.sha_tag }}
+          REF_TAG: ${{ needs.resolve.outputs.ref_tag }}
+        run: |
+          set -euo pipefail
+          docker push "${IMAGE_REPO}:${SHA_TAG}"
+          docker push "${IMAGE_REPO}:${REF_TAG}"
+
+      # Create the release only after the smoke test passed and the image pushed.
       - name: Create per-build release with tarball
         id: release
         uses: softprops/action-gh-release@v3
@@ -214,60 +291,6 @@ jobs:
 
             These are development builds and should not be used in production.
           files: .github/cassandra-image/${{ needs.resolve.outputs.tarball_name }}
-
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push image
-        env:
-          IMAGE_REPO: ${{ needs.resolve.outputs.image_repo }}
-          SHA_TAG: ${{ needs.resolve.outputs.sha_tag }}
-          REF_TAG: ${{ needs.resolve.outputs.ref_tag }}
-          BASE_IMAGE: ${{ needs.resolve.outputs.base_image }}
-          TARBALL_NAME: ${{ needs.resolve.outputs.tarball_name }}
-        run: |
-          set -euo pipefail
-          docker build \
-            --build-arg BASE_IMAGE="$BASE_IMAGE" \
-            --build-arg TARBALL="$TARBALL_NAME" \
-            --tag "${IMAGE_REPO}:${SHA_TAG}" \
-            --tag "${IMAGE_REPO}:${REF_TAG}" \
-            .github/cassandra-image
-          docker push "${IMAGE_REPO}:${SHA_TAG}"
-          docker push "${IMAGE_REPO}:${REF_TAG}"
-
-      - name: Smoke test — image serves CQL
-        env:
-          IMAGE_REPO: ${{ needs.resolve.outputs.image_repo }}
-          SHA_TAG: ${{ needs.resolve.outputs.sha_tag }}
-        run: |
-          set -euo pipefail
-          image="${IMAGE_REPO}:${SHA_TAG}"
-          docker pull "$image"
-          cid="$(docker run -d -p 9042:9042 "$image")"
-          trap 'docker rm -f "$cid" >/dev/null 2>&1 || true' EXIT
-
-          echo "Waiting for CQL on 9042 (bounded timeout)..."
-          ready=
-          for _ in $(seq 1 60); do
-            if docker exec "$cid" cqlsh -e 'SELECT release_version FROM system.local;' >/tmp/cql.out 2>/dev/null; then
-              ready=1
-              break
-            fi
-            sleep 5
-          done
-
-          if [[ -z "$ready" ]]; then
-            echo "::error::container did not serve CQL within the timeout"
-            docker logs "$cid" || true
-            exit 1
-          fi
-          echo "CQL query succeeded:"
-          cat /tmp/cql.out
 
       - name: Write run summary
         env:


### PR DESCRIPTION
Closes #764.

## Root cause (confirmed on a real amd64 runner)
The image built `FROM` a **floating** `eclipse-temurin:{11,17,21}-jre` tag that drifted to an
Ubuntu shipping **Python 3.14**. cqlsh caps the interpreter at **3.13** (`sys.version_info`
guard), so it exited "No appropriate Python interpreter found" — shipping an unusable cqlsh in
the image **and** failing the smoke test on every otherwise-healthy build. Cassandra itself was
fine.

## Fix

**Pin each base image to a specific-OS tag whose Python is in that version's cqlsh range** (no
more floating tags):

| Cassandra | Base image | Python | Why |
|---|---|---|---|
| 4.x | `eclipse-temurin:11-jre-jammy` | 3.10 | 4.x cqlsh uses stdlib `asyncore` (removed in 3.12), vendors no backport → breaks above 3.11 |
| 5.0 | `eclipse-temurin:17-jre-noble` | 3.12 | guard `3.6–3.13`, vendors `pyasyncore` |
| 5.1+/6.0/trunk | `eclipse-temurin:21-jre-noble` | 3.12 | same `3.6–3.13` guard |

Dockerfile default `ARG BASE_IMAGE` also pinned (`17-jre-noble`).

**Smoke test hardened + reordered to actually gate:**
- Build the image locally (load, don't push) → **smoke test the local image** → only on success
  push to GHCR + create the release. (Previously it published *before* the smoke test, so a
  broken image shipped.)
- Wait on `nodetool statusbinary` (real readiness) instead of a blind CQL retry loop.
- Remove the `2>/dev/null` that hid cqlsh's real error.

## Verification (local, arm64 — the Python check is arch-independent)
- Base Python confirmed: jammy 3.10.12, noble 3.12.3.
- Rebuilt the 6.0 image with the noble pin → `cqlsh --version` → **`cqlsh 6.3.0`** (no longer the
  interpreter error); `cassandra -v` → `6.0-alpha2-SNAPSHOT`.
- `resolve-build-plan.test.sh` updated for the new pins: `testCassandraBuildPlan` (22) +
  `testCassandraResolveRef` (8) green.