### PR TITLE
fix(ci): quote matrix versions in build-cassandra-set (6.0 tarball name)

### DIFF
--- a/.github/workflows/build-cassandra-set.yml
+++ b/.github/workflows/build-cassandra-set.yml
@@ -38,12 +38,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # Quote every version: an unquoted 6.0 is a YAML float that GitHub
+          # Actions stringifies to "6", producing apache-cassandra-6-bin.tar.gz
+          # instead of the apache-cassandra-6.0-bin.tar.gz the versions file needs.
           - ref: cassandra-5.0
-            version: 5.0-HEAD
+            version: "5.0-HEAD"
           - ref: cassandra-6.0
-            version: 6.0
+            version: "6.0"
           - ref: trunk
-            version: trunk
+            version: "trunk"
     uses: ./.github/workflows/build-cassandra-ref.yml
     with:
       ref: ${{ matrix.ref }}


### PR DESCRIPTION
The first `build-cassandra-set` run published the 6.0 tarball as **`apache-cassandra-6-bin.tar.gz`** instead of `apache-cassandra-6.0-bin.tar.gz`. Root cause: the matrix had `version: 6.0` unquoted — a YAML float that GitHub Actions stringifies to `"6"`, so `stable_version` (and the derived tarball name) lost the `.0`. 5.0-HEAD and trunk were unaffected (non-numeric strings).

Fix: quote all three matrix `version` values. After merge I'll re-run `build-cassandra-set` and confirm `nightly/apache-cassandra-6.0-bin.tar.gz` resolves (unblocks #775).

`actionlint` clean.