### PR TITLE
fix(packer): ARM64 arch fixes in cassandra provisioning

### DIFF
--- a/packer/cassandra/install/install_axon.sh
+++ b/packer/cassandra/install/install_axon.sh
@@ -34,15 +34,15 @@ install_axon_agent() {
     if [ -n "$file" ]; then
       echo -e "\e[32mSuccessfully downloaded ${package}:all as $file\e[0m"
     else
-      # If we couldn't find the file, fall back to amd64
-      echo -e "\e[31mPackage downloaded but file not found, falling back to amd64...\e[0m"
-      sudo apt install --download-only -y "${package}:amd64"
+      # If we couldn't find the file, fall back to the builder's native arch
+      echo -e "\e[31mPackage downloaded but file not found, falling back to native arch...\e[0m"
+      sudo apt install --download-only -y "${package}:$(dpkg --print-architecture)"
       file=$(sudo find /var/cache/apt/archives/ -name "${package}*")
     fi
   else
-    # Fall back to amd64 if 'all' is not available
-    echo "Package not available for 'all' architecture, falling back to amd64..."
-    sudo apt install --download-only -y "${package}:amd64" 
+    # Fall back to the builder's native arch if 'all' is not available
+    echo "Package not available for 'all' architecture, falling back to native arch..."
+    sudo apt install --download-only -y "${package}:$(dpkg --print-architecture)"
     file=$(sudo find /var/cache/apt/archives/ -name "${package}*")
   fi
 

--- a/packer/cassandra/install/install_cassandra.sh
+++ b/packer/cassandra/install/install_cassandra.sh
@@ -113,7 +113,7 @@ uv tool install cqlsh
 
 # used to skip the expensive checkstyle checks
 
-sudo update-java-alternatives -s java-1.11.0-openjdk-amd64 >/tmp/cassandra-setup.log 2>&1
+sudo update-java-alternatives -s "java-1.11.0-openjdk-$(dpkg --print-architecture)" >/tmp/cassandra-setup.log 2>&1
 
 lsblk
 


### PR DESCRIPTION
Hardcoded-`amd64` assumptions in the cassandra image provisioning that break ARM64/Graviton builds. Surfaced while verifying #784 on AWS. Same class as #771's k3s fix.

## Fix 1 — Java alternative (`install_cassandra.sh:116`) — Closes #785  ✅ the real arm64 blocker
Hardcoded `java-1.11.0-openjdk-amd64`; on arm64 the alternative is `-arm64`, so `update-java-alternatives` failed, the ERR trap fired, and the cassandra image build **aborted**. Now `java-1.11.0-openjdk-$(dpkg --print-architecture)`. **AWS-verified**: arm64 `build-cassandra` cleared line 116 and the image built green (`ami-0b159aca37fc68d13`).

## Fix 2 — AxonOps agent fallback (`install_axon.sh`) — latent-bug hardening
The per-version agent install had a hardcoded `${package}:amd64` fallback for agents not published as `:all`. On arm64 that would fetch a nonexistent/wrong-arch deb. Both fallback paths now use `$(dpkg --print-architecture)`.

**Honest scope note:** on the current package set this fallback is not actually exercised — every real agent (3.0, 3.11, 4.0×2, 4.1×2, 5.0 via `axon-cassandra5.0-agent-jdk17`) installs via the `:all` path. This commit is defensive hardening against a latent arm64 bug for any future per-arch agent; it does **not** fix the pre-existing tolerated `ERROR: Could not find package file for axon-cassandra5.0-agent`, which is a **stale entry** in the hardcoded `agent_versions` list (that package doesn't exist on any arch — it fails on amd64 too). That cleanup is filed as a separate arch-independent issue.

## Verification
`shellcheck --severity=error` clean on both scripts. AWS-verified via arm64 `build-cassandra` (green AMI, java-alt step passes). amd64 unaffected (derived arch is `amd64` there).

Closes #785.