### PR TITLE
fix(packer): correct AxonOps agent install + wiring for Cassandra 5.0

### DIFF
--- a/packer/cassandra/cassandra.in.sh
+++ b/packer/cassandra/cassandra.in.sh
@@ -51,9 +51,9 @@ case "$ECL_CASSANDRA_VERSION" in
         ;;
     "5.0")
         if [ "$ECL_JAVA_VERSION" = "11" ]; then
-            AXONOPS_AGENT="5.0-agent"
+            AXONOPS_AGENT="5.0-agent-jdk11"
         elif [ "$ECL_JAVA_VERSION" = "17" ]; then
-            ECL_AGENT_JAR="/usr/share/axonops/5.0-agent-jdk17/lib/axon-cassandra5.0-agent.jar"
+            AXONOPS_AGENT="5.0-agent-jdk17"
         fi
         ;;
     "5.1"|"6.0")
@@ -62,15 +62,17 @@ case "$ECL_CASSANDRA_VERSION" in
         ;;
 esac
 
-# Configure JVM_EXTRA_OPTS with agent if applicable
+# Configure JVM_EXTRA_OPTS with agent if applicable.
+# The install dir is named after the full agent version (e.g. 5.0-agent-jdk11),
+# but the jar inside is always axon-cassandra<X.Y>-agent.jar (no jdk suffix),
+# so resolve it by glob rather than assuming the name matches the directory.
 if [ -n "$AXONOPS_AGENT" ]; then
-    ECL_AGENT_JAR="/usr/share/axonops/${AXONOPS_AGENT}/lib/axon-cassandra${AXONOPS_AGENT}.jar"
-fi
-
-if [ -f "$ECL_AGENT_JAR" ]; then
-    export JVM_EXTRA_OPTS="-javaagent:${ECL_AGENT_JAR}=/etc/axonops/axon-agent.yml"
-else
-    echo "WARNING: AxonOps agent jar not found at $ECL_AGENT_JAR" >&2
+    ECL_AGENT_JAR=$(find "/usr/share/axonops/${AXONOPS_AGENT}/lib" -maxdepth 1 -name 'axon-cassandra*.jar' 2>/dev/null | head -n 1)
+    if [ -f "$ECL_AGENT_JAR" ]; then
+        export JVM_EXTRA_OPTS="-javaagent:${ECL_AGENT_JAR}=/etc/axonops/axon-agent.yml"
+    else
+        echo "WARNING: AxonOps agent jar not found for $AXONOPS_AGENT" >&2
+    fi
 fi
 
 # MAAC (Management API for Apache Cassandra) metrics agent

--- a/packer/cassandra/install/install_axon.sh
+++ b/packer/cassandra/install/install_axon.sh
@@ -10,7 +10,7 @@ sudo apt-get install -y axon-agent
 # need to add a new start script for C*
 
 # some versions have JVM specific agents
-declare -a agent_versions=("3.0-agent" "3.11-agent"  "4.0-agent-jdk8" "4.0-agent" "4.1-agent-jdk8" "4.1-agent" "5.0-agent" "5.0-agent-jdk17")
+declare -a agent_versions=("3.0-agent" "3.11-agent"  "4.0-agent-jdk8" "4.0-agent" "4.1-agent-jdk8" "4.1-agent" "5.0-agent-jdk11" "5.0-agent-jdk17")
 
 # Function to install an axon agent version
 install_axon_agent() {
@@ -71,7 +71,10 @@ install_axon_agent() {
 # download each version of the axon agent
 for agent_version in "${agent_versions[@]}"
 do
-  install_axon_agent "$agent_version"
+  install_axon_agent "$agent_version" || {
+    echo -e "\e[31mERROR: failed to install axon agent $agent_version\e[0m" >&2
+    exit 1
+  }
 done
 
 # install agent_service file included with every version since its expected


### PR DESCRIPTION
AxonOps was silently broken for Cassandra 5.0 on the lab's default JDK (11). Full diagnosis in #787 (verified against the AxonOps apt repo + by unpacking the debs — no build-looping).

## Defects fixed
1. **`install_axon.sh`** installed a **non-existent** `axon-cassandra5.0-agent` (only `-jdk11`/`-jdk17` exist) and never installed the jdk11 agent the lab needs. The install loop also **swallowed failures**. → list `5.0-agent`→`5.0-agent-jdk11`; loop now **fails loud** on any agent install error (every package in the list genuinely exists now).
2. **`cassandra.in.sh`** wired 5.0/JDK11 to that ghost package → `WARNING: agent jar not found` → **agent not attached** (the live lab default). → 5.0: java11→`5.0-agent-jdk11`, java17→`5.0-agent-jdk17`.
3. **`cassandra.in.sh:67`** built `axon-cassandra${AGENT}.jar`, assuming the jar carries the jdk suffix — but the jar inside every package is `axon-cassandra<X.Y>-agent.jar` (no suffix). → resolve the jar by **glob** against the agent's `lib` dir; also fixes the latent 4.0/4.1 jdk8 branches. Unsupported versions (5.1/6.0/trunk) now **skip cleanly** (no spurious warning).

## Verification (owner-directed)
`shellcheck --severity=error` clean on both scripts. Building the cassandra AMI (amd64) once, then a **single db-node cluster**: for each version confirm the AxonOps agent attaches (jar present, `-javaagent` set) or is cleanly skipped (6.0/trunk).

Closes #787.