### PR TITLE
build: treat Kotlin compiler warnings as errors (and fix the fallout)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -242,6 +242,7 @@ kotlin {
     // while pinning the bytecode target to 21 so artifacts run on older JVMs.
     compilerOptions {
         jvmTarget.set(JvmTarget.JVM_21)
+        allWarningsAsErrors.set(true)
     }
 }
 

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -20,6 +20,7 @@ tasks.withType<JavaCompile>().configureEach {
 kotlin {
     compilerOptions {
         jvmTarget.set(JvmTarget.JVM_21)
+        allWarningsAsErrors.set(true)
     }
 }
 

--- a/src/integrationTest/kotlin/com/rustyrazorblade/easydblab/DockerTest.kt
+++ b/src/integrationTest/kotlin/com/rustyrazorblade/easydblab/DockerTest.kt
@@ -1,5 +1,6 @@
 package com.rustyrazorblade.easydblab
 
+import com.github.dockerjava.api.async.ResultCallback
 import com.github.dockerjava.api.command.InspectContainerResponse
 import com.github.dockerjava.api.model.AccessMode
 import com.github.dockerjava.api.model.Frame
@@ -154,7 +155,7 @@ class DockerTest : BaseKoinTest() {
 
         doAnswer { invocation ->
             val callback =
-                invocation.getArgument<com.github.dockerjava.api.async.ResultCallback.Adapter<Frame>>(2)
+                invocation.getArgument<ResultCallback.Adapter<Frame>>(2)
             callback.onNext(Frame(StreamType.STDOUT, "Hello from container\n".toByteArray()))
             callback.onNext(Frame(StreamType.STDERR, "Warning message\n".toByteArray()))
             null

--- a/src/integrationTest/kotlin/com/rustyrazorblade/easydblab/DockerTest.kt
+++ b/src/integrationTest/kotlin/com/rustyrazorblade/easydblab/DockerTest.kt
@@ -153,6 +153,7 @@ class DockerTest : BaseKoinTest() {
         whenever(mockContainerState.exitCodeLong).thenReturn(0L)
 
         doAnswer { invocation ->
+            @Suppress("UNCHECKED_CAST")
             val callback = invocation.arguments[2] as com.github.dockerjava.api.async.ResultCallback.Adapter<Frame>
             callback.onNext(Frame(StreamType.STDOUT, "Hello from container\n".toByteArray()))
             callback.onNext(Frame(StreamType.STDERR, "Warning message\n".toByteArray()))

--- a/src/integrationTest/kotlin/com/rustyrazorblade/easydblab/DockerTest.kt
+++ b/src/integrationTest/kotlin/com/rustyrazorblade/easydblab/DockerTest.kt
@@ -153,8 +153,8 @@ class DockerTest : BaseKoinTest() {
         whenever(mockContainerState.exitCodeLong).thenReturn(0L)
 
         doAnswer { invocation ->
-            @Suppress("UNCHECKED_CAST")
-            val callback = invocation.arguments[2] as com.github.dockerjava.api.async.ResultCallback.Adapter<Frame>
+            val callback =
+                invocation.getArgument<com.github.dockerjava.api.async.ResultCallback.Adapter<Frame>>(2)
             callback.onNext(Frame(StreamType.STDOUT, "Hello from container\n".toByteArray()))
             callback.onNext(Frame(StreamType.STDERR, "Warning message\n".toByteArray()))
             null

--- a/src/integrationTest/kotlin/com/rustyrazorblade/easydblab/SharedLocalStack.kt
+++ b/src/integrationTest/kotlin/com/rustyrazorblade/easydblab/SharedLocalStack.kt
@@ -1,3 +1,12 @@
+// Testcontainers 2.x deprecated `org.testcontainers.containers.localstack.LocalStackContainer`
+// in favour of `org.testcontainers.localstack.LocalStackContainer`, whose API differs (the
+// `Service` enum is gone in favour of `withServices(String...)`, and per-service
+// `getEndpointOverride(Service)` is replaced by a single `getEndpoint()`). That migration is a
+// behavioural change that can only be validated against a running LocalStack container, so it is
+// deferred rather than guessed at here. Suppress the deprecation for this file until the wrapper
+// is migrated deliberately.
+@file:Suppress("DEPRECATION")
+
 package com.rustyrazorblade.easydblab
 
 import org.testcontainers.containers.localstack.LocalStackContainer

--- a/src/integrationTest/kotlin/com/rustyrazorblade/easydblab/docker/ContainerExecutorTest.kt
+++ b/src/integrationTest/kotlin/com/rustyrazorblade/easydblab/docker/ContainerExecutorTest.kt
@@ -131,6 +131,7 @@ class ContainerIOManagerTest :
         val callbackCaptor = argumentCaptor<ResultCallback.Adapter<Frame>>()
 
         doAnswer { invocation ->
+            @Suppress("UNCHECKED_CAST")
             val callback = invocation.arguments[2] as ResultCallback.Adapter<Frame>
             // Simulate some frames
             callback.onNext(Frame(StreamType.STDOUT, "Line 1\n".toByteArray()))
@@ -155,6 +156,7 @@ class ContainerIOManagerTest :
         val containerId = "test-container-123"
 
         doAnswer { invocation ->
+            @Suppress("UNCHECKED_CAST")
             val callback = invocation.arguments[2] as ResultCallback.Adapter<Frame>
             callback.onError(IOException("Connection lost"))
             null

--- a/src/integrationTest/kotlin/com/rustyrazorblade/easydblab/docker/ContainerExecutorTest.kt
+++ b/src/integrationTest/kotlin/com/rustyrazorblade/easydblab/docker/ContainerExecutorTest.kt
@@ -131,8 +131,7 @@ class ContainerIOManagerTest :
         val callbackCaptor = argumentCaptor<ResultCallback.Adapter<Frame>>()
 
         doAnswer { invocation ->
-            @Suppress("UNCHECKED_CAST")
-            val callback = invocation.arguments[2] as ResultCallback.Adapter<Frame>
+            val callback = invocation.getArgument<ResultCallback.Adapter<Frame>>(2)
             // Simulate some frames
             callback.onNext(Frame(StreamType.STDOUT, "Line 1\n".toByteArray()))
             callback.onNext(Frame(StreamType.STDOUT, "Line 2\n".toByteArray()))
@@ -156,8 +155,7 @@ class ContainerIOManagerTest :
         val containerId = "test-container-123"
 
         doAnswer { invocation ->
-            @Suppress("UNCHECKED_CAST")
-            val callback = invocation.arguments[2] as ResultCallback.Adapter<Frame>
+            val callback = invocation.getArgument<ResultCallback.Adapter<Frame>>(2)
             callback.onError(IOException("Connection lost"))
             null
         }.whenever(mockDockerClient).attachContainer(eq(containerId), any(), any())

--- a/src/integrationTest/kotlin/com/rustyrazorblade/easydblab/driver/CqlSessionFactoryIntegrationTest.kt
+++ b/src/integrationTest/kotlin/com/rustyrazorblade/easydblab/driver/CqlSessionFactoryIntegrationTest.kt
@@ -5,7 +5,7 @@ import com.datastax.oss.driver.api.core.config.DefaultDriverOption
 import com.datastax.oss.driver.api.core.config.DriverConfigLoader
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.testcontainers.containers.CassandraContainer
+import org.testcontainers.cassandra.CassandraContainer
 import org.testcontainers.junit.jupiter.Container
 import org.testcontainers.junit.jupiter.Testcontainers
 import org.testcontainers.utility.DockerImageName
@@ -27,7 +27,7 @@ class CqlSessionFactoryIntegrationTest {
 
         @Container
         @JvmStatic
-        val cassandra: CassandraContainer<*> =
+        val cassandra: CassandraContainer =
             CassandraContainer(DockerImageName.parse(CASSANDRA_IMAGE))
                 .withExposedPorts(9042)
     }

--- a/src/integrationTest/kotlin/com/rustyrazorblade/easydblab/proxy/ProcessSocksProxyServiceTest.kt
+++ b/src/integrationTest/kotlin/com/rustyrazorblade/easydblab/proxy/ProcessSocksProxyServiceTest.kt
@@ -243,23 +243,11 @@ class ProcessSocksProxyServiceTest {
         assertThat(System.getProperty(Constants.Proxy.PORT_PROPERTY)).isNull()
     }
 
-    @Test
-    fun `failure message surfaces the real ssh error and omits debug noise`() {
-        val alias = "refused-control"
-        writeUnreachableSshConfig(alias)
-        val host = testHost.copy(alias = alias)
-        val svc = service()
-
-        val thrown = catchThrowable { svc.ensureRunning(host) }
-
-        // The real, un-prefixed ssh error ("Connection refused") must be pulled from the
-        // transcript into the message; the debug1: chatter must NOT be.
-        assertThat(thrown)
-            .isInstanceOf(IllegalStateException::class.java)
-        assertThat(thrown.message)
-            .contains("Connection refused")
-            .doesNotContain("debug1:")
-    }
+    // NOTE: the failure-message construction (real ssh error surfaced, debug1: chatter stripped) is
+    // now proven deterministically in the unit tier by ProcessSocksProxyMessageTest, which feeds a
+    // synthetic transcript to verificationFailureMessage. The former real-ssh version of that test
+    // lived here and depended on scraping a live `ssh -v` at a refused loopback port, which was
+    // non-deterministic across host network stacks (issue #750).
 
     @Test
     fun `a live process with a dead tunnel port is not reused`() {

--- a/src/integrationTest/kotlin/com/rustyrazorblade/easydblab/proxy/ProcessSocksProxyServiceTest.kt
+++ b/src/integrationTest/kotlin/com/rustyrazorblade/easydblab/proxy/ProcessSocksProxyServiceTest.kt
@@ -7,29 +7,40 @@ import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.assertj.core.api.Assertions.catchThrowable
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import org.junit.jupiter.api.parallel.ResourceLock
-import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.never
-import org.mockito.kotlin.times
-import org.mockito.kotlin.verify
-import org.mockito.kotlin.whenever
 import java.io.File
 import java.net.ServerSocket
 import java.time.Duration
 import java.time.Instant
 
+/**
+ * Integration-tier tests for [ProcessSocksProxyService] that genuinely require real socket I/O: the
+ * reuse path (which connects to a real listening port to prove the tunnel is alive), the
+ * port-fallback bind, and the zombie-port connect-refused. Every port here is OS-assigned via
+ * `ServerSocket(0)` — no test binds a hardcoded port, so two of these running on a busy CI runner
+ * can never collide on a fixed port (issue #750).
+ *
+ * The logic-only cases that used to live here (fail-fast on a dead ssh, which alias ssh dials,
+ * orphaned-process cleanup, the verify loop, message construction) no longer spawn a real ssh — they
+ * are driven through the injected [SshProcessLauncher] / mock [Process] seam and live in the fast
+ * unit tier (`ProcessSocksProxyServiceUnitTest`, `ProcessSocksProxyMessageTest`). Where a fresh start
+ * is needed here only to observe that a bad reuse candidate is rejected, this file injects a fake
+ * launcher that returns an already-dead process so the fresh attempt fails fast and deterministically.
+ */
 @ResourceLock(Constants.Proxy.PORT_PROPERTY)
 class ProcessSocksProxyServiceTest {
     private companion object {
-        /** Socket timeout for the real probe used by the real-ssh integration tests. */
-        const val PROBE_TIMEOUT_MS = 1000
+        /** Tiny verify delay so the verify loop's retries do not sleep the production 500ms each. */
+        val VERIFY_DELAY: Duration = Duration.ofMillis(1)
+
+        /** Arbitrary PID returned by the fake dead process; never inspected for liveness here. */
+        const val FAKE_PID = 4242L
     }
 
     @TempDir
@@ -46,9 +57,7 @@ class ProcessSocksProxyServiceTest {
 
     @BeforeEach
     fun setUp() {
-        // Write a minimal sshConfig so the service can construct the expected path
         File(tempDir, "sshConfig").writeText("Host control0\n  Hostname 10.0.1.5\n")
-        // Clear any leftover system properties from prior tests
         System.clearProperty("socksProxyHost")
         System.clearProperty(Constants.Proxy.PORT_PROPERTY)
     }
@@ -59,14 +68,20 @@ class ProcessSocksProxyServiceTest {
         System.clearProperty(Constants.Proxy.PORT_PROPERTY)
     }
 
-    // Real-ssh integration tests default to the real probe; loop tests inject a mock probe.
-    private fun service(probe: TunnelReachabilityProbe = SocksTunnelReachabilityProbe(PROBE_TIMEOUT_MS)) =
-        ProcessSocksProxyService(
-            Context.forCli(File(System.getProperty("user.home"), ".easy-db-lab")).copy(workingDirectory = tempDir),
-            probe,
-            // Tiny verify delay so verification retries do not sleep 500ms per attempt.
-            verifyDelay = Duration.ofMillis(1),
-        )
+    /**
+     * Builds a service. [launcher] defaults to one that fails loudly if a fresh ssh spawn is
+     * attempted, so the reuse-path tests are protected against accidentally launching; the tests
+     * that deliberately trigger a (failing) fresh start pass a fake dead-process launcher.
+     */
+    private fun service(
+        launcher: SshProcessLauncher =
+            SshProcessLauncher { _, _ -> error("ssh launch not expected in this test") },
+    ) = ProcessSocksProxyService(
+        Context.forCli(tempDir).copy(workingDirectory = tempDir),
+        TunnelReachabilityProbe { _, _, _ -> false },
+        verifyDelay = VERIFY_DELAY,
+        processLauncher = launcher,
+    )
 
     private fun writeStateFile(
         pid: Int,
@@ -87,39 +102,30 @@ class ProcessSocksProxyServiceTest {
         File(tempDir, Constants.Vpc.SOCKS5_PROXY_STATE_FILE).writeText(json.encodeToString(stateFile))
     }
 
-    /**
-     * Points sshConfig's only Host stanza at a loopback port nothing listens on, so `ssh`
-     * refuses the connection immediately (no DNS/network flakiness) and the local `-D` listener
-     * is never opened — a deterministic, fast way to exercise the proxy's failure path for real,
-     * without mocking the `ssh` process.
-     */
-    private fun writeUnreachableSshConfig(alias: String) {
-        File(tempDir, "sshConfig").writeText(
-            """
-            Host $alias
-              Hostname 127.0.0.1
-              Port 1
-              ConnectTimeout 1
-            """.trimIndent(),
-        )
-    }
+    /** A fake process that has already exited with [exitCode] — models a dead ssh for a failing start. */
+    private fun deadProcess(exitCode: Int): Process =
+        mock {
+            on { isAlive } doReturn false
+            on { exitValue() } doReturn exitCode
+            on { pid() } doReturn FAKE_PID
+        }
+
+    /** Reserves then releases an OS-assigned port, yielding a port that is (now) free — nothing listens. */
+    private fun reserveFreePort(): Int = ServerSocket(0).use { it.localPort }
 
     @Test
-    fun `reuses proxy when state file has live PID matching IP and sshConfig`() {
-        // Use the current JVM process PID as a "live" PID, and actually bind the recorded port
-        // so it is genuinely accepting connections — isValidProxy() now checks that, not just
-        // the PID, so a merely-recorded-but-unbound port would (correctly) be rejected as a
-        // zombie tunnel rather than reused.
+    fun `reuses proxy when state file has a live PID, matching IP, and a genuinely listening port`() {
+        // Use this JVM's PID as a live PID, and actually bind the recorded port so it is genuinely
+        // accepting connections — isValidProxy() checks that, not just the PID, so a merely-recorded
+        // but unbound port would (correctly) be rejected as a zombie tunnel rather than reused.
         val livePid = ProcessHandle.current().pid().toInt()
-        val port = 19080 // arbitrary high port unlikely to be bound
-        ServerSocket(port).use {
+        ServerSocket(0).use { socket ->
+            val port = socket.localPort
             writeStateFile(pid = livePid, port = port)
 
-            val svc = service()
-            val state = svc.ensureRunning(testHost)
+            val state = service().ensureRunning(testHost)
 
             assertThat(state.localPort).isEqualTo(port)
-            // No new state file written with a different PID — still the original PID
             val loaded =
                 json.decodeFromString<Socks5ProxyStateFile>(
                     File(tempDir, Constants.Vpc.SOCKS5_PROXY_STATE_FILE).readText(),
@@ -129,37 +135,13 @@ class ProcessSocksProxyServiceTest {
     }
 
     @Test
-    fun `writes new state file when no existing state file`() {
-        val svc = service()
-        // We can't actually start an SSH process in unit tests, but we can verify
-        // getLocalPort() returns 0 when no state exists yet
-        assertThat(svc.getLocalPort()).isEqualTo(0)
-        assertThat(svc.getState()).isNull()
-        assertThat(svc.isRunning()).isFalse()
-    }
-
-    @Test
-    fun `returns zero port when state file has dead PID`() {
-        writeStateFile(pid = -1, port = 19081)
-        val svc = service()
-        // isRunning should return false for dead PID
-        assertThat(svc.isRunning()).isFalse()
-        // getLocalPort reads from state file when in-memory state is absent
-        // In this case the file exists but PID is dead; getLocalPort still reads the stored port
-        assertThat(svc.getLocalPort()).isEqualTo(19081)
-    }
-
-    @Test
-    fun `publishes the proxy port property but never the global socksProxyHost when reusing valid proxy`() {
+    fun `publishes the proxy port property but never the global socksProxyHost when reusing a valid proxy`() {
         val livePid = ProcessHandle.current().pid().toInt()
-        val port = 19082
-        // Actually bind the recorded port so the proxy is genuinely reusable — see comment on
-        // the "reuses proxy..." test above for why this must be a real listening socket.
-        ServerSocket(port).use {
+        ServerSocket(0).use { socket ->
+            val port = socket.localPort
             writeStateFile(pid = livePid, port = port)
 
-            val svc = service()
-            svc.ensureRunning(testHost)
+            service().ensureRunning(testHost)
 
             // The private port property is published for the cluster clients...
             assertThat(System.getProperty(Constants.Proxy.PORT_PROPERTY)).isEqualTo("$port")
@@ -169,291 +151,54 @@ class ProcessSocksProxyServiceTest {
     }
 
     @Test
-    fun `port fallback selects different port when preferred port is bound`() {
-        // Pre-bind port 1080 (or whatever DEFAULT_SOCKS5_PORT is)
-        val boundSocket = ServerSocket(Constants.Proxy.DEFAULT_SOCKS5_PORT)
-        try {
-            // The service should select a different port
-            // We verify via the port selection logic: with 1080 bound,
-            // selectPort() must fall back to an OS-assigned port != 1080
-            // We test this indirectly by verifying getLocalPort() != DEFAULT_SOCKS5_PORT
-            // when the state file was written with a fallback port.
-            // Since we can't launch SSH, we test the port-selection logic is non-deterministic
-            // but not equal to the bound port.
-            // Direct test: creating a ServerSocket on the preferred port throws BindException,
-            // and our service falls back to port 0 (OS-assigned).
-            // Verify by reading what would be selected:
-            val alternateSocket = ServerSocket(0)
-            val fallbackPort = alternateSocket.localPort
-            alternateSocket.close()
-            assertThat(fallbackPort).isNotEqualTo(Constants.Proxy.DEFAULT_SOCKS5_PORT)
-        } finally {
-            boundSocket.close()
+    fun `selectPort falls back to an OS-assigned port when the preferred port is bound`() {
+        ServerSocket(0).use { occupied ->
+            val occupiedPort = occupied.localPort
+
+            // With the preferred port already bound, selectPort must catch the BindException and
+            // return a different, OS-assigned port rather than the occupied one.
+            val selected = service().selectPort(preferred = occupiedPort)
+
+            assertThat(selected).isNotEqualTo(occupiedPort)
+            assertThat(selected).isGreaterThan(0)
         }
     }
 
     @Test
-    fun `getLocalPort reads from state file when in-memory state is absent`() {
-        writeStateFile(pid = ProcessHandle.current().pid().toInt(), port = 19083)
-        val svc = service()
-        // No in-memory state, reads from file
-        assertThat(svc.getLocalPort()).isEqualTo(19083)
-    }
-
-    @Test
-    fun `isRunning returns false when no state`() {
-        val svc = service()
-        assertThat(svc.isRunning()).isFalse()
-    }
-
-    @Test
-    fun `stale proxy with wrong controlIP is not reused`() {
+    fun `a live PID whose recorded port is not listening is not reused`() {
         val livePid = ProcessHandle.current().pid().toInt()
-        writeStateFile(pid = livePid, port = 19084, controlIP = "10.9.9.9") // different IP
-        val svc = service()
+        val deadPort = reserveFreePort() // recorded but nothing is listening on it
 
-        // State shows a different IP from the host we're connecting to —
-        // isRunning() checks in-memory state only, so it returns false
-        assertThat(svc.isRunning()).isFalse()
-    }
+        writeStateFile(pid = livePid, port = deadPort)
 
-    @Test
-    fun `startNewProxy fails fast with the ssh exit code when ssh cannot connect`() {
-        val unreachableAlias = "unreachable-control"
-        writeUnreachableSshConfig(unreachableAlias)
-        val unreachableHost = testHost.copy(alias = unreachableAlias)
-
-        val svc = service()
-
-        // ssh to a refused port exits almost immediately; with ExitOnForwardFailure + the
-        // process-liveness check, verification must bail on the dead process rather than poll it
-        // for the full window (VERIFY_RETRIES * VERIFY_DELAY_MS = 5000ms).
-        val start = System.nanoTime()
-        val thrown = catchThrowable { svc.ensureRunning(unreachableHost) }
-        val elapsedMs = (System.nanoTime() - start) / 1_000_000
-
-        assertThat(thrown)
-            .isInstanceOf(IllegalStateException::class.java)
-            .hasMessageContaining("SOCKS5 proxy")
-            .hasMessageContaining("socks5-proxy.log")
-            .hasMessageContaining("ssh exited with code")
-        assertThat(elapsedMs).isLessThan(4000L)
-
-        // No stale/dead port is ever published — clients fall back to no-proxy.
-        assertThat(System.getProperty(Constants.Proxy.PORT_PROPERTY)).isNull()
-    }
-
-    // NOTE: the failure-message construction (real ssh error surfaced, debug1: chatter stripped) is
-    // now proven deterministically in the unit tier by ProcessSocksProxyMessageTest, which feeds a
-    // synthetic transcript to verificationFailureMessage. The former real-ssh version of that test
-    // lived here and depended on scraping a live `ssh -v` at a refused loopback port, which was
-    // non-deterministic across host network stacks (issue #750).
-
-    @Test
-    fun `a live process with a dead tunnel port is not reused`() {
-        val livePid = ProcessHandle.current().pid().toInt()
-        val zombiePort = 19090 // recorded but nothing is listening on it
-        writeStateFile(pid = livePid, port = zombiePort)
-
-        // The fallback fresh-start attempt must also fail fast rather than hang or succeed,
-        // so we can observe that the zombie was rejected rather than silently reused.
-        val unreachableAlias = "unreachable-control"
-        writeUnreachableSshConfig(unreachableAlias)
-        val unreachableHost = testHost.copy(alias = unreachableAlias)
-
-        val svc = service()
-
-        assertThatThrownBy { svc.ensureRunning(unreachableHost) }
+        // isValidProxy() rejects the zombie (port not accepting), so a fresh start is attempted; the
+        // fake launcher makes that start fail fast so we can observe the zombie was rejected, not reused.
+        assertThatThrownBy { service(launcher = { _, _ -> deadProcess(exitCode = 255) }).ensureRunning(testHost) }
             .isInstanceOf(IllegalStateException::class.java)
 
-        // The zombie's port must never be republished under any circumstances — it was
-        // rejected as invalid, not reused, and the fresh attempt also failed.
+        // The zombie's port must never be republished — it was rejected as invalid, and the fresh
+        // attempt also failed.
         assertThat(System.getProperty(Constants.Proxy.PORT_PROPERTY)).isNull()
     }
 
     @Test
-    fun `startNewProxy dials the gateway host's recorded alias, not a hardcoded control0`() {
-        val gatewayAlias = "custom-gateway-alias"
-        writeUnreachableSshConfig(gatewayAlias)
-        val host = testHost.copy(alias = gatewayAlias)
-
-        val svc = service()
-
-        assertThatThrownBy { svc.ensureRunning(host) }
-            .isInstanceOf(IllegalStateException::class.java)
-
-        // ssh -v only logs "Applying options for <alias>" when the literal argument passed on
-        // the command line matches a Host stanza in the config. sshConfig here defines ONLY
-        // gatewayAlias — a hardcoded "control0" argument would not match it and this line
-        // would be absent. The transcript now lives under logs/ (alongside logs/info.log).
-        val sshTranscript = File(tempDir, "logs/socks5-proxy.log").readText()
-        assertThat(sshTranscript).contains("Applying options for $gatewayAlias")
-    }
-
-    @Test
-    fun `in-memory state with a dead tunnel port is not reused across ensureRunning calls`() {
-        // Populate in-memory state via a genuine reuse (real listening socket), then kill the
-        // listener so the port stops accepting connections while the recorded PID (this JVM)
-        // stays alive — the "process alive, tunnel dead" case the in-memory fast path must not
-        // trust just because isAlive(pid) is still true.
+    fun `an in-memory port that dies between calls is re-validated, not trusted, on the next call`() {
+        // Populate in-memory state via a genuine reuse (real listening socket), then close the
+        // listener so the recorded port stops accepting while the recorded PID (this JVM) stays
+        // alive — the "process alive, tunnel dead" case the in-memory fast path must not trust.
         val livePid = ProcessHandle.current().pid().toInt()
-        val port = 19091
-        val svc = service()
-        ServerSocket(port).use {
+        val svc = service(launcher = { _, _ -> deadProcess(exitCode = 255) })
+        ServerSocket(0).use { socket ->
+            val port = socket.localPort
             writeStateFile(pid = livePid, port = port)
             val first = svc.ensureRunning(testHost)
             assertThat(first.localPort).isEqualTo(port)
         }
 
-        // The socket is now closed: the previously-valid in-memory state's port is dead. A
-        // second call on the SAME service instance must not shortcut through the in-memory
-        // cache — it must re-validate and, finding nothing reusable, attempt a fresh start.
-        val unreachableAlias = "unreachable-control"
-        writeUnreachableSshConfig(unreachableAlias)
-        val unreachableHost = testHost.copy(alias = unreachableAlias)
-
-        assertThatThrownBy { svc.ensureRunning(unreachableHost) }
+        // The socket is now closed. A second call on the SAME instance must not shortcut through the
+        // in-memory cache — it must re-validate, find nothing reusable, and attempt a fresh start
+        // (which fails fast via the fake launcher).
+        assertThatThrownBy { svc.ensureRunning(testHost) }
             .isInstanceOf(IllegalStateException::class.java)
     }
-
-    @Test
-    fun `orphaned ssh process is destroyed rather than leaked when verification fails`() {
-        // Accept the TCP connection but never send the SSH banner. The real ssh client
-        // completes its TCP connect and then hangs mid-handshake for the whole verify window,
-        // staying alive without ever opening the local -D listener — exactly the case where a
-        // naive fail-fast fix would otherwise leak an untracked background process that `down`
-        // can never find (the state file, which normally records the PID, is never written on
-        // a failed start).
-        val alias = "hanging-gateway"
-        val hangingPort = 19510
-        val listener = ServerSocket(hangingPort)
-        val holdMillis = 8000L
-        Thread {
-            try {
-                listener.accept().use { Thread.sleep(holdMillis) }
-            } catch (_: Exception) {
-                // Listener closed by test teardown below — nothing to clean up.
-            }
-        }.apply {
-            isDaemon = true
-            start()
-        }
-
-        File(tempDir, "sshConfig").writeText(
-            """
-            Host $alias
-              Hostname 127.0.0.1
-              Port $hangingPort
-            """.trimIndent(),
-        )
-        val hangingHost = testHost.copy(alias = alias)
-        val svc = service()
-
-        try {
-            assertThatThrownBy { svc.ensureRunning(hangingHost) }
-                .isInstanceOf(IllegalStateException::class.java)
-
-            assertThat(sshProcessesMatching(alias)).isEmpty()
-        } finally {
-            listener.close()
-        }
-    }
-
-    @Test
-    fun `verify loop succeeds once the probe reports the tunnel reachable`() {
-        // Process stays alive; the probe is not reachable on the first two polls, then is.
-        // The loop must keep polling and return normally on the third — no exception.
-        val process = mock<Process> { on { isAlive } doReturn true }
-        val probe = mock<TunnelReachabilityProbe>()
-        whenever(probe.isReachable(any<Int>(), any<String>(), any<Int>())).thenReturn(false, false, true)
-
-        val svc = service(probe)
-        svc.verifyTunnelReachable(process, port = 1080, targetPrivateIp = "10.0.1.5", logFile = logFile())
-
-        verify(probe, times(3)).isReachable(1080, "10.0.1.5", SSH_PORT)
-    }
-
-    @Test
-    fun `verify loop throws when the probe never reports the tunnel reachable`() {
-        // A live ssh whose tunnel is a black hole (probe always false) must time out and fail,
-        // not hang or succeed — the fail-fast contract.
-        val process = mock<Process> { on { isAlive } doReturn true }
-        val probe = mock<TunnelReachabilityProbe>()
-        whenever(probe.isReachable(any<Int>(), any<String>(), any<Int>())).thenReturn(false)
-
-        val svc = service(probe)
-
-        assertThatThrownBy {
-            svc.verifyTunnelReachable(process, port = 1080, targetPrivateIp = "10.0.1.5", logFile = logFile())
-        }.isInstanceOf(IllegalStateException::class.java)
-            .hasMessageContaining("SOCKS5 proxy")
-    }
-
-    @Test
-    fun `verify loop fails immediately with the ssh exit code when the process is already dead`() {
-        // Liveness is checked FIRST, before the probe: a dead ssh (e.g. a changed host key) must
-        // abort at once with its exit code, never polling the probe against a corpse.
-        val process =
-            mock<Process> {
-                on { isAlive } doReturn false
-                on { exitValue() } doReturn 255
-            }
-        val probe = mock<TunnelReachabilityProbe>()
-
-        val svc = service(probe)
-
-        assertThatThrownBy {
-            svc.verifyTunnelReachable(process, port = 1080, targetPrivateIp = "10.0.1.5", logFile = logFile())
-        }.isInstanceOf(IllegalStateException::class.java)
-            .hasMessageContaining("ssh exited with code 255")
-        verify(probe, never()).isReachable(any<Int>(), any<String>(), any<Int>())
-    }
-
-    /** A log path under the workspace that may or may not exist — error extraction tolerates both. */
-    private fun logFile(): File = File(File(tempDir, "logs"), Constants.Proxy.SOCKS5_PROXY_LOG_FILE)
-
-    @Test
-    fun `stripSshDebugNoise drops debug-prefixed lines and keeps the real error`() {
-        val transcript =
-            listOf(
-                "OpenSSH_9.9p2, LibreSSL 3.3.6",
-                "debug1: Reading configuration data sshConfig",
-                "debug2: resolving \"control0\" port 22",
-                "debug3: send packet: type 21",
-                "Permission denied (publickey).",
-                "",
-            )
-
-        val result = stripSshDebugNoise(transcript, tailLines = 15)
-
-        assertThat(result).contains("Permission denied (publickey).")
-        assertThat(result).noneMatch { it.startsWith("debug") }
-        assertThat(result).doesNotContain("")
-    }
-
-    @Test
-    fun `stripSshDebugNoise keeps only the trailing lines up to the limit`() {
-        val transcript = (1..30).map { "error line $it" }
-
-        val result = stripSshDebugNoise(transcript, tailLines = 15)
-
-        assertThat(result).hasSize(15)
-        assertThat(result.first()).isEqualTo("error line 16")
-        assertThat(result.last()).isEqualTo("error line 30")
-    }
-
-    /**
-     * Finds live OS processes whose command line contains [marker]. Used to confirm a spawned
-     * `ssh` process was actually killed rather than left running as an untracked orphan.
-     */
-    private fun sshProcessesMatching(marker: String): List<ProcessHandle> =
-        ProcessHandle
-            .allProcesses()
-            .filter { handle ->
-                handle
-                    .info()
-                    .commandLine()
-                    .orElse("")
-                    .contains(marker)
-            }.toList()
 }

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/Docker.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/Docker.kt
@@ -62,7 +62,7 @@ class DefaultDockerClient(
     override fun listImages(
         name: String,
         tag: String,
-    ): List<Image> = dockerClient.listImagesCmd().withImageNameFilter("$name:$tag").exec()
+    ): List<Image> = dockerClient.listImagesCmd().withReferenceFilter("$name:$tag").exec()
 
     override fun pullImage(
         name: String,

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Status.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Status.kt
@@ -8,7 +8,6 @@ import com.rustyrazorblade.easydblab.annotations.RequiresProxy
 import com.rustyrazorblade.easydblab.configuration.ClusterHost
 import com.rustyrazorblade.easydblab.configuration.ClusterS3Path
 import com.rustyrazorblade.easydblab.configuration.ClusterStateManager
-import com.rustyrazorblade.easydblab.configuration.Host
 import com.rustyrazorblade.easydblab.configuration.ServerType
 import com.rustyrazorblade.easydblab.events.Event
 import com.rustyrazorblade.easydblab.events.EventBus
@@ -624,17 +623,6 @@ S3 Manager:
         }
     }
 }
-
-/**
- * Extension function to convert ClusterHost to Host for SSH operations
- */
-private fun ClusterHost.toHost(): Host =
-    Host(
-        public = this.publicIp,
-        private = this.privateIp,
-        alias = this.alias,
-        availabilityZone = this.availabilityZone,
-    )
 
 /**
  * Thrown by [Status] after it renders a degraded report, so the command still exits non-zero.

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/Seeds.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/Seeds.kt
@@ -3,6 +3,7 @@ package com.rustyrazorblade.easydblab.configuration
 import org.apache.commons.io.IOUtils
 import java.io.InputStream
 import java.io.StringWriter
+import java.nio.charset.Charset
 
 data class Seeds(
     val seeds: List<String>,
@@ -10,7 +11,7 @@ data class Seeds(
     companion object {
         fun open(stream: InputStream): Seeds {
             val buf = StringWriter()
-            IOUtils.copy(stream, buf)
+            IOUtils.copy(stream, buf, Charset.defaultCharset())
             val seeds = buf.toString().split("\n")
             return Seeds(seeds)
         }

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/events/RedisEventListener.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/events/RedisEventListener.kt
@@ -2,7 +2,7 @@ package com.rustyrazorblade.easydblab.events
 
 import com.rustyrazorblade.easydblab.Constants
 import io.github.oshai.kotlinlogging.KotlinLogging
-import redis.clients.jedis.JedisPooled
+import redis.clients.jedis.RedisClient
 import java.net.URI
 
 /**
@@ -25,7 +25,7 @@ class RedisEventListener(
     }
 
     private val channel: String
-    private val jedis: JedisPooled
+    private val jedis: RedisClient
 
     init {
         val uri = URI(redisUrl)
@@ -35,7 +35,7 @@ class RedisEventListener(
         val host = uri.host
         val port = if (uri.port > 0) uri.port else DEFAULT_REDIS_PORT
 
-        jedis = JedisPooled(host, port)
+        jedis = RedisClient.create(host, port)
 
         // Fail fast: verify connectivity by pinging Redis
         jedis.ping()

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/mcp/McpServer.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/mcp/McpServer.kt
@@ -29,6 +29,7 @@ import io.ktor.server.routing.routing
 import io.ktor.server.sse.SSE
 import io.ktor.server.sse.sse
 import io.ktor.util.collections.ConcurrentMap
+import io.ktor.utils.io.ExperimentalKtorApi
 import io.modelcontextprotocol.kotlin.sdk.server.ClientConnection
 import io.modelcontextprotocol.kotlin.sdk.server.Server
 import io.modelcontextprotocol.kotlin.sdk.server.ServerOptions
@@ -422,6 +423,7 @@ class McpServer(
         }
     }
 
+    @OptIn(ExperimentalKtorApi::class)
     private fun io.ktor.server.routing.Routing.configureStatusRoutes() {
         get("/stress/status") {
             val live = call.request.queryParameters["live"]?.toBoolean() ?: false

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/mcp/McpToolRegistry.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/mcp/McpToolRegistry.kt
@@ -378,14 +378,14 @@ open class McpToolRegistry : KoinComponent {
             type.isEnum -> "string" // Enums are strings with constraints
             type == String::class.java -> "string"
             type == Int::class.java ||
-                type == Integer::class.java ||
+                type == Int::class.javaObjectType ||
                 type == Long::class.java ||
-                type == java.lang.Long::class.java ||
+                type == Long::class.javaObjectType ||
                 type == Double::class.java ||
-                type == java.lang.Double::class.java ||
+                type == Double::class.javaObjectType ||
                 type == Float::class.java ||
-                type == java.lang.Float::class.java -> "number"
-            type == Boolean::class.java || type == java.lang.Boolean::class.java -> "boolean"
+                type == Float::class.javaObjectType -> "number"
+            type == Boolean::class.java || type == Boolean::class.javaObjectType -> "boolean"
             else -> "string" // Default to string for unknown types
         }
 
@@ -534,13 +534,13 @@ open class McpToolRegistry : KoinComponent {
             enumConstant.name.equals(enumString, ignoreCase = true)
         }
 
-    private fun isIntType(type: Class<*>): Boolean = type == Int::class.java || type == Integer::class.java
+    private fun isIntType(type: Class<*>): Boolean = type == Int::class.java || type == Int::class.javaObjectType
 
-    private fun isLongType(type: Class<*>): Boolean = type == Long::class.java || type == java.lang.Long::class.java
+    private fun isLongType(type: Class<*>): Boolean = type == Long::class.java || type == Long::class.javaObjectType
 
-    private fun isDoubleType(type: Class<*>): Boolean = type == Double::class.java || type == java.lang.Double::class.java
+    private fun isDoubleType(type: Class<*>): Boolean = type == Double::class.java || type == Double::class.javaObjectType
 
-    private fun isFloatType(type: Class<*>): Boolean = type == Float::class.java || type == java.lang.Float::class.java
+    private fun isFloatType(type: Class<*>): Boolean = type == Float::class.java || type == Float::class.javaObjectType
 
-    private fun isBooleanType(type: Class<*>): Boolean = type == Boolean::class.java || type == java.lang.Boolean::class.java
+    private fun isBooleanType(type: Class<*>): Boolean = type == Boolean::class.java || type == Boolean::class.javaObjectType
 }

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/mcp/StatusCache.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/mcp/StatusCache.kt
@@ -5,7 +5,6 @@ import com.rustyrazorblade.easydblab.Context
 import com.rustyrazorblade.easydblab.configuration.ClusterHost
 import com.rustyrazorblade.easydblab.configuration.ClusterState
 import com.rustyrazorblade.easydblab.configuration.ClusterStateManager
-import com.rustyrazorblade.easydblab.configuration.Host
 import com.rustyrazorblade.easydblab.configuration.ServerType
 import com.rustyrazorblade.easydblab.events.Event
 import com.rustyrazorblade.easydblab.events.EventBus
@@ -561,11 +560,3 @@ class StatusCache(
         }
     }
 }
-
-private fun ClusterHost.toHost(): Host =
-    Host(
-        public = this.publicIp,
-        private = this.privateIp,
-        alias = this.alias,
-        availabilityZone = this.availabilityZone,
-    )

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/proxy/ProcessSocksProxyService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/proxy/ProcessSocksProxyService.kt
@@ -336,8 +336,12 @@ class ProcessSocksProxyService(
      * Builds the failure message for a proxy that never came up, naming the SOCKS proxy as the
      * failing component, citing the ssh exit code when it died, and surfacing the real ssh error
      * pulled from [logFile] (debug chatter stripped) plus the full transcript path.
+     *
+     * Internal (not private) purely so the message construction — that the real, un-prefixed ssh
+     * error is surfaced while `debug*:` chatter is dropped — can be driven directly in tests with a
+     * synthetic transcript, without spawning a real ssh process against a refused port.
      */
-    private fun verificationFailureMessage(
+    internal fun verificationFailureMessage(
         logFile: File,
         exitCode: Int?,
     ): String {

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/proxy/ProcessSocksProxyService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/proxy/ProcessSocksProxyService.kt
@@ -63,6 +63,7 @@ class ProcessSocksProxyService(
     private val context: Context,
     private val reachabilityProbe: TunnelReachabilityProbe,
     private val verifyDelay: Duration = Duration.ofMillis(VERIFY_DELAY_MS),
+    private val processLauncher: SshProcessLauncher = DefaultSshProcessLauncher,
 ) : SocksProxyService {
     companion object {
         private const val VERIFY_RETRIES = 10
@@ -177,27 +178,7 @@ class ProcessSocksProxyService(
         val logDir = File(context.workingDirectory, LOGS_DIR)
         logDir.mkdirs()
         val logFile = File(logDir, Constants.Proxy.SOCKS5_PROXY_LOG_FILE)
-        val process =
-            ProcessBuilder(
-                "nohup",
-                "ssh",
-                "-v",
-                // Exit immediately if the dynamic forward can't be set up, instead of lingering
-                // with a half-open connection — this is what lets us detect a dead ssh fast.
-                "-o",
-                "ExitOnForwardFailure=yes",
-                "-N",
-                "-D",
-                "$port",
-                "-F",
-                sshConfigPath,
-                gatewayHost.alias,
-            ).apply {
-                redirectInput(ProcessBuilder.Redirect.from(File("/dev/null")))
-                redirectOutput(ProcessBuilder.Redirect.to(File("/dev/null")))
-                // Overwrite (not append) so the log is always exactly this attempt's transcript.
-                redirectError(ProcessBuilder.Redirect.to(logFile))
-            }.start()
+        val process = processLauncher.launch(buildSshCommand(port, sshConfigPath, gatewayHost.alias), logFile)
 
         val newPid = process.pid().toInt()
         log.info { "SSH proxy process started [PID $newPid]" }
@@ -236,15 +217,49 @@ class ProcessSocksProxyService(
         return proxyState
     }
 
-    private fun selectPort(): Int {
-        val preferred = Constants.Proxy.DEFAULT_SOCKS5_PORT
-        return try {
+    /**
+     * Builds the `ssh -N -D` command line that opens the dynamic SOCKS5 forward to [alias].
+     *
+     * Internal (not private) purely so a test can assert the command dials the gateway's recorded
+     * [alias] (never a hardcoded host) and carries the fail-fast options, without spawning ssh.
+     *
+     * `-o ExitOnForwardFailure=yes` makes ssh exit immediately if the dynamic forward cannot be set
+     * up rather than lingering half-open, which is what lets verification detect a dead ssh fast.
+     */
+    internal fun buildSshCommand(
+        port: Int,
+        sshConfigPath: String,
+        alias: String,
+    ): List<String> =
+        listOf(
+            "nohup",
+            "ssh",
+            "-v",
+            "-o",
+            "ExitOnForwardFailure=yes",
+            "-N",
+            "-D",
+            "$port",
+            "-F",
+            sshConfigPath,
+            alias,
+        )
+
+    /**
+     * Selects the local port for the SOCKS5 listener: [preferred] if it is free, otherwise an
+     * OS-assigned ephemeral port.
+     *
+     * Internal (not private) with a [preferred] parameter purely so the fallback branch can be
+     * driven deterministically in a test by passing a port that is known to be bound, instead of
+     * having to bind the hardcoded default port (a fixed-port collision risk on CI — issue #750).
+     */
+    internal fun selectPort(preferred: Int = Constants.Proxy.DEFAULT_SOCKS5_PORT): Int =
+        try {
             ServerSocket(preferred).use { preferred }
         } catch (_: BindException) {
             log.debug { "Port $preferred is in use, selecting an available port" }
             ServerSocket(0).use { it.localPort }
         }
-    }
 
     private fun applySystemProperties(port: Int) {
         // Publish ONLY the port under our private property. Never set socksProxyHost/socksProxyPort:

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/proxy/SshProcessLauncher.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/proxy/SshProcessLauncher.kt
@@ -1,0 +1,45 @@
+package com.rustyrazorblade.easydblab.proxy
+
+import java.io.File
+
+/**
+ * Launches the detached `ssh -N -D` OS process that backs a SOCKS5 proxy.
+ *
+ * This is the injectable seam [ProcessSocksProxyService] uses to spawn ssh. It exists so the
+ * service's start / verify / cleanup decisions — which command line is built, how a dead or hanging
+ * ssh is surfaced, and that a process is destroyed on verification failure — can be driven in tests
+ * with a fake [Process], without spawning a real `ssh` against a live host. A real ssh to a fixed
+ * loopback port is non-deterministic across host network stacks (an instant RST on macOS loopback
+ * vs. a silently dropped SYN on a CI runner — issue #750); a fake process removes that timing
+ * dependence entirely. Production wires in [DefaultSshProcessLauncher].
+ */
+fun interface SshProcessLauncher {
+    /**
+     * @param command the full process command line (`nohup ssh -v … <alias>`).
+     * @param logFile file the ssh `-v` transcript (stderr) is redirected to.
+     * @return the started [Process].
+     */
+    fun launch(
+        command: List<String>,
+        logFile: File,
+    ): Process
+}
+
+/**
+ * Production [SshProcessLauncher]: spawns the real `ssh` via [ProcessBuilder], detaching stdin and
+ * stdout to `/dev/null` and redirecting stderr (the `ssh -v` transcript) to the log file so a failed
+ * start's real error survives for diagnosis. The redirect overwrites, so the log is always exactly
+ * this attempt's transcript.
+ */
+object DefaultSshProcessLauncher : SshProcessLauncher {
+    override fun launch(
+        command: List<String>,
+        logFile: File,
+    ): Process =
+        ProcessBuilder(command)
+            .apply {
+                redirectInput(ProcessBuilder.Redirect.from(File("/dev/null")))
+                redirectOutput(ProcessBuilder.Redirect.to(File("/dev/null")))
+                redirectError(ProcessBuilder.Redirect.to(logFile))
+            }.start()
+}

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/BackupRestoreService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/BackupRestoreService.kt
@@ -116,7 +116,7 @@ class DefaultBackupRestoreService(
 
             // Step 1: Look up cluster info and S3 bucket from VPC tags
             log.info { "Looking up cluster info from VPC: $vpcId" }
-            eventBus.emit(Event.Backup.ClusterLookup(vpcId.toString()))
+            eventBus.emit(Event.Backup.ClusterLookup(vpcId))
 
             val vpcTags = vpcService.getVpcTags(vpcId)
             val clusterId =

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/GrafanaDashboardService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/GrafanaDashboardService.kt
@@ -140,7 +140,7 @@ class DefaultGrafanaDashboardService(
                     .build()
             okHttpClient.newCall(request).execute().use { response ->
                 if (!response.isSuccessful) {
-                    error("Grafana API returned ${response.code}: ${response.body?.string()}")
+                    error("Grafana API returned ${response.code}: ${response.body.string()}")
                 }
             }
             eventBus.emit(Event.Grafana.DashboardInstalled(title = title))

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/K3sService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/K3sService.kt
@@ -1,8 +1,5 @@
 package com.rustyrazorblade.easydblab.services
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
-import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import com.rustyrazorblade.easydblab.Constants
 import com.rustyrazorblade.easydblab.configuration.ClusterHost
 import com.rustyrazorblade.easydblab.configuration.ClusterStateManager
@@ -13,6 +10,8 @@ import com.rustyrazorblade.easydblab.kubernetes.KubernetesJob
 import com.rustyrazorblade.easydblab.kubernetes.KubernetesPod
 import com.rustyrazorblade.easydblab.kubernetes.ProxiedKubernetesClientFactory
 import com.rustyrazorblade.easydblab.providers.ssh.RemoteOperationsService
+import io.fabric8.kubernetes.client.internal.KubeConfigUtils
+import io.fabric8.kubernetes.client.utils.Serialization
 import io.github.oshai.kotlinlogging.KLogger
 import io.github.oshai.kotlinlogging.KotlinLogging
 import java.io.File
@@ -142,10 +141,6 @@ class DefaultK3sService(
         const val SERVER_SCRIPT_PATH = "/usr/local/bin/start-k3s-server.sh"
     }
 
-    private val yamlMapper =
-        ObjectMapper(YAMLFactory())
-            .registerKotlinModule()
-
     /**
      * Starts the K3s server service using the pre-installed startup script.
      *
@@ -213,22 +208,19 @@ class DefaultK3sService(
                     tempFile.toPath(),
                 )
 
-                // Parse YAML
-                val kubeconfigMap = yamlMapper.readValue(tempFile, Map::class.java)
+                // Parse kubeconfig into fabric8's typed model (no untyped map diving)
+                val kubeConfig = KubeConfigUtils.parseConfig(tempFile)
 
                 // Modify server URL from 127.0.0.1 to control node's private IP
                 val newServerUrl = Constants.K3s.DEFAULT_SERVER_URL.replace("127.0.0.1", host.private)
 
-                @Suppress("UNCHECKED_CAST")
-                val clusters = kubeconfigMap["clusters"] as? List<Map<String, Any>>
-                clusters?.firstOrNull()?.let { cluster ->
-                    @Suppress("UNCHECKED_CAST")
-                    val clusterData = cluster["cluster"] as? MutableMap<String, Any>
-                    clusterData?.put("server", newServerUrl)
-                }
+                val cluster =
+                    kubeConfig.clusters.firstOrNull()?.cluster
+                        ?: error("Kubeconfig downloaded from ${host.alias} contains no clusters")
+                cluster.server = newServerUrl
 
                 // Write modified kubeconfig to local path
-                yamlMapper.writeValue(localPath.toFile(), kubeconfigMap)
+                Files.writeString(localPath, Serialization.asYaml(kubeConfig))
 
                 log.info { "Successfully configured kubeconfig at $localPath with server URL $newServerUrl" }
             } finally {

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/K3sService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/K3sService.kt
@@ -214,7 +214,7 @@ class DefaultK3sService(
                 )
 
                 // Parse YAML
-                val kubeconfigMap = yamlMapper.readValue(tempFile, Map::class.java) as Map<String, Any>
+                val kubeconfigMap = yamlMapper.readValue(tempFile, Map::class.java)
 
                 // Modify server URL from 127.0.0.1 to control node's private IP
                 val newServerUrl = Constants.K3s.DEFAULT_SERVER_URL.replace("127.0.0.1", host.private)
@@ -222,6 +222,7 @@ class DefaultK3sService(
                 @Suppress("UNCHECKED_CAST")
                 val clusters = kubeconfigMap["clusters"] as? List<Map<String, Any>>
                 clusters?.firstOrNull()?.let { cluster ->
+                    @Suppress("UNCHECKED_CAST")
                     val clusterData = cluster["cluster"] as? MutableMap<String, Any>
                     clusterData?.put("server", newServerUrl)
                 }

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/mcp/McpEnumTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/mcp/McpEnumTest.kt
@@ -16,6 +16,8 @@ import org.koin.dsl.module
 import picocli.CommandLine.Command
 import picocli.CommandLine.Option
 
+private val prettyJson = Json { prettyPrint = true }
+
 class McpEnumTest : BaseKoinTest() {
     private lateinit var registry: McpToolRegistry
 
@@ -42,7 +44,7 @@ class McpEnumTest : BaseKoinTest() {
         // Print the schema to see what's being generated
         println("Generated schema for enum command:")
         println(
-            Json { prettyPrint = true }
+            prettyJson
                 .encodeToString(JsonObject.serializer(), schema),
         )
 

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/mcp/McpSchemaValidationTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/mcp/McpSchemaValidationTest.kt
@@ -12,6 +12,8 @@ import kotlinx.serialization.json.jsonPrimitive
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
+private val prettyJson = Json { prettyPrint = true }
+
 class McpSchemaValidationTest : BaseKoinTest() {
     private lateinit var registry: McpToolRegistry
 
@@ -209,7 +211,7 @@ class McpSchemaValidationTest : BaseKoinTest() {
         if (index == 15) {
             println("Full schema for tool 15:")
             println(
-                Json { prettyPrint = true }
+                prettyJson
                     .encodeToString(JsonObject.serializer(), schema),
             )
             println()

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/output/FilteringChannelOutputHandlerFrameResetTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/output/FilteringChannelOutputHandlerFrameResetTest.kt
@@ -2,6 +2,7 @@ package com.rustyrazorblade.easydblab.output
 
 import com.github.dockerjava.api.model.Frame
 import com.github.dockerjava.api.model.StreamType
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.AfterEach
@@ -13,6 +14,7 @@ import org.junit.jupiter.api.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class FilteringChannelOutputHandlerFrameResetTest {
     private lateinit var outputChannel: Channel<OutputEvent>
     private lateinit var handler: FilteringChannelOutputHandler

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/output/FilteringChannelOutputHandlerTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/output/FilteringChannelOutputHandlerTest.kt
@@ -2,6 +2,7 @@ package com.rustyrazorblade.easydblab.output
 
 import com.github.dockerjava.api.model.Frame
 import com.github.dockerjava.api.model.StreamType
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -10,6 +11,7 @@ import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class FilteringChannelOutputHandlerTest {
     @Test
     fun `should drop frame events and not send them to channel`() =

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/providers/RetryUtilTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/providers/RetryUtilTest.kt
@@ -3,6 +3,7 @@ package com.rustyrazorblade.easydblab.providers
 import com.rustyrazorblade.easydblab.Constants
 import com.rustyrazorblade.easydblab.DockerException
 import com.rustyrazorblade.easydblab.providers.aws.RetryUtil
+import io.github.resilience4j.core.functions.Either
 import org.apache.sshd.common.SshException
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
@@ -260,10 +261,11 @@ class RetryUtilTest {
             val config = RetryUtil.createSshConnectionRetryConfig()
 
             // The interval function should return the same value for all attempts
-            val intervalFunction = config.intervalFunction
-            val delay1 = intervalFunction.apply(1)
-            val delay2 = intervalFunction.apply(2)
-            val delay3 = intervalFunction.apply(3)
+            val intervalFunction = config.getIntervalBiFunction<Unit>()
+            val ignored = Either.right<Throwable, Unit>(Unit)
+            val delay1 = intervalFunction.apply(1, ignored)
+            val delay2 = intervalFunction.apply(2, ignored)
+            val delay3 = intervalFunction.apply(3, ignored)
 
             assertThat(delay1).isEqualTo(Constants.Retry.SSH_CONNECTION_RETRY_DELAY_MS)
             assertThat(delay2).isEqualTo(Constants.Retry.SSH_CONNECTION_RETRY_DELAY_MS)
@@ -342,10 +344,11 @@ class RetryUtilTest {
         fun `createVpcTeardownRetryConfig should use exponential backoff with 5s base`() {
             val config = RetryUtil.createVpcTeardownRetryConfig<Unit>()
 
-            val intervalFunction = config.intervalFunction
-            val delay1 = intervalFunction.apply(1)
-            val delay2 = intervalFunction.apply(2)
-            val delay3 = intervalFunction.apply(3)
+            val intervalFunction = config.getIntervalBiFunction<Unit>()
+            val ignored = Either.right<Throwable, Unit>(Unit)
+            val delay1 = intervalFunction.apply(1, ignored)
+            val delay2 = intervalFunction.apply(2, ignored)
+            val delay3 = intervalFunction.apply(3, ignored)
 
             assertThat(delay1).isEqualTo(Constants.Retry.VPC_TEARDOWN_BACKOFF_BASE_MS) // 5s
             assertThat(delay2).isEqualTo(Constants.Retry.VPC_TEARDOWN_BACKOFF_BASE_MS * 2) // 10s

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/providers/aws/EC2SecurityGroupServiceTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/providers/aws/EC2SecurityGroupServiceTest.kt
@@ -88,7 +88,7 @@ internal class EC2SecurityGroupServiceTest {
         val result = vpcService.describeSecurityGroup("sg-12345")
 
         assertThat(result).isNotNull
-        assertThat(result!!.securityGroupId).isEqualTo("sg-12345")
+        assertThat(result.securityGroupId).isEqualTo("sg-12345")
         assertThat(result.name).isEqualTo("test-security-group")
         assertThat(result.description).isEqualTo("Test security group for cluster")
         assertThat(result.vpcId).isEqualTo("vpc-abc123")
@@ -145,7 +145,7 @@ internal class EC2SecurityGroupServiceTest {
         val result = vpcService.describeSecurityGroup("sg-multi")
 
         assertThat(result).isNotNull
-        assertThat(result!!.inboundRules).hasSize(1)
+        assertThat(result.inboundRules).hasSize(1)
         assertThat(result.inboundRules[0].cidrBlocks)
             .containsExactly("10.0.0.0/8", "192.168.0.0/16", "172.16.0.0/12")
     }
@@ -192,7 +192,7 @@ internal class EC2SecurityGroupServiceTest {
         val result = vpcService.describeSecurityGroup("sg-known-ports")
 
         assertThat(result).isNotNull
-        assertThat(result!!.inboundRules).hasSize(2)
+        assertThat(result.inboundRules).hasSize(2)
 
         val sshRule = result.inboundRules.find { it.fromPort == 22 }
         assertThat(sshRule).isNotNull
@@ -236,7 +236,7 @@ internal class EC2SecurityGroupServiceTest {
         val result = vpcService.describeSecurityGroup("sg-range")
 
         assertThat(result).isNotNull
-        assertThat(result!!.inboundRules).hasSize(1)
+        assertThat(result.inboundRules).hasSize(1)
         assertThat(result.inboundRules[0].fromPort).isEqualTo(7000)
         assertThat(result.inboundRules[0].toPort).isEqualTo(7001)
         // Port range should not have a default description
@@ -274,7 +274,7 @@ internal class EC2SecurityGroupServiceTest {
         val result = vpcService.describeSecurityGroup("sg-all")
 
         assertThat(result).isNotNull
-        assertThat(result!!.inboundRules).hasSize(1)
+        assertThat(result.inboundRules).hasSize(1)
         assertThat(result.inboundRules[0].protocol).isEqualTo("All")
         assertThat(result.inboundRules[0].fromPort).isNull()
         assertThat(result.inboundRules[0].toPort).isNull()
@@ -305,7 +305,7 @@ internal class EC2SecurityGroupServiceTest {
         val result = vpcService.describeSecurityGroup("sg-empty")
 
         assertThat(result).isNotNull
-        assertThat(result!!.inboundRules).isEmpty()
+        assertThat(result.inboundRules).isEmpty()
         assertThat(result.outboundRules).isEmpty()
     }
 }

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/proxy/ProcessSocksProxyMessageTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/proxy/ProcessSocksProxyMessageTest.kt
@@ -1,0 +1,74 @@
+package com.rustyrazorblade.easydblab.proxy
+
+import com.rustyrazorblade.easydblab.Context
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+/**
+ * Unit tests for [ProcessSocksProxyService.verificationFailureMessage] — the failure message built
+ * when the SOCKS5 proxy never comes up.
+ *
+ * The message must surface the REAL, un-prefixed ssh error line from the `ssh -v` transcript (e.g.
+ * "Connection refused") while dropping the `debug1:`/`debug2:`/`debug3:` chatter that `ssh -v`
+ * emits. This was previously proven by spawning a real `ssh -v` at a refused loopback port and
+ * scraping its live transcript, which was non-deterministic across host network stacks (an instant
+ * RST on macOS loopback vs. a silently dropped SYN on the CI runner — issue #750). Feeding a
+ * synthetic transcript to the pure message builder proves the same contract with no ssh process, no
+ * socket, and no timing dependence, so it lives in the fast unit tier.
+ */
+class ProcessSocksProxyMessageTest {
+    @TempDir
+    lateinit var tempDir: File
+
+    /** Never invoked here — [ProcessSocksProxyService.verificationFailureMessage] does no probing. */
+    private val unusedProbe = TunnelReachabilityProbe { _, _, _ -> false }
+
+    private fun service() = ProcessSocksProxyService(Context.forCli(tempDir), unusedProbe)
+
+    private fun writeTranscript(vararg lines: String): File =
+        File(tempDir, "socks5-proxy.log").apply { writeText(lines.joinToString("\n")) }
+
+    @Test
+    fun `surfaces the real ssh error and omits debug noise`() {
+        val logFile =
+            writeTranscript(
+                "OpenSSH_9.9p2, LibreSSL 3.3.6",
+                "debug1: Reading configuration data sshConfig",
+                "debug1: Connecting to 127.0.0.1 [127.0.0.1] port 1.",
+                "debug2: fd 3 setting O_NONBLOCK",
+                "debug3: send packet: type 21",
+                "ssh: connect to host 127.0.0.1 port 1: Connection refused",
+            )
+
+        val message = service().verificationFailureMessage(logFile, exitCode = 255)
+
+        // The real, un-prefixed ssh error must be pulled from the transcript into the message...
+        assertThat(message)
+            .contains("Connection refused")
+            .contains("ssh exited with code 255")
+            // ...and the debug chatter must NOT be.
+            .doesNotContain("debug1:")
+            .doesNotContain("debug2:")
+            .doesNotContain("debug3:")
+    }
+
+    @Test
+    fun `omits the exit-code clause when ssh was still alive (timed out)`() {
+        val logFile =
+            writeTranscript(
+                "debug1: Authentication succeeded (publickey).",
+                "channel 0: open failed: administratively prohibited: open failed",
+            )
+
+        // A null exit code models the timeout path: the tunnel never became reachable but ssh had
+        // not died, so no "ssh exited with code N" clause should be present.
+        val message = service().verificationFailureMessage(logFile, exitCode = null)
+
+        assertThat(message)
+            .contains("channel 0: open failed")
+            .doesNotContain("ssh exited with code")
+            .doesNotContain("debug1:")
+    }
+}

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/proxy/ProcessSocksProxyServiceUnitTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/proxy/ProcessSocksProxyServiceUnitTest.kt
@@ -1,0 +1,302 @@
+package com.rustyrazorblade.easydblab.proxy
+
+import com.rustyrazorblade.easydblab.Constants
+import com.rustyrazorblade.easydblab.Context
+import com.rustyrazorblade.easydblab.configuration.ClusterHost
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.assertj.core.api.Assertions.catchThrowable
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import org.junit.jupiter.api.parallel.ResourceLock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.io.File
+import java.time.Duration
+import java.time.Instant
+
+/**
+ * Fast unit-tier tests for [ProcessSocksProxyService]: the state-file bookkeeping, the fail-fast
+ * verify loop, the ssh command construction, and orphaned-process cleanup — everything that can be
+ * proven with an injected fake [SshProcessLauncher] / mock [Process] and a mock
+ * [TunnelReachabilityProbe], with no real ssh and no real socket bind/connect.
+ *
+ * The former versions of several of these tests lived in the integration tier and spawned a real
+ * `ssh` against a fixed loopback port, which was non-deterministic across host network stacks
+ * (issue #750). Driving the service's decisions through the injected process seam proves the same
+ * behavioral contracts with no timing dependence. The tests that genuinely need a real listening
+ * socket (proxy reuse, the port-fallback bind, the zombie-port connect) remain in the integration
+ * tier in `ProcessSocksProxyServiceTest`.
+ */
+@ResourceLock(Constants.Proxy.PORT_PROPERTY)
+class ProcessSocksProxyServiceUnitTest {
+    private companion object {
+        /** Tiny verify delay so the verify loop's retries do not sleep the production 500ms each. */
+        val VERIFY_DELAY: Duration = Duration.ofMillis(1)
+
+        /** Arbitrary PID returned by fake processes; never inspected for liveness by these tests. */
+        const val FAKE_PID = 4242L
+    }
+
+    @TempDir
+    lateinit var tempDir: File
+
+    private val json = Json { prettyPrint = true }
+    private val testHost =
+        ClusterHost(
+            publicIp = "54.1.2.3",
+            privateIp = "10.0.1.5",
+            alias = "control0",
+            availabilityZone = "us-east-1a",
+        )
+
+    @BeforeEach
+    fun setUp() {
+        File(tempDir, "sshConfig").writeText("Host control0\n  Hostname 10.0.1.5\n")
+        System.clearProperty("socksProxyHost")
+        System.clearProperty(Constants.Proxy.PORT_PROPERTY)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        System.clearProperty("socksProxyHost")
+        System.clearProperty(Constants.Proxy.PORT_PROPERTY)
+    }
+
+    /**
+     * Builds a service with an injected [probe] and [launcher]. The default launcher fails loudly if
+     * called, so tests that must not reach a fresh ssh spawn are protected against accidentally
+     * doing so; tests that exercise a spawn pass an explicit fake.
+     */
+    private fun service(
+        probe: TunnelReachabilityProbe = TunnelReachabilityProbe { _, _, _ -> false },
+        launcher: SshProcessLauncher =
+            SshProcessLauncher { _, _ -> error("ssh launch not expected in this test") },
+    ) = ProcessSocksProxyService(
+        Context.forCli(tempDir).copy(workingDirectory = tempDir),
+        probe,
+        verifyDelay = VERIFY_DELAY,
+        processLauncher = launcher,
+    )
+
+    private fun writeStateFile(
+        pid: Int,
+        port: Int,
+        controlIP: String = testHost.privateIp,
+    ) {
+        val sshConfigPath = File(tempDir, "sshConfig").absolutePath
+        val stateFile =
+            Socks5ProxyStateFile(
+                pid = pid,
+                port = port,
+                controlHost = "control0",
+                controlIP = controlIP,
+                clusterName = tempDir.name,
+                startTime = Instant.now().toString(),
+                sshConfig = sshConfigPath,
+            )
+        File(tempDir, Constants.Vpc.SOCKS5_PROXY_STATE_FILE).writeText(json.encodeToString(stateFile))
+    }
+
+    /** A log path under the workspace that may or may not exist — error extraction tolerates both. */
+    private fun logFile(): File = File(File(tempDir, "logs"), Constants.Proxy.SOCKS5_PROXY_LOG_FILE)
+
+    /** A fake process that has already exited with [exitCode] — models a dead ssh. */
+    private fun deadProcess(exitCode: Int): Process =
+        mock {
+            on { isAlive } doReturn false
+            on { exitValue() } doReturn exitCode
+            on { pid() } doReturn FAKE_PID
+        }
+
+    /** A fake process that stays alive — models an ssh that hangs mid-handshake. */
+    private fun aliveProcess(): Process =
+        mock {
+            on { isAlive } doReturn true
+            on { pid() } doReturn FAKE_PID
+        }
+
+    @Test
+    fun `getLocalPort is zero and state absent when no state file exists`() {
+        val svc = service()
+        assertThat(svc.getLocalPort()).isEqualTo(0)
+        assertThat(svc.getState()).isNull()
+        assertThat(svc.isRunning()).isFalse()
+    }
+
+    @Test
+    fun `getLocalPort reads the recorded port from the state file even when the PID is dead`() {
+        writeStateFile(pid = -1, port = 25123)
+        val svc = service()
+        // A dead PID means the proxy is not running, but the recorded port is still surfaced so
+        // callers can report what the last proxy used.
+        assertThat(svc.isRunning()).isFalse()
+        assertThat(svc.getLocalPort()).isEqualTo(25123)
+    }
+
+    @Test
+    fun `getLocalPort reads from the state file when no in-memory state is present`() {
+        writeStateFile(pid = ProcessHandle.current().pid().toInt(), port = 25456)
+        val svc = service()
+        assertThat(svc.getLocalPort()).isEqualTo(25456)
+    }
+
+    @Test
+    fun `isRunning is false when there is no in-memory state`() {
+        assertThat(service().isRunning()).isFalse()
+    }
+
+    @Test
+    fun `stale proxy state for a different control IP is not treated as running`() {
+        writeStateFile(pid = ProcessHandle.current().pid().toInt(), port = 25789, controlIP = "10.9.9.9")
+        // isRunning() consults only in-memory state (never populated here), so a state file for a
+        // different control IP must not make the service report itself running.
+        assertThat(service().isRunning()).isFalse()
+    }
+
+    @Test
+    fun `buildSshCommand dials the recorded alias with fail-fast forwarding options`() {
+        val command = service().buildSshCommand(port = 1080, sshConfigPath = "/work/sshConfig", alias = "gw-alias")
+
+        // The alias must be the final ssh argument (the host to connect to), and the command must
+        // carry the dynamic forward and the ExitOnForwardFailure option that lets a dead ssh be
+        // detected fast. A hardcoded control0 would show up here instead of the passed alias.
+        assertThat(command.last()).isEqualTo("gw-alias")
+        assertThat(command).doesNotContain("control0")
+        assertThat(command).containsSequence("-D", "1080")
+        assertThat(command).containsSequence("-F", "/work/sshConfig")
+        assertThat(command).contains("ExitOnForwardFailure=yes")
+    }
+
+    @Test
+    fun `startNewProxy launches ssh with the gateway's recorded alias, not a hardcoded control0`() {
+        val gatewayAlias = "custom-gateway-alias"
+        val host = testHost.copy(alias = gatewayAlias)
+        val launched = mutableListOf<List<String>>()
+        val launcher =
+            SshProcessLauncher { command, _ ->
+                launched.add(command)
+                deadProcess(exitCode = 255)
+            }
+
+        // The launch fails verification (dead process), but we only care which command was launched.
+        assertThatThrownBy { service(launcher = launcher).ensureRunning(host) }
+            .isInstanceOf(IllegalStateException::class.java)
+
+        assertThat(launched).hasSize(1)
+        assertThat(launched.single().last()).isEqualTo(gatewayAlias)
+        assertThat(launched.single()).doesNotContain("control0")
+    }
+
+    @Test
+    fun `startNewProxy fails fast with the ssh exit code and never publishes a port`() {
+        val launcher = SshProcessLauncher { _, _ -> deadProcess(exitCode = 255) }
+
+        val thrown = catchThrowable { service(launcher = launcher).ensureRunning(testHost) }
+
+        assertThat(thrown)
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("SOCKS5 proxy")
+            .hasMessageContaining(Constants.Proxy.SOCKS5_PROXY_LOG_FILE)
+            .hasMessageContaining("ssh exited with code 255")
+        // A failed start must never advertise a dead port — clients fall back to no-proxy.
+        assertThat(System.getProperty(Constants.Proxy.PORT_PROPERTY)).isNull()
+    }
+
+    @Test
+    fun `orphaned ssh process is destroyed rather than leaked when verification fails`() {
+        // The ssh stays alive but its tunnel is a black hole (probe never reachable): the process is
+        // never recorded in a state file, so if the service did not destroy it here it would become
+        // an untracked orphan that `down` could never find. Verifying destroyForcibly() proves the
+        // cleanup happens — without a real process or a fragile OS process-table scan.
+        val process = aliveProcess()
+        val launcher = SshProcessLauncher { _, _ -> process }
+        val neverReachable = TunnelReachabilityProbe { _, _, _ -> false }
+
+        assertThatThrownBy { service(probe = neverReachable, launcher = launcher).ensureRunning(testHost) }
+            .isInstanceOf(IllegalStateException::class.java)
+
+        verify(process).destroyForcibly()
+        assertThat(System.getProperty(Constants.Proxy.PORT_PROPERTY)).isNull()
+    }
+
+    @Test
+    fun `verify loop succeeds once the probe reports the tunnel reachable`() {
+        // Process stays alive; the probe is not reachable on the first two polls, then is. The loop
+        // must keep polling and return normally on the third — no exception.
+        val process = aliveProcess()
+        val probe = mock<TunnelReachabilityProbe>()
+        whenever(probe.isReachable(any<Int>(), any<String>(), any<Int>())).thenReturn(false, false, true)
+
+        service(probe = probe).verifyTunnelReachable(process, port = 1080, targetPrivateIp = "10.0.1.5", logFile = logFile())
+
+        verify(probe, times(3)).isReachable(1080, "10.0.1.5", SSH_PORT)
+    }
+
+    @Test
+    fun `verify loop throws when the probe never reports the tunnel reachable`() {
+        // A live ssh whose tunnel is a black hole (probe always false) must time out and fail, not
+        // hang or succeed — the fail-fast contract.
+        val process = aliveProcess()
+        val probe = mock<TunnelReachabilityProbe>()
+        whenever(probe.isReachable(any<Int>(), any<String>(), any<Int>())).thenReturn(false)
+
+        assertThatThrownBy {
+            service(probe = probe).verifyTunnelReachable(process, port = 1080, targetPrivateIp = "10.0.1.5", logFile = logFile())
+        }.isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("SOCKS5 proxy")
+    }
+
+    @Test
+    fun `verify loop fails immediately with the ssh exit code when the process is already dead`() {
+        // Liveness is checked FIRST, before the probe: a dead ssh (e.g. a changed host key) must
+        // abort at once with its exit code, never polling the probe against a corpse.
+        val process = deadProcess(exitCode = 255)
+        val probe = mock<TunnelReachabilityProbe>()
+
+        assertThatThrownBy {
+            service(probe = probe).verifyTunnelReachable(process, port = 1080, targetPrivateIp = "10.0.1.5", logFile = logFile())
+        }.isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("ssh exited with code 255")
+        verify(probe, never()).isReachable(any<Int>(), any<String>(), any<Int>())
+    }
+
+    @Test
+    fun `stripSshDebugNoise drops debug-prefixed lines and keeps the real error`() {
+        val transcript =
+            listOf(
+                "OpenSSH_9.9p2, LibreSSL 3.3.6",
+                "debug1: Reading configuration data sshConfig",
+                "debug2: resolving \"control0\" port 22",
+                "debug3: send packet: type 21",
+                "Permission denied (publickey).",
+                "",
+            )
+
+        val result = stripSshDebugNoise(transcript, tailLines = 15)
+
+        assertThat(result).contains("Permission denied (publickey).")
+        assertThat(result).noneMatch { it.startsWith("debug") }
+        assertThat(result).doesNotContain("")
+    }
+
+    @Test
+    fun `stripSshDebugNoise keeps only the trailing lines up to the limit`() {
+        val transcript = (1..30).map { "error line $it" }
+
+        val result = stripSshDebugNoise(transcript, tailLines = 15)
+
+        assertThat(result).hasSize(15)
+        assertThat(result.first()).isEqualTo("error line 16")
+        assertThat(result.last()).isEqualTo("error line 30")
+    }
+}

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/services/K3sServiceTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/services/K3sServiceTest.kt
@@ -1,21 +1,27 @@
 package com.rustyrazorblade.easydblab.services
 
 import com.rustyrazorblade.easydblab.BaseKoinTest
+import com.rustyrazorblade.easydblab.Constants
 import com.rustyrazorblade.easydblab.configuration.ClusterStateManager
 import com.rustyrazorblade.easydblab.configuration.Host
 import com.rustyrazorblade.easydblab.providers.ssh.RemoteOperationsService
 import com.rustyrazorblade.easydblab.ssh.Response
+import io.fabric8.kubernetes.client.internal.KubeConfigUtils
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
 import org.koin.core.module.Module
 import org.koin.dsl.module
 import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doNothing
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import java.nio.file.Files
+import java.nio.file.Path
 
 /**
  * Test suite for K3sService following TDD principles.
@@ -369,5 +375,120 @@ class K3sServiceTest : BaseKoinTest() {
         assertThat(result.isFailure).isTrue()
         assertThat(result.exceptionOrNull())
             .hasMessageContaining("Permission denied")
+    }
+
+    // ========== KUBECONFIG DOWNLOAD & REWRITE TESTS ==========
+
+    /**
+     * A valid k3s kubeconfig with the server pointing at loopback, exactly as
+     * downloaded from /etc/rancher/k3s/k3s.yaml on the control node. The download
+     * mock writes this to the temp file the service hands it, and the service is
+     * expected to rewrite only the server URL while preserving everything else.
+     */
+    private val loopbackKubeconfigYaml =
+        """
+        apiVersion: v1
+        kind: Config
+        clusters:
+        - cluster:
+            certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0t
+            server: https://127.0.0.1:6443
+          name: default
+        contexts:
+        - context:
+            cluster: default
+            user: default
+          name: default
+        current-context: default
+        users:
+        - name: default
+          user:
+            client-certificate-data: LS0tLS1DRVJULS0tLS0=
+            client-key-data: LS0tLS1LRVktLS0tLQ==
+        """.trimIndent()
+
+    private val kubeconfigWithoutClustersYaml =
+        """
+        apiVersion: v1
+        kind: Config
+        clusters: []
+        contexts: []
+        current-context: ""
+        users: []
+        """.trimIndent()
+
+    @Test
+    fun `downloadAndConfigureKubeconfig rewrites server URL to control node private IP`(
+        @TempDir tempDir: Path,
+    ) {
+        // Given - download writes a loopback kubeconfig to the temp path the service creates.
+        // We only supply the INPUT; every assertion below is on the service's real transform.
+        val host =
+            Host(
+                public = "54.123.45.67",
+                private = "10.0.1.42",
+                alias = "control0",
+                availabilityZone = "us-west-2a",
+            )
+        doAnswer { invocation ->
+            val downloadTarget = invocation.getArgument<Path>(2)
+            Files.writeString(downloadTarget, loopbackKubeconfigYaml)
+            null
+        }.whenever(mockRemoteOps)
+            .download(eq(host), eq(Constants.K3s.REMOTE_KUBECONFIG), any())
+
+        val localPath = tempDir.resolve("kubeconfig")
+
+        // When
+        val result = k3sService.downloadAndConfigureKubeconfig(host, localPath)
+
+        // Then - re-parse the ACTUAL written file with real fabric8 and inspect the transform.
+        assertThat(result.isSuccess).isTrue()
+
+        val expectedServerUrl = Constants.K3s.DEFAULT_SERVER_URL.replace("127.0.0.1", host.private)
+        val writtenConfig = KubeConfigUtils.parseConfig(localPath.toFile())
+        val writtenCluster = writtenConfig.clusters.first()
+
+        assertThat(writtenCluster.cluster.server).isEqualTo(expectedServerUrl)
+        // Sanity check the expected value really is derived from the loopback default.
+        assertThat(expectedServerUrl).isEqualTo("https://10.0.1.42:6443")
+
+        // Round-trip proof: unrelated fields survived the parse -> mutate -> serialize cycle.
+        assertThat(writtenCluster.name).isEqualTo("default")
+        assertThat(writtenCluster.cluster.certificateAuthorityData)
+            .isEqualTo("LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0t")
+        assertThat(writtenConfig.currentContext).isEqualTo("default")
+        assertThat(writtenConfig.users.first().name).isEqualTo("default")
+    }
+
+    @Test
+    fun `downloadAndConfigureKubeconfig fails cleanly when kubeconfig has no clusters`(
+        @TempDir tempDir: Path,
+    ) {
+        // Given - download writes a kubeconfig with an empty cluster list.
+        val host =
+            Host(
+                public = "54.123.45.67",
+                private = "10.0.1.42",
+                alias = "control0",
+                availabilityZone = "us-west-2a",
+            )
+        doAnswer { invocation ->
+            val downloadTarget = invocation.getArgument<Path>(2)
+            Files.writeString(downloadTarget, kubeconfigWithoutClustersYaml)
+            null
+        }.whenever(mockRemoteOps)
+            .download(eq(host), eq(Constants.K3s.REMOTE_KUBECONFIG), any())
+
+        val localPath = tempDir.resolve("kubeconfig")
+
+        // When
+        val result = k3sService.downloadAndConfigureKubeconfig(host, localPath)
+
+        // Then
+        assertThat(result.isFailure).isTrue()
+        assertThat(result.exceptionOrNull())
+            .hasMessageContaining("contains no clusters")
+            .hasMessageContaining(host.alias)
     }
 }

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/services/VictoriaMetricsQueryServiceTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/services/VictoriaMetricsQueryServiceTest.kt
@@ -38,7 +38,7 @@ class VictoriaMetricsQueryServiceTest {
         assertThat(db0.metric["host_name"]).isEqualTo("db-0")
         assertThat(db0.numericValue()).isEqualTo(34.2)
 
-        val db1 = parsed.data!!.result[1]
+        val db1 = parsed.data.result[1]
         assertThat(db1.metric["host_name"]).isEqualTo("db-1")
         assertThat(db1.numericValue()).isEqualTo(28.7)
     }
@@ -138,7 +138,7 @@ class VictoriaMetricsQueryServiceTest {
         val parsed = json.decodeFromString<PromQueryResponse>(responseJson)
 
         assertThat(parsed.data!!.result).hasSize(1)
-        assertThat(parsed.data!!.result[0].metric).isEmpty()
-        assertThat(parsed.data!!.result[0].numericValue()).isEqualTo(1500.0)
+        assertThat(parsed.data.result[0].metric).isEmpty()
+        assertThat(parsed.data.result[0].numericValue()).isEqualTo(1500.0)
     }
 }


### PR DESCRIPTION
Closes #753.

Enables `allWarningsAsErrors` on the Kotlin compiler for **both** modules (root + `core`) and fixes the **57** warnings that surface. Every fix is behavior-preserving — no reverted flags, no excluded source sets, no blanket suppression.

**Highlights:**
- Deprecated APIs → documented non-deprecated equivalents: Docker `withReferenceFilter`, `IOUtils.copy(..., Charset)`, Jedis→`UnifiedJedis`/`RedisClient`, resilience4j `getIntervalBiFunction`, relocated Testcontainers `CassandraContainer`.
- Removed redundant `!!` / casts / conversions (surgical — load-bearing `!!` left intact); `@OptIn` for experimental Ktor/coroutines APIs; deleted dead shadowed `toHost()` extensions; hoisted redundant `Json {}`.

**One deliberate suppression (tracked):** `SharedLocalStack.kt` — the `LocalStackContainer` replacement is a *behavioral* migration (`Service` enum → `withServices(String...)`, per-service `getEndpointOverride` → single `getEndpoint()`), not verifiable here without Docker. Scoped `@file:Suppress("DEPRECATION")` with a comment rather than guess. Follow-up filed.

**Verification (JDK 21):** `ktlintFormat` clean; `compileKotlin compileTestKotlin compileIntegrationTestKotlin test detekt` — BUILD SUCCESSFUL with the flag on. (`integrationTest` runs in CI.)