### PR TITLE
fix(ci): smoke-test cqlsh against the container IP, not loopback (#768)

### DIFF
--- a/.github/workflows/build-cassandra-ref.yml
+++ b/.github/workflows/build-cassandra-ref.yml
@@ -223,8 +223,22 @@ jobs:
         run: |
           set -euo pipefail
           image="${IMAGE_REPO}:${SHA_TAG}"
-          cid="$(docker run -d -p 9042:9042 "$image")"
-          trap 'docker rm -f "$cid" >/dev/null 2>&1 || true' EXIT
+
+          # Pin Cassandra to a deterministic IP on a user-defined docker network
+          # and dial cqlsh at that same IP. The vendored docker-entrypoint.sh
+          # binds listen_address/broadcast_rpc_address to the container's own IP
+          # (never loopback), and nodetool statusbinary reports readiness against
+          # that interface — so cqlsh must connect to that IP, not 127.0.0.1
+          # (issue #768). Never bind to 0.0.0.0; pin to the node's real IP.
+          net="cass-smoke-$$"
+          cass_ip="172.28.0.10"
+          docker network create --subnet 172.28.0.0/16 "$net"
+          cid="$(docker run -d --network "$net" --ip "$cass_ip" \
+                  -e CASSANDRA_LISTEN_ADDRESS="$cass_ip" \
+                  -e CASSANDRA_RPC_ADDRESS="$cass_ip" \
+                  -e CASSANDRA_BROADCAST_RPC_ADDRESS="$cass_ip" \
+                  "$image")"
+          trap 'docker rm -f "$cid" >/dev/null 2>&1 || true; docker network rm "$net" >/dev/null 2>&1 || true' EXIT
 
           echo "Waiting for the native transport to report running (bounded timeout)..."
           ready=
@@ -247,8 +261,9 @@ jobs:
           # Real cqlsh run. NO 2>/dev/null — cqlsh's own error (e.g. the #764
           # "No appropriate Python interpreter found") must be visible and must
           # fail the job. --debug surfaces the interpreter/driver details.
+          # Dial the pinned container IP (not loopback) — see #768 above.
           echo "Running cqlsh query (errors visible)..."
-          docker exec "$cid" cqlsh --debug \
+          docker exec "$cid" cqlsh --debug "$cass_ip" 9042 \
             -e 'SELECT release_version FROM system.local;' | tee /tmp/cql.out
           echo "CQL query succeeded."
 


### PR DESCRIPTION
## Problem

The `build-cassandra-ref` smoke test fails on `cassandra-6.0`: `nodetool statusbinary` reports `running`, then cqlsh gets `ConnectionRefusedError(111)` on `127.0.0.1:9042`.

Root cause: the smoke step ran `cqlsh` with **no host arg**, so cqlsh defaulted to **127.0.0.1**. But the vendored `docker-entrypoint.sh` binds `listen_address` / `broadcast_rpc_address` to the **container's own IP** (never loopback), and `statusbinary` reports readiness against that interface. The gate was truthful; the test knocked on the wrong door.

## Fix

Match the lab's own `commands/cassandra/UpdateConfig.kt` pattern — never `0.0.0.0`, always the node's real IP:

- Run the smoke container on a per-run-unique user-defined docker network (`cass-smoke-$$`, subnet `172.28.0.0/16`) with a fixed `--ip 172.28.0.10`.
- Pin `CASSANDRA_LISTEN_ADDRESS` / `CASSANDRA_RPC_ADDRESS` / `CASSANDRA_BROADCAST_RPC_ADDRESS` to that IP.
- Dial `cqlsh --debug 172.28.0.10 9042` explicitly.
- Drop the now-dead `-p 9042:9042` host publish; the trap cleans up both container and network.

All #766 hardening preserved: `set -euo pipefail`, the bounded `statusbinary` readiness loop, `::error::` + `docker logs` on timeout, `--debug` with **no `2>/dev/null`**, and the success echo.

`actionlint` clean. Only `.github/workflows/build-cassandra-ref.yml` changed; `docker-entrypoint.sh` untouched.

Note: `workflow_dispatch` can only be triggered once the workflow is on `main`, so full end-to-end proof comes from re-dispatching the 6.0 build after merge.

Closes #768