### PR TITLE
feat: add Cassandra 6.0 to cassandra_versions.yaml

### DIFF
--- a/packer/cassandra/cassandra_versions.yaml
+++ b/packer/cassandra/cassandra_versions.yaml
@@ -29,6 +29,11 @@
   java: "11"
   python: "3.11.9"
 
+- version: "6.0"
+  url: https://github.com/rustyrazorblade/easy-db-lab/releases/download/nightly/apache-cassandra-6.0-bin.tar.gz
+  java: "21"
+  python: "3.11.9"
+
 - version: "trunk"
   url: https://github.com/rustyrazorblade/easy-db-lab/releases/download/nightly/apache-cassandra-trunk-bin.tar.gz
   java: "21"


### PR DESCRIPTION
Closes #775. Depended on #763/#778 — now satisfied: `nightly/apache-cassandra-6.0-bin.tar.gz` resolves (HTTP 200).

Adds the `6.0` entry (java 21, nightly tarball URL) mirroring the existing `5.0-HEAD`/`trunk` entries. The AMI build stages every version listed here, so this is also what wires 6.0 into the AMI — a rebuild picks it up.