### PR TITLE
packer: prune build cruft before baking the AMI

### DIFF
--- a/packer/base/base.pkr.hcl
+++ b/packer/base/base.pkr.hcl
@@ -253,6 +253,10 @@ build {
       # to the home dir before moving it to /etc/profile.d, so remove any stray copy here.
       "rm -rf /home/ubuntu/aliases.sh",
       "rm -rf /home/ubuntu/.cache /home/ubuntu/.wget-hsts /home/ubuntu/.bash_history /home/ubuntu/.m2 /home/ubuntu/.sudo_as_admin_successful /home/ubuntu/.lesshst",
+      # Discard the now-freed blocks so EBS excludes them from the snapshot (this is what
+      # actually shrinks the snapshot and cuts AMI-creation time). -av prints bytes trimmed
+      # per filesystem for verification. No `|| true`: a fstrim failure must surface.
+      "sudo fstrim -av",
     ]
   }
 }

--- a/packer/base/base.pkr.hcl
+++ b/packer/base/base.pkr.hcl
@@ -230,5 +230,30 @@ build {
   provisioner "shell" {
     script = "install/save_s3_cache.sh"
   }
+
+  # Final image cleanup: prune build cruft so it is not baked into the AMI and to shrink
+  # the EBS snapshot. This MUST run AFTER save_s3_cache.sh above (which calls apt_cache_save),
+  # otherwise the warm apt archive cache would be stripped before it is persisted to S3,
+  # slowing future builds. First we log a pre-prune inventory, then prune system caches/logs
+  # and the surgical set of home-dir build leftovers. Runtime paths (.local/cqlsh,
+  # .config/htoprc, .ssh, shell dotfiles) are deliberately left untouched.
+  provisioner "shell" {
+    inline = [
+      "echo '=== image cleanup: pre-prune inventory ==='",
+      "ls -la /home/ubuntu || true",
+      "sudo du -sh /var/cache/apt/archives /var/lib/apt/lists /tmp /var/tmp /var/log /home/ubuntu/.cache 2>/dev/null || true",
+      "df -h / || true",
+      "echo '=== image cleanup: pruning ==='",
+      # System caches and logs
+      "sudo apt-get clean",
+      "sudo rm -rf /var/cache/apt/archives/*.deb /var/lib/apt/lists/*",
+      "sudo rm -rf /tmp/* /var/tmp/*",
+      "sudo find /var/log -type f -exec truncate -s 0 {} +",
+      # Home-dir build leftovers (surgical; tolerate absence). The base build uploads aliases.sh
+      # to the home dir before moving it to /etc/profile.d, so remove any stray copy here.
+      "rm -rf /home/ubuntu/aliases.sh",
+      "rm -rf /home/ubuntu/.cache /home/ubuntu/.wget-hsts /home/ubuntu/.bash_history /home/ubuntu/.m2 /home/ubuntu/.sudo_as_admin_successful /home/ubuntu/.lesshst",
+    ]
+  }
 }
 

--- a/packer/cassandra/cassandra.pkr.hcl
+++ b/packer/cassandra/cassandra.pkr.hcl
@@ -270,6 +270,30 @@ build {
       ". /usr/local/lib/edl-cache.sh && apt_cache_save",
     ]
   }
