### PR TITLE
refactor: replace inline FQNs with imports (#794)

### DIFF
--- a/core/src/main/kotlin/com/rustyrazorblade/easydblab/core/YamlDelegate.kt
+++ b/core/src/main/kotlin/com/rustyrazorblade/easydblab/core/YamlDelegate.kt
@@ -15,9 +15,9 @@ import kotlin.reflect.KProperty
 class YamlDelegate(val ignoreUnknown : Boolean = false) {
     operator fun getValue(thisRef: Any?, property: KProperty<*>) : ObjectMapper {
         if(ignoreUnknown) {
-            return com.rustyrazorblade.easydblab.core.YamlDelegate.Companion.yaml.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+            return yaml.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
         }
-        return com.rustyrazorblade.easydblab.core.YamlDelegate.Companion.yaml
+        return yaml
     }
 
     companion object {

--- a/src/integrationTest/kotlin/com/rustyrazorblade/easydblab/DockerIntegrationTest.kt
+++ b/src/integrationTest/kotlin/com/rustyrazorblade/easydblab/DockerIntegrationTest.kt
@@ -1,5 +1,7 @@
 package com.rustyrazorblade.easydblab
 
+import com.github.dockerjava.api.command.CreateContainerCmd
+import com.github.dockerjava.api.command.CreateContainerResponse
 import com.github.dockerjava.api.command.InspectContainerResponse
 import com.github.dockerjava.api.model.AccessMode
 import com.rustyrazorblade.easydblab.events.EventBus
@@ -54,7 +56,7 @@ class DockerIntegrationTest : BaseKoinTest() {
     private lateinit var mockUserIdProvider: UserIdProvider
     private lateinit var docker: Docker
     private lateinit var mockContainerCreationCommand: ContainerCreationCommand
-    private lateinit var mockContainerResponse: com.github.dockerjava.api.command.CreateContainerResponse
+    private lateinit var mockContainerResponse: CreateContainerResponse
     private lateinit var mockContainerState: InspectContainerResponse.ContainerState
     private lateinit var mockInspectContainerResponse: InspectContainerResponse
 
@@ -156,7 +158,7 @@ class DockerIntegrationTest : BaseKoinTest() {
 
     @Test
     fun `ContainerCreationCommand validates blank working directory`() {
-        val mockCreateCmd = mock<com.github.dockerjava.api.command.CreateContainerCmd>()
+        val mockCreateCmd = mock<CreateContainerCmd>()
         val command = ContainerCreationCommand(mockCreateCmd)
 
         assertThatThrownBy { command.withWorkingDir("") }

--- a/src/integrationTest/kotlin/com/rustyrazorblade/easydblab/DockerTest.kt
+++ b/src/integrationTest/kotlin/com/rustyrazorblade/easydblab/DockerTest.kt
@@ -1,6 +1,7 @@
 package com.rustyrazorblade.easydblab
 
 import com.github.dockerjava.api.async.ResultCallback
+import com.github.dockerjava.api.command.CreateContainerResponse
 import com.github.dockerjava.api.command.InspectContainerResponse
 import com.github.dockerjava.api.model.AccessMode
 import com.github.dockerjava.api.model.Frame
@@ -58,7 +59,7 @@ class DockerTest : BaseKoinTest() {
     private lateinit var mockUserIdProvider: UserIdProvider
     private lateinit var docker: Docker
     private lateinit var mockContainerCreationCommand: ContainerCreationCommand
-    private lateinit var mockContainerResponse: com.github.dockerjava.api.command.CreateContainerResponse
+    private lateinit var mockContainerResponse: CreateContainerResponse
     private lateinit var mockContainerState: InspectContainerResponse.ContainerState
     private lateinit var mockInspectContainerResponse: InspectContainerResponse
 
@@ -136,7 +137,7 @@ class DockerTest : BaseKoinTest() {
         val mockVolume = mock<VolumeMapping>()
         whenever(mockVolume.source).thenReturn("/host/path")
         whenever(mockVolume.destination).thenReturn("/container/path")
-        whenever(mockVolume.mode).thenReturn(com.github.dockerjava.api.model.AccessMode.rw)
+        whenever(mockVolume.mode).thenReturn(AccessMode.rw)
 
         whenever(mockContainerState.running).thenReturn(true).thenReturn(false)
         whenever(mockContainerState.exitCodeLong).thenReturn(0L)

--- a/src/integrationTest/kotlin/com/rustyrazorblade/easydblab/services/aws/EC2VpcServiceIntegrationTest.kt
+++ b/src/integrationTest/kotlin/com/rustyrazorblade/easydblab/services/aws/EC2VpcServiceIntegrationTest.kt
@@ -1,6 +1,7 @@
 package com.rustyrazorblade.easydblab.services.aws
 
 import com.rustyrazorblade.easydblab.SharedLocalStack
+import com.rustyrazorblade.easydblab.network.CidrBlock
 import com.rustyrazorblade.easydblab.services.aws.EC2VpcService
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -313,7 +314,7 @@ class EC2VpcServiceIntegrationTest {
 
             val existingCidrs = vpcService.listAllVpcCidrs()
             val selected =
-                com.rustyrazorblade.easydblab.network.CidrBlock
+                CidrBlock
                     .selectAvailable(existingCidrs)
 
             assertThat(existingCidrs).doesNotContain(selected.value)

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/CommandLineParser.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/CommandLineParser.kt
@@ -46,6 +46,7 @@ import com.rustyrazorblade.easydblab.services.CommandExecutor
 import com.rustyrazorblade.easydblab.services.DefaultCommandExecutor
 import com.rustyrazorblade.easydblab.services.InstallTemplateResolver
 import com.rustyrazorblade.easydblab.services.KitCommandScanner
+import com.rustyrazorblade.easydblab.services.ScannedKitCommand
 import com.rustyrazorblade.easydblab.services.TemplateVariables
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.koin.core.component.KoinComponent
@@ -172,7 +173,7 @@ class CommandLineParser : KoinComponent {
         }
 
     /** Kit commands discovered via classpath scan, grouped by kit name. Evaluated once. */
-    private val kitCommandsByKit: Map<String, List<com.rustyrazorblade.easydblab.services.ScannedKitCommand>> by lazy {
+    private val kitCommandsByKit: Map<String, List<ScannedKitCommand>> by lazy {
         get<KitCommandScanner>().findAll()
     }
 

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/Docker.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/Docker.kt
@@ -2,6 +2,8 @@ package com.rustyrazorblade.easydblab
 
 import com.github.dockerjava.api.DockerClient
 import com.github.dockerjava.api.async.ResultCallback
+import com.github.dockerjava.api.command.CreateContainerCmd
+import com.github.dockerjava.api.command.CreateContainerResponse
 import com.github.dockerjava.api.command.InspectContainerResponse
 import com.github.dockerjava.api.command.PullImageResultCallback
 import com.github.dockerjava.api.model.AccessMode
@@ -114,7 +116,7 @@ class DefaultDockerClient(
 
 // Wrapper class for container creation commands to make testing easier
 class ContainerCreationCommand(
-    private val command: com.github.dockerjava.api.command.CreateContainerCmd,
+    private val command: CreateContainerCmd,
 ) {
     fun withCmd(commands: List<String>): ContainerCreationCommand {
         command.withCmd(commands)
@@ -149,7 +151,7 @@ class ContainerCreationCommand(
         return this
     }
 
-    fun exec(): com.github.dockerjava.api.command.CreateContainerResponse = command.exec()
+    fun exec(): CreateContainerResponse = command.exec()
 }
 
 // Utility for getting user ID, extracted for testability

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Status.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Status.kt
@@ -13,6 +13,7 @@ import com.rustyrazorblade.easydblab.events.Event
 import com.rustyrazorblade.easydblab.events.EventBus
 import com.rustyrazorblade.easydblab.kubernetes.KubernetesJob
 import com.rustyrazorblade.easydblab.kubernetes.getLocalKubeconfigPath
+import com.rustyrazorblade.easydblab.providers.aws.InstanceDetails
 import com.rustyrazorblade.easydblab.providers.aws.SecurityGroupRuleInfo
 import com.rustyrazorblade.easydblab.providers.aws.VpcService
 import com.rustyrazorblade.easydblab.providers.ssh.RemoteOperationsService
@@ -243,7 +244,7 @@ class Status :
 
     private fun buildNodeDetails(
         serverType: ServerType,
-        instanceStates: Map<String, com.rustyrazorblade.easydblab.providers.aws.InstanceDetails>,
+        instanceStates: Map<String, InstanceDetails>,
     ): List<NodeDetail> {
         val hosts = clusterState.hosts[serverType] ?: emptyList()
         return hosts.map { host ->

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/grafana/GrafanaManifestBuilder.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/grafana/GrafanaManifestBuilder.kt
@@ -15,6 +15,7 @@ import io.fabric8.kubernetes.api.model.Volume
 import io.fabric8.kubernetes.api.model.VolumeBuilder
 import io.fabric8.kubernetes.api.model.VolumeMount
 import io.fabric8.kubernetes.api.model.VolumeMountBuilder
+import io.fabric8.kubernetes.api.model.apps.Deployment
 import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder
 
 /**
@@ -141,7 +142,7 @@ class GrafanaManifestBuilder(
      *
      * @return Fabric8 Deployment object
      */
-    fun buildDeployment(): io.fabric8.kubernetes.api.model.apps.Deployment {
+    fun buildDeployment(): Deployment {
         val clusterName = templateService.buildContextVariables()["CLUSTER_NAME"] ?: "cluster"
 
         return DeploymentBuilder()

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/s3manager/S3ManagerManifestBuilder.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/s3manager/S3ManagerManifestBuilder.kt
@@ -3,6 +3,7 @@ package com.rustyrazorblade.easydblab.configuration.s3manager
 import com.rustyrazorblade.easydblab.Constants
 import com.rustyrazorblade.easydblab.services.TemplateService
 import io.fabric8.kubernetes.api.model.HasMetadata
+import io.fabric8.kubernetes.api.model.apps.Deployment
 import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder
 
 /**
@@ -45,7 +46,7 @@ class S3ManagerManifestBuilder(
      * Runs on control plane with hostNetwork. Uses IAM role for AWS credentials.
      */
     @Suppress("LongMethod")
-    fun buildDeployment(): io.fabric8.kubernetes.api.model.apps.Deployment {
+    fun buildDeployment(): Deployment {
         val region = templateService.buildContextVariables()["AWS_REGION"] ?: "us-east-1"
 
         return DeploymentBuilder()

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/mcp/McpServer.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/mcp/McpServer.kt
@@ -21,6 +21,8 @@ import io.ktor.server.netty.Netty
 import io.ktor.server.plugins.swagger.swaggerUI
 import io.ktor.server.response.respond
 import io.ktor.server.response.respondText
+import io.ktor.server.routing.Routing
+import io.ktor.server.routing.RoutingContext
 import io.ktor.server.routing.get
 import io.ktor.server.routing.openapi.OpenApiDocSource
 import io.ktor.server.routing.openapi.describe
@@ -391,7 +393,7 @@ class McpServer(
         log.info { "Server stopped" }
     }
 
-    private fun io.ktor.server.routing.Routing.configureSseRoutes(
+    private fun Routing.configureSseRoutes(
         server: Server,
         serverSessions: ConcurrentMap<String, ServerSession>,
     ) {
@@ -424,7 +426,7 @@ class McpServer(
     }
 
     @OptIn(ExperimentalKtorApi::class)
-    private fun io.ktor.server.routing.Routing.configureStatusRoutes() {
+    private fun Routing.configureStatusRoutes() {
         get("/stress/status") {
             val live = call.request.queryParameters["live"]?.toBoolean() ?: false
             if (live) statusCache.forceRefresh()
@@ -484,7 +486,7 @@ class McpServer(
         }
     }
 
-    private suspend fun io.ktor.server.routing.RoutingContext.respondWithCachedStatus(section: String?) {
+    private suspend fun RoutingContext.respondWithCachedStatus(section: String?) {
         try {
             val json = statusCache.getStatus(section)
             if (json == null) {

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/mcp/McpToolRegistry.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/mcp/McpToolRegistry.kt
@@ -20,6 +20,7 @@ import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import picocli.CommandLine.Mixin
 import picocli.CommandLine.Option
+import java.lang.reflect.Field
 import kotlin.reflect.KClass
 import kotlin.reflect.KProperty1
 import kotlin.reflect.full.memberProperties
@@ -229,7 +230,7 @@ open class McpToolRegistry : KoinComponent {
     // ==================== PicoCLI @Option Processing ====================
 
     private fun processOptionAnnotation(
-        javaField: java.lang.reflect.Field,
+        javaField: Field,
         fieldName: String,
         command: PicoCommand,
         properties: MutableMap<String, JsonElement>,
@@ -245,7 +246,7 @@ open class McpToolRegistry : KoinComponent {
     }
 
     private fun buildPicoOptionSchema(
-        javaField: java.lang.reflect.Field,
+        javaField: Field,
         fieldName: String,
         optionAnnotation: Option,
         command: PicoCommand,
@@ -276,7 +277,7 @@ open class McpToolRegistry : KoinComponent {
     // ==================== PicoCLI @Mixin Processing ====================
 
     private fun processMixinAnnotation(
-        javaField: java.lang.reflect.Field,
+        javaField: Field,
         command: PicoCommand,
         properties: MutableMap<String, JsonElement>,
         requiredFields: MutableList<String>,
@@ -321,7 +322,7 @@ open class McpToolRegistry : KoinComponent {
     }
 
     private fun buildMixinPropertySchema(
-        javaField: java.lang.reflect.Field,
+        javaField: Field,
         fieldName: String,
         optionAnnotation: Option,
         mixin: Any,
@@ -339,7 +340,7 @@ open class McpToolRegistry : KoinComponent {
 
     /** Add default value to JSON schema from any object (not just ICommand). */
     private fun JsonObjectBuilder.addDefaultValueFromAny(
-        javaField: java.lang.reflect.Field,
+        javaField: Field,
         target: Any,
     ) {
         javaField.isAccessible = true
@@ -469,7 +470,7 @@ open class McpToolRegistry : KoinComponent {
 
     private fun setFieldValue(
         target: Any,
-        field: java.lang.reflect.Field,
+        field: Field,
         value: JsonElement,
     ) {
         try {
@@ -492,7 +493,7 @@ open class McpToolRegistry : KoinComponent {
     }
 
     private fun setEnumFieldValue(
-        field: java.lang.reflect.Field,
+        field: Field,
         target: Any,
         value: JsonElement,
     ) {

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/ClusterProvisioningService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/ClusterProvisioningService.kt
@@ -10,6 +10,7 @@ import com.rustyrazorblade.easydblab.configuration.ServerType
 import com.rustyrazorblade.easydblab.configuration.User
 import com.rustyrazorblade.easydblab.events.Event
 import com.rustyrazorblade.easydblab.events.EventBus
+import com.rustyrazorblade.easydblab.providers.aws.AWS
 import com.rustyrazorblade.easydblab.providers.aws.InstanceCreationConfig
 import com.rustyrazorblade.easydblab.services.aws.DomainState
 import com.rustyrazorblade.easydblab.services.aws.EC2InstanceService
@@ -166,7 +167,7 @@ class DefaultClusterProvisioningService(
     private val ec2InstanceService: EC2InstanceService,
     private val emrProvisioningService: EMRProvisioningService,
     private val openSearchService: OpenSearchService,
-    private val aws: com.rustyrazorblade.easydblab.providers.aws.AWS,
+    private val aws: AWS,
     private val user: User,
     private val eventBus: EventBus,
 ) : ClusterProvisioningService {

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/DefaultK8sJobOperations.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/DefaultK8sJobOperations.kt
@@ -7,6 +7,7 @@ import com.rustyrazorblade.easydblab.kubernetes.KubernetesJob
 import com.rustyrazorblade.easydblab.kubernetes.KubernetesPod
 import com.rustyrazorblade.easydblab.kubernetes.ManifestApplier
 import io.fabric8.kubernetes.api.model.DeletionPropagation
+import io.fabric8.kubernetes.api.model.batch.v1.Job
 import io.github.oshai.kotlinlogging.KotlinLogging
 import java.time.Duration
 import java.time.Instant
@@ -46,7 +47,7 @@ class DefaultK8sJobOperations(
     override fun createJob(
         controlHost: ClusterHost,
         namespace: String,
-        job: io.fabric8.kubernetes.api.model.batch.v1.Job,
+        job: Job,
     ): Result<String> =
         runCatching {
             log.info { "Creating K8s job '${job.metadata?.name}' in namespace $namespace" }

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/DefaultK8sNamespaceOperations.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/DefaultK8sNamespaceOperations.kt
@@ -5,6 +5,7 @@ import com.rustyrazorblade.easydblab.configuration.ClusterHost
 import com.rustyrazorblade.easydblab.events.Event
 import com.rustyrazorblade.easydblab.events.EventBus
 import io.fabric8.kubernetes.api.model.HasMetadata
+import io.fabric8.kubernetes.api.model.Pod
 import io.fabric8.kubernetes.client.KubernetesClient
 import io.github.oshai.kotlinlogging.KotlinLogging
 import java.time.Duration
@@ -285,7 +286,7 @@ class DefaultK8sNamespaceOperations(
         }
     }
 
-    private fun describePodState(pod: io.fabric8.kubernetes.api.model.Pod): String {
+    private fun describePodState(pod: Pod): String {
         val phase = pod.status?.phase ?: "Unknown"
         val parts = mutableListOf("phase=$phase")
 

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/K8sClientProvider.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/K8sClientProvider.kt
@@ -2,6 +2,7 @@ package com.rustyrazorblade.easydblab.services
 
 import com.rustyrazorblade.easydblab.Constants
 import com.rustyrazorblade.easydblab.configuration.ClusterHost
+import com.rustyrazorblade.easydblab.configuration.ClusterStateManager
 import com.rustyrazorblade.easydblab.kubernetes.ProxiedKubernetesClientFactory
 import io.fabric8.kubernetes.client.KubernetesClient
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -22,7 +23,7 @@ private val log = KotlinLogging.logger {}
  * directly to the private IP without any proxy.
  */
 class K8sClientProvider(
-    private val clusterStateManager: com.rustyrazorblade.easydblab.configuration.ClusterStateManager,
+    private val clusterStateManager: ClusterStateManager,
 ) {
     fun createClient(controlHost: ClusterHost): KubernetesClient {
         log.debug { "Creating K8s client for ${controlHost.alias} (${controlHost.privateIp})" }

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/K8sService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/K8sService.kt
@@ -6,6 +6,7 @@ import com.rustyrazorblade.easydblab.events.EventBus
 import com.rustyrazorblade.easydblab.kubernetes.KubernetesJob
 import com.rustyrazorblade.easydblab.kubernetes.KubernetesPod
 import io.fabric8.kubernetes.api.model.HasMetadata
+import io.fabric8.kubernetes.api.model.batch.v1.Job
 import java.nio.file.Path
 
 /**
@@ -73,7 +74,7 @@ interface K8sJobOperations {
     fun createJob(
         controlHost: ClusterHost,
         namespace: String,
-        job: io.fabric8.kubernetes.api.model.batch.v1.Job,
+        job: Job,
     ): Result<String>
 
     fun deleteJob(

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/StressJobService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/StressJobService.kt
@@ -8,6 +8,7 @@ import com.rustyrazorblade.easydblab.events.Event
 import com.rustyrazorblade.easydblab.events.EventBus
 import com.rustyrazorblade.easydblab.kubernetes.KubernetesJob
 import com.rustyrazorblade.easydblab.kubernetes.KubernetesPod
+import io.fabric8.kubernetes.api.model.Container
 import io.fabric8.kubernetes.api.model.ContainerBuilder
 import io.fabric8.kubernetes.api.model.EnvVarBuilder
 import io.fabric8.kubernetes.api.model.VolumeBuilder
@@ -378,7 +379,7 @@ class DefaultStressJobService(
         region: String,
         controlNodeIp: String,
         clusterName: String,
-    ): io.fabric8.kubernetes.api.model.Container {
+    ): Container {
         val pyroscopeServerAddress = "http://$controlNodeIp:${Constants.K8s.PYROSCOPE_PORT}"
         val pyroscopeLabels = "cluster=$clusterName,job_name=${config.jobName}"
 
@@ -432,7 +433,7 @@ class DefaultStressJobService(
         jobName: String,
         tags: Map<String, String>,
         promPort: Int,
-    ): io.fabric8.kubernetes.api.model.Container {
+    ): Container {
         val resourceAttributes = buildResourceAttributes(jobName, tags)
 
         return ContainerBuilder()
@@ -490,8 +491,8 @@ class DefaultStressJobService(
     private fun assembleJob(
         jobName: String,
         labels: Map<String, String>,
-        stressContainer: io.fabric8.kubernetes.api.model.Container,
-        otelSidecar: io.fabric8.kubernetes.api.model.Container,
+        stressContainer: Container,
+        otelSidecar: Container,
     ): Job =
         JobBuilder()
             .withNewMetadata()

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/VictoriaMetricsQueryService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/VictoriaMetricsQueryService.kt
@@ -2,6 +2,7 @@ package com.rustyrazorblade.easydblab.services
 
 import com.rustyrazorblade.easydblab.Constants
 import com.rustyrazorblade.easydblab.configuration.ClusterHost
+import com.rustyrazorblade.easydblab.configuration.ClusterStateManager
 import com.rustyrazorblade.easydblab.proxy.HttpClientFactory
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.serialization.Serializable
@@ -68,7 +69,7 @@ interface VictoriaMetricsQueryService {
 
 class DefaultVictoriaMetricsQueryService(
     private val httpClientFactory: HttpClientFactory,
-    private val clusterStateManager: com.rustyrazorblade.easydblab.configuration.ClusterStateManager,
+    private val clusterStateManager: ClusterStateManager,
 ) : VictoriaMetricsQueryService {
     override fun query(
         controlHost: ClusterHost,

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/VictoriaStreamService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/VictoriaStreamService.kt
@@ -2,6 +2,7 @@ package com.rustyrazorblade.easydblab.services
 
 import com.rustyrazorblade.easydblab.Constants
 import com.rustyrazorblade.easydblab.configuration.ClusterHost
+import com.rustyrazorblade.easydblab.configuration.ClusterStateManager
 import com.rustyrazorblade.easydblab.proxy.HttpClientFactory
 import io.github.oshai.kotlinlogging.KotlinLogging
 import okhttp3.MediaType.Companion.toMediaType
@@ -67,7 +68,7 @@ interface VictoriaStreamService {
  */
 class DefaultVictoriaStreamService(
     private val httpClientFactory: HttpClientFactory,
-    private val clusterStateManager: com.rustyrazorblade.easydblab.configuration.ClusterStateManager,
+    private val clusterStateManager: ClusterStateManager,
 ) : VictoriaStreamService {
     companion object {
         private const val HTTP_NO_CONTENT = 204

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/BaseKoinTestExample.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/BaseKoinTestExample.kt
@@ -3,6 +3,7 @@ package com.rustyrazorblade.easydblab
 import com.rustyrazorblade.easydblab.configuration.User
 import com.rustyrazorblade.easydblab.output.OutputHandler
 import com.rustyrazorblade.easydblab.providers.aws.AWS
+import com.rustyrazorblade.easydblab.providers.ssh.SSHConfiguration
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.koin.core.component.KoinComponent
@@ -56,7 +57,7 @@ class BaseKoinTestWithSSH :
     @Test
     fun `test SSH module is available by default`() {
         // SSH configuration should be available automatically from core modules
-        val sshConfig: com.rustyrazorblade.easydblab.providers.ssh.SSHConfiguration by inject()
+        val sshConfig: SSHConfiguration by inject()
         assertThat(sshConfig).isNotNull
         assertThat(sshConfig.keyPath).isEqualTo("test")
     }

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/commands/SetupProfileTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/commands/SetupProfileTest.kt
@@ -4,6 +4,7 @@ import com.rustyrazorblade.easydblab.BaseKoinTest
 import com.rustyrazorblade.easydblab.Prompter
 import com.rustyrazorblade.easydblab.TestPrompter
 import com.rustyrazorblade.easydblab.configuration.Arch
+import com.rustyrazorblade.easydblab.configuration.User
 import com.rustyrazorblade.easydblab.configuration.UserConfigProvider
 import com.rustyrazorblade.easydblab.output.BufferedOutputHandler
 import com.rustyrazorblade.easydblab.output.OutputHandler
@@ -98,7 +99,7 @@ class SetupProfileTest : BaseKoinTest() {
 
             // Mock getUserConfig to return a User object
             val userConfig =
-                com.rustyrazorblade.easydblab.configuration.User(
+                User(
                     email = "test@example.com",
                     region = "us-west-2",
                     keyName = "test-key",
@@ -152,7 +153,7 @@ class SetupProfileTest : BaseKoinTest() {
             whenever(mockUserConfigProvider.loadExistingConfig()).thenReturn(existingConfig)
 
             val userConfig =
-                com.rustyrazorblade.easydblab.configuration.User(
+                User(
                     email = "test@example.com",
                     region = "us-west-2",
                     keyName = "test-key",
@@ -190,7 +191,7 @@ class SetupProfileTest : BaseKoinTest() {
             whenever(mockUserConfigProvider.loadExistingConfig()).thenReturn(existingConfig)
 
             val userConfig =
-                com.rustyrazorblade.easydblab.configuration.User(
+                User(
                     email = "test@example.com",
                     region = "us-west-2",
                     keyName = "test-key",
@@ -226,7 +227,7 @@ class SetupProfileTest : BaseKoinTest() {
             whenever(mockUserConfigProvider.loadExistingConfig()).thenReturn(existingConfig)
 
             val userConfig =
-                com.rustyrazorblade.easydblab.configuration.User(
+                User(
                     email = "test@example.com",
                     region = "us-west-2",
                     keyName = "test-key",
@@ -691,7 +692,7 @@ class SetupProfileTest : BaseKoinTest() {
             whenever(mockUserConfigProvider.loadExistingConfig()).thenReturn(existingConfig)
 
             val userConfig =
-                com.rustyrazorblade.easydblab.configuration.User(
+                User(
                     email = "test@example.com",
                     region = "us-west-2",
                     keyName = "test-key",

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/commands/install/KitRequirementTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/commands/install/KitRequirementTest.kt
@@ -1,6 +1,7 @@
 package com.rustyrazorblade.easydblab.commands.install
 
 import com.rustyrazorblade.easydblab.BaseKoinTest
+import com.rustyrazorblade.easydblab.Context
 import com.rustyrazorblade.easydblab.configuration.ClusterHost
 import com.rustyrazorblade.easydblab.configuration.ClusterState
 import com.rustyrazorblade.easydblab.configuration.ClusterStateManager
@@ -58,7 +59,7 @@ class KitRequirementTest : BaseKoinTest() {
 
     @BeforeEach
     fun setup() {
-        workingDir = get<com.rustyrazorblade.easydblab.Context>().workingDirectory
+        workingDir = get<Context>().workingDirectory
         capturedEvents.clear()
         eventBus = get()
         eventBus.addListener(

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/kubernetes/ManifestApplierTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/kubernetes/ManifestApplierTest.kt
@@ -148,13 +148,13 @@ class ManifestApplierTest {
      * This allows testing validation logic that runs before client operations.
      */
     @Suppress("UNCHECKED_CAST")
-    private fun createNullClient(): io.fabric8.kubernetes.client.KubernetesClient {
+    private fun createNullClient(): KubernetesClient {
         // Use a proxy that throws NPE for any method call
         return java.lang.reflect.Proxy.newProxyInstance(
-            io.fabric8.kubernetes.client.KubernetesClient::class.java.classLoader,
-            arrayOf(io.fabric8.kubernetes.client.KubernetesClient::class.java),
+            KubernetesClient::class.java.classLoader,
+            arrayOf(KubernetesClient::class.java),
         ) { _, _, _ ->
             throw NullPointerException("Client method should not be called for validation tests")
-        } as io.fabric8.kubernetes.client.KubernetesClient
+        } as KubernetesClient
     }
 }

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/services/CommandExecutorTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/services/CommandExecutorTest.kt
@@ -10,6 +10,7 @@ import com.rustyrazorblade.easydblab.configuration.ClusterHost
 import com.rustyrazorblade.easydblab.configuration.ClusterState
 import com.rustyrazorblade.easydblab.configuration.ClusterStateManager
 import com.rustyrazorblade.easydblab.configuration.InfrastructureStatus
+import com.rustyrazorblade.easydblab.configuration.ServerType
 import com.rustyrazorblade.easydblab.configuration.User
 import com.rustyrazorblade.easydblab.configuration.UserConfigProvider
 import com.rustyrazorblade.easydblab.events.EventBus
@@ -339,7 +340,7 @@ class CommandExecutorTest : BaseKoinTest() {
                 versions = mutableMapOf(),
                 infrastructureStatus = InfrastructureStatus.UP,
                 tailscaleActive = false,
-                hosts = mapOf(com.rustyrazorblade.easydblab.configuration.ServerType.Control to listOf(controlHost)),
+                hosts = mapOf(ServerType.Control to listOf(controlHost)),
             )
         whenever(mockClusterStateManager.exists()).thenReturn(true)
         whenever(mockClusterStateManager.load()).thenReturn(state)
@@ -367,7 +368,7 @@ class CommandExecutorTest : BaseKoinTest() {
                 versions = mutableMapOf(),
                 infrastructureStatus = InfrastructureStatus.UP,
                 tailscaleActive = false,
-                hosts = mapOf(com.rustyrazorblade.easydblab.configuration.ServerType.Control to listOf(controlHost)),
+                hosts = mapOf(ServerType.Control to listOf(controlHost)),
             )
         whenever(mockClusterStateManager.exists()).thenReturn(true)
         whenever(mockClusterStateManager.load()).thenReturn(state)
@@ -427,7 +428,7 @@ class CommandExecutorTest : BaseKoinTest() {
                 versions = mutableMapOf(),
                 infrastructureStatus = InfrastructureStatus.UP,
                 tailscaleActive = false,
-                hosts = mapOf(com.rustyrazorblade.easydblab.configuration.ServerType.Control to listOf(controlHost)),
+                hosts = mapOf(ServerType.Control to listOf(controlHost)),
             )
         whenever(mockClusterStateManager.exists()).thenReturn(true)
         whenever(mockClusterStateManager.load()).thenReturn(state)
@@ -464,7 +465,7 @@ class CommandExecutorTest : BaseKoinTest() {
                 versions = mutableMapOf(),
                 infrastructureStatus = InfrastructureStatus.UP,
                 tailscaleActive = false,
-                hosts = mapOf(com.rustyrazorblade.easydblab.configuration.ServerType.Control to listOf(controlHost)),
+                hosts = mapOf(ServerType.Control to listOf(controlHost)),
             )
         whenever(mockClusterStateManager.exists()).thenReturn(true)
         whenever(mockClusterStateManager.load()).thenReturn(state)
@@ -498,7 +499,7 @@ class CommandExecutorTest : BaseKoinTest() {
                 versions = mutableMapOf(),
                 infrastructureStatus = InfrastructureStatus.UP,
                 tailscaleActive = false,
-                hosts = mapOf(com.rustyrazorblade.easydblab.configuration.ServerType.Control to listOf(controlHost)),
+                hosts = mapOf(ServerType.Control to listOf(controlHost)),
             )
         whenever(mockClusterStateManager.exists()).thenReturn(true)
         whenever(mockClusterStateManager.load()).thenReturn(state)
@@ -533,7 +534,7 @@ class CommandExecutorTest : BaseKoinTest() {
                 versions = mutableMapOf(),
                 infrastructureStatus = InfrastructureStatus.UP,
                 tailscaleActive = false,
-                hosts = mapOf(com.rustyrazorblade.easydblab.configuration.ServerType.Control to listOf(controlHost)),
+                hosts = mapOf(ServerType.Control to listOf(controlHost)),
             )
         whenever(mockClusterStateManager.exists()).thenReturn(true)
         whenever(mockClusterStateManager.load()).thenReturn(state)
@@ -567,7 +568,7 @@ class CommandExecutorTest : BaseKoinTest() {
                 versions = mutableMapOf(),
                 infrastructureStatus = InfrastructureStatus.UP,
                 tailscaleActive = false,
-                hosts = mapOf(com.rustyrazorblade.easydblab.configuration.ServerType.Control to listOf(controlHost)),
+                hosts = mapOf(ServerType.Control to listOf(controlHost)),
             )
         whenever(mockClusterStateManager.exists()).thenReturn(true)
         whenever(mockClusterStateManager.load()).thenReturn(state)

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/services/CqlSessionServiceTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/services/CqlSessionServiceTest.kt
@@ -1,5 +1,6 @@
 package com.rustyrazorblade.easydblab.services
 
+import com.datastax.oss.driver.api.core.CqlSession
 import com.rustyrazorblade.easydblab.BaseKoinTest
 import com.rustyrazorblade.easydblab.configuration.ClusterHost
 import com.rustyrazorblade.easydblab.configuration.ClusterState
@@ -59,7 +60,7 @@ class CqlSessionServiceTest : BaseKoinTest() {
         mockResourceManager = mock()
 
         whenever(mockSocksProxy.getLocalPort()).thenReturn(1080)
-        val mockSession = mock<com.datastax.oss.driver.api.core.CqlSession>()
+        val mockSession = mock<CqlSession>()
         whenever(mockSession.isClosed).thenReturn(false)
         whenever(mockSessionFactory.createDirectSession(any(), any())).thenReturn(mockSession)
         whenever(mockSessionFactory.createSession(any(), any(), any())).thenReturn(mockSession)

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/services/EMRProvisioningServiceTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/services/EMRProvisioningServiceTest.kt
@@ -17,6 +17,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.KArgumentCaptor
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
@@ -436,7 +437,7 @@ internal class EMRProvisioningServiceTest {
     private fun setupEmrMocks(
         clusterId: String,
         clusterName: String,
-        configCaptor: org.mockito.kotlin.KArgumentCaptor<EMRClusterConfig>? = null,
+        configCaptor: KArgumentCaptor<EMRClusterConfig>? = null,
     ) {
         val createResult =
             EMRClusterResult(

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/services/SystemDServiceManagerTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/services/SystemDServiceManagerTest.kt
@@ -2,6 +2,7 @@ package com.rustyrazorblade.easydblab.services
 
 import com.rustyrazorblade.easydblab.BaseKoinTest
 import com.rustyrazorblade.easydblab.configuration.Host
+import com.rustyrazorblade.easydblab.events.EventBus
 import com.rustyrazorblade.easydblab.providers.ssh.RemoteOperationsService
 import com.rustyrazorblade.easydblab.ssh.Response
 import io.github.oshai.kotlinlogging.KLogger
@@ -41,7 +42,7 @@ class SystemDServiceManagerTest : BaseKoinTest() {
      */
     private class TestSystemDService(
         remoteOps: RemoteOperationsService,
-        eventBus: com.rustyrazorblade.easydblab.events.EventBus,
+        eventBus: EventBus,
     ) : AbstractSystemDServiceManager("test-service", remoteOps, eventBus) {
         override val log: KLogger = KotlinLogging.logger {}
     }

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/services/TemplateServiceTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/services/TemplateServiceTest.kt
@@ -6,6 +6,7 @@ import com.rustyrazorblade.easydblab.configuration.ClusterState
 import com.rustyrazorblade.easydblab.configuration.ClusterStateManager
 import com.rustyrazorblade.easydblab.configuration.InitConfig
 import com.rustyrazorblade.easydblab.configuration.ServerType
+import com.rustyrazorblade.easydblab.configuration.otel.OtelManifestBuilder
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -184,7 +185,7 @@ class TemplateServiceTest : BaseKoinTest() {
         // Use a known resource — OTel collector config contains __KEY__ variables
         val template =
             service.fromResource(
-                com.rustyrazorblade.easydblab.configuration.otel.OtelManifestBuilder::class.java,
+                OtelManifestBuilder::class.java,
                 "otel-collector-config.yaml",
             )
 


### PR DESCRIPTION
Closes #794.

## What

Mechanical cleanup: replace inline fully-qualified type names (FQNs) with a top-level `import` and the short name across `src/main`, `src/test`, `src/integrationTest`, and `core/`. No behavior change.

28 files touched, 85 insertions / 56 deletions. Verified on JDK 21: all source sets compile, `ktlintFormat` and `detekt` (incl. `detektMain`/`detektTest`/`detektIntegrationTest`) are clean, and `./gradlew test` passes (2242 tests).

## Notably

- Caught two cases the issue inventory missed (via re-grep): `Docker.kt` used `com.github.dockerjava.api.command.CreateContainerCmd` and `CreateContainerResponse` inline — both now imported.
- `YamlDelegate` used a fully-qualified companion self-reference; replaced with the plain `yaml` member (no import needed).

## Left fully-qualified on purpose (genuine same-name disambiguation)

- dockerjava `DockerException` in `Docker.kt`, `RetryUtil.kt`, `ContainerExecutor.kt`, `ContainerExecutorTest.kt` — collides with the project's own `DockerException`.
- fabric8 `Container` in `K8sServiceIntegrationTest.kt` — collides with testcontainers `Container`.
- `java.lang.Long/Double/Float/Boolean::class.java` in `McpToolRegistry.kt` — deliberately distinct from the Kotlin types.
- `ResultCallback.Adapter<Frame>` cast in `DockerTest.kt` — owned by #780, left untouched to avoid conflict.
- The 15 `commands.*::class` entries in `McpToolRegistry`'s registration table — intentionally inline; importing 15 command classes for a lookup table is noisier than the inline form.

## Lint guard: deferred (recommended follow-up)

There is **no built-in detekt (1.23.8) or ktlint rule** for inline FQNs. A guard would require a new **custom detekt ruleset module** (jar + `RuleSetProvider` + `META-INF/services`), wired **type-resolution-aware** against the existing `detektMain`/`detektTest`/`detektIntegrationTest` tasks so it can tell a real collision (the cases above) from a shortenable FQN, plus its own tests and a baseline for the disambiguation cases. That is heavier and more fragile than this mechanical cleanup warrants, so I split it out: this PR lands the cleanup, and the custom rule is recommended as a separate follow-up (worthwhile only if these recur).
