### PR TITLE
fix(packer): ARM64 k3s binary + IMDSv2 on builder instances

### DIFF
--- a/packer/base/base.pkr.hcl
+++ b/packer/base/base.pkr.hcl
@@ -88,6 +88,12 @@ source "amazon-ebs" "ubuntu" {
     }
   }
 
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 2
+  }
+
   run_tags = {
     easy_cass_lab = "1"
   }

--- a/packer/base/install/install_k3s.sh
+++ b/packer/base/install/install_k3s.sh
@@ -10,7 +10,16 @@ echo "=== Running: install_k3s.sh ==="
 
 # Determine k3s version and architecture
 K3S_VERSION="v1.35.1+k3s1"
-ARCH="amd64"
+# Detect architecture from the running system if Packer did not provide ARCH.
+# On a Graviton build the builder instance is aarch64, so uname resolves it
+# correctly even when ARCH is unset.
+if [ -z "${ARCH}" ]; then
+  case "$(uname -m)" in
+    x86_64)  ARCH="amd64" ;;
+    aarch64) ARCH="arm64" ;;
+    *) echo "Unsupported architecture: $(uname -m)"; exit 1 ;;
+  esac
+fi
 
 # Use the shared S3 download cache when present; otherwise download directly (local script
 # tests, or no cache configured).
@@ -23,10 +32,15 @@ fi
 
 echo "Downloading k3s ${K3S_VERSION} for airgap installation..."
 
-# Download k3s binary (via S3 cache)
-echo "Downloading k3s binary..."
+# Download k3s binary (via S3 cache).
+# k3s binary naming: "k3s" for amd64, "k3s-arm64" for arm64.
+K3S_BINARY="k3s"
+if [ "$ARCH" = "arm64" ]; then
+  K3S_BINARY="k3s-arm64"
+fi
+echo "Downloading k3s binary (${K3S_BINARY})..."
 cached_fetch \
-  "https://github.com/k3s-io/k3s/releases/download/${K3S_VERSION}/k3s" \
+  "https://github.com/k3s-io/k3s/releases/download/${K3S_VERSION}/${K3S_BINARY}" \
   "k3s/${K3S_VERSION}/k3s-${ARCH}" \
   /tmp/k3s
 sudo install -m 0755 /tmp/k3s /usr/local/bin/k3s

--- a/packer/cassandra/cassandra.pkr.hcl
+++ b/packer/cassandra/cassandra.pkr.hcl
@@ -93,6 +93,12 @@ source "amazon-ebs" "ubuntu" {
     }
   }
 
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 2
+  }
+
   run_tags = {
     easy_cass_lab = "1"
   }


### PR DESCRIPTION
Two small, independent packer builder fixes, both recreated on top of current `main` because the original fork branches were too far behind to rebase.

## 1. ARM64 k3s binary (recreates #771 by @michaelraney)

### Problem
`packer/base/install/install_k3s.sh` hardcoded `ARCH="amd64"` and always downloaded the amd64 k3s binary, so ARM64 (Graviton) base-AMI builds baked an amd64 k3s that can't run on aarch64.

### Fix
- Detect arch from `uname -m` when Packer doesn't set `ARCH` (`x86_64`→`amd64`, `aarch64`→`arm64`; unknown → hard fail). On a Graviton build the builder instance is aarch64, so this resolves correctly.
- Select the right k3s release asset: `k3s` for amd64, `k3s-arm64` for arm64.
- The airgap-images download already parameterizes `${ARCH}`, so it now resolves to the correct arch too.

### Validation
Base image built on `--arch arm64` — logs confirm the `k3s-arm64` binary was selected and baked (amd64 path unchanged).

## 2. IMDSv2 on builder instances (recreates #772 by @michaelraney)

### Problem
On accounts that enforce IMDSv2 (`httpTokensEnforced`), packer can't launch the builder with the default IMDSv1-permitted metadata options — it fails with `UnsupportedOperation`.

### Fix
Add `metadata_options { http_tokens = "required" }` to both the base and cassandra builders. No-op on non-enforcing accounts. The runtime cluster path (`EC2InstanceService`) already sets IMDSv2 — this closes the remaining builder-side gap so IMDSv2-enforced accounts work end-to-end.

`shellcheck --severity=error` clean; HCL valid.

Closes #771. Closes #772.