+
+  # Final image cleanup: prune build cruft so it is not baked into the AMI and to shrink
+  # the EBS snapshot. This MUST run AFTER apt_cache_save above, otherwise the warm apt
+  # archive cache would be stripped before it is persisted to S3, slowing future builds.
+  # First we log a pre-prune inventory, then prune system caches/logs and the surgical set
+  # of home-dir build leftovers. Runtime paths (.local/cqlsh, .config/htoprc, .ssh, shell
+  # dotfiles) are deliberately left untouched.
+  provisioner "shell" {
+    inline = [
+      "echo '=== image cleanup: pre-prune inventory ==='",
+      "ls -la /home/ubuntu || true",
+      "sudo du -sh /var/cache/apt/archives /var/lib/apt/lists /tmp /var/tmp /var/log /home/ubuntu/.cache 2>/dev/null || true",
+      "df -h / || true",
+      "echo '=== image cleanup: pruning ==='",
+      # System caches and logs
+      "sudo apt-get clean",
+      "sudo rm -rf /var/cache/apt/archives/*.deb /var/lib/apt/lists/*",
+      "sudo rm -rf /tmp/* /var/tmp/*",
+      "sudo find /var/log -type f -exec truncate -s 0 {} +",
+      # Home-dir build leftovers (surgical; tolerate absence)
+      "rm -rf /home/ubuntu/cassandra /home/ubuntu/bin-cassandra /home/ubuntu/cassandra_versions.yaml /home/ubuntu/axonops-sudoers /home/ubuntu/services /home/ubuntu/aliases.sh",
+      "rm -rf /home/ubuntu/.cache /home/ubuntu/.wget-hsts /home/ubuntu/.bash_history /home/ubuntu/.m2 /home/ubuntu/.sudo_as_admin_successful /home/ubuntu/.lesshst",
+    ]
+  }
 }
 
 

--- a/packer/cassandra/cassandra.pkr.hcl
+++ b/packer/cassandra/cassandra.pkr.hcl
@@ -292,6 +292,10 @@ build {
       # Home-dir build leftovers (surgical; tolerate absence)
       "rm -rf /home/ubuntu/cassandra /home/ubuntu/bin-cassandra /home/ubuntu/cassandra_versions.yaml /home/ubuntu/axonops-sudoers /home/ubuntu/services /home/ubuntu/aliases.sh",
       "rm -rf /home/ubuntu/.cache /home/ubuntu/.wget-hsts /home/ubuntu/.bash_history /home/ubuntu/.m2 /home/ubuntu/.sudo_as_admin_successful /home/ubuntu/.lesshst",
+      # Discard the now-freed blocks so EBS excludes them from the snapshot (this is what
+      # actually shrinks the snapshot and cuts AMI-creation time). -av prints bytes trimmed
+      # per filesystem for verification. No `|| true`: a fstrim failure must surface.
+      "sudo fstrim -av",
     ]
   }
 }


### PR DESCRIPTION
Adds a final "clean image" provisioner to **both** `base.pkr.hcl` and `cassandra.pkr.hcl` that prunes build-time cruft before the AMI is baked — so it isn't shipped, and to shrink the EBS snapshot (fewer used blocks → faster AMI creation, which is where the real build time goes; the version-install loop is only ~9s, measured).

## Ordering (safe)
Runs **after** the `apt_cache_save` step in each HCL, so the warm apt archive cache is still persisted to S3 for future builds, then stripped from the shipping image.

## Removes
- **System:** `apt-get clean`, `/var/cache/apt/archives/*.deb` (incl. ~258 MB of axon agents), `/var/lib/apt/lists/*`, `/tmp/*`, `/var/tmp/*`, and truncates `/var/log/*` (structure preserved).
- **Home-dir leftovers (surgical, absence-tolerant):** `~/cassandra`, `~/bin-cassandra`, `~/cassandra_versions.yaml`, `~/axonops-sudoers`, `~/services`, `~/aliases.sh`, `~/.cache`, `~/.wget-hsts`, `~/.bash_history`, `~/.m2`, `~/.sudo_as_admin_successful`, `~/.lesshst`. (base only removes `~/aliases.sh` + the dotfile set.)

## Keeps (never touched)
`~/.local` (uv-installed **cqlsh**), `~/.config` (htoprc), `~/.ssh`, shell dotfiles. No blanket `rm -rf ~/*`.

## Diagnostic
Logs `ls -la ~` + `du -sh` of the target paths + `df -h /` **before** pruning, so the build log records exactly what was there.

## Verification
Building the cassandra AMI: the log shows the pre-prune inventory + the cleanup; confirm cqlsh/config survive and measure the image/snapshot size delta.

Closes #791.