### PR TITLE
feat(cli): namespace db/app init options (--db.*/--app.*) + auto-derive arch from instance type

### DIFF
--- a/docs/getting-started/setup.md
+++ b/docs/getting-started/setup.md
@@ -208,8 +208,8 @@ Building an AMI takes approximately 10-15 minutes. Docker must be installed and 
 |----------|-------------|---------|
 | `EASY_DB_LAB_USER_DIR` | Override configuration directory | `~/.easy-db-lab` |
 | `EASY_DB_LAB_PROFILE` | Use a named profile | `default` |
-| `EASY_DB_LAB_INSTANCE_TYPE` | Default instance type for `init` | `r3.2xlarge` |
-| `EASY_DB_LAB_STRESS_INSTANCE_TYPE` | Default stress instance type | `c7i.2xlarge` |
+| `EASY_DB_LAB_INSTANCE_TYPE` | Default database instance type for `init` | `i4i.xlarge` |
+| `EASY_DB_LAB_STRESS_INSTANCE_TYPE` | Default application (stress) instance type | `c6id.2xlarge` |
 | `EASY_DB_LAB_AMI` | Override AMI ID | (auto-detected) |
 
 ## Verify Installation

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -72,14 +72,27 @@ Initialize a directory for easy-db-lab.
 easy-db-lab init [cluster-name] [options]
 ```
 
+The database and application node groups are configured through a namespaced
+`--db.*` / `--app.*` scheme. Every pre-existing flag continues to work as an
+**alias** carrying its established default. When both a namespaced option and its
+legacy alias are supplied for the same setting, **the namespaced option always
+wins**, regardless of the order they appear on the command line.
+
+Architecture is no longer a flag. Each node group's CPU architecture is derived
+automatically from that group's resolved instance type at `init` time (via the
+EC2 `DescribeInstanceTypes` `SupportedArchitectures` field) and persisted per
+group in cluster state. A cluster whose database and application groups have
+different architectures is provisioned correctly, each group booting from the
+AMI for its own architecture. An instance type whose architecture cannot be
+determined fails at `init`, before any instance is created.
+
 | Option | Description | Default |
 |--------|-------------|---------|
-| `--db`, `--cassandra`, `-c` | Number of Cassandra instances | 3 |
-| `--app`, `--stress`, `-s` | Number of stress instances | 0 |
-| `--instance`, `-i` | Cassandra instance type | r3.2xlarge |
-| `--stress-instance`, `-si` | Stress instance type | c7i.2xlarge |
+| `--db.count` (alias `--db`, `--cassandra`, `-c`) | Number of database instances | 3 |
+| `--app.count` (alias `--app`, `--stress`, `-s`) | Number of application instances | 0 |
+| `--db.instance-type` (alias `--instance`, `-i`) | Database instance type | i4i.xlarge |
+| `--app.instance-type` (alias `--stress-instance`, `-si`) | Application instance type | c6id.2xlarge |
 | `--azs`, `-z` | Availability zones (e.g., `a,b,c`) | all |
-| `--arch`, `-a` | CPU architecture (AMD64, ARM64) | AMD64 |
 | `--ebs.type` | EBS volume type (NONE, gp2, gp3, io1, io2) | NONE |
 | `--ebs.size` | EBS volume size in GB | 256 |
 | `--ebs.iops` | EBS IOPS (gp3 only) | 0 |

--- a/docs/user-guide/tutorial.md
+++ b/docs/user-guide/tutorial.md
@@ -84,7 +84,7 @@ Database instances need a data disk separate from the root volume. This can come
 If the selected instance type has no instance store and `--ebs.type` is not specified, `up` will fail. For example:
 
 ```bash
-easy-db-lab init my-cluster --instance c5.2xlarge --ebs.type gp3 --ebs.size 200
+easy-db-lab init my-cluster --db.instance-type c5.2xlarge --ebs.type gp3 --ebs.size 200
 ```
 
 ## Part 2: Launch Infrastructure

--- a/docs/user-guide/tutorial.md
+++ b/docs/user-guide/tutorial.md
@@ -18,14 +18,18 @@ This creates a 3-node Cassandra cluster by default.
 
 ### Init Options
 
+The database and application node groups use a namespaced `--db.*` / `--app.*`
+scheme. Every older flag still works as an **alias** with its established
+default; when both a namespaced option and its legacy alias are given for the
+same setting, **the namespaced option wins**, regardless of order.
+
 | Option | Description | Default |
 |--------|-------------|---------|
-| `--db`, `--cassandra`, `-c` | Number of Cassandra instances | 3 |
-| `--app`, `--stress`, `-s` | Number of stress/application instances | 0 |
-| `--instance`, `-i` | Cassandra instance type | r3.2xlarge |
-| `--stress-instance`, `-si` | Stress instance type | c7i.2xlarge |
+| `--db.count` (alias `--db`, `--cassandra`, `-c`) | Number of database instances | 3 |
+| `--app.count` (alias `--app`, `--stress`, `-s`) | Number of application instances | 0 |
+| `--db.instance-type` (alias `--instance`, `-i`) | Database instance type | i4i.xlarge |
+| `--app.instance-type` (alias `--stress-instance`, `-si`) | Application instance type | c6id.2xlarge |
 | `--azs`, `-z` | Availability zones (e.g., `a,b,c`) | all available |
-| `--arch`, `-a` | CPU architecture (AMD64, ARM64) | AMD64 |
 | `--ebs.type` | EBS volume type (NONE, gp2, gp3, io1, io2) | NONE |
 | `--ebs.size` | EBS volume size in GB | 256 |
 | `--ebs.iops` | EBS IOPS (gp3 only) | 0 |
@@ -54,8 +58,14 @@ easy-db-lab init prod-test --db 5 --ebs.type gp3 --ebs.size 500 --ebs.iops 3000
 ```
 
 **ARM64 cluster for Graviton instances:**
+The architecture is derived automatically from the instance type — no flag needed.
 ```bash
-easy-db-lab init my-cluster --arch ARM64 --instance r7g.2xlarge
+easy-db-lab init my-cluster --db.instance-type r7g.2xlarge
+```
+
+**Mixed-architecture cluster (arm64 database, x86_64 application):**
+```bash
+easy-db-lab init my-cluster --db.instance-type r7g.2xlarge --app.instance-type c6id.2xlarge
 ```
 
 **Initialize and provision in one step:**

--- a/openspec/changes/namespace-db-app-arch/.openspec.yaml
+++ b/openspec/changes/namespace-db-app-arch/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-15

--- a/openspec/changes/namespace-db-app-arch/design.md
+++ b/openspec/changes/namespace-db-app-arch/design.md
@@ -1,0 +1,190 @@
+## Context
+
+`init` configures two symmetric node groups — database and application (stress) — but
+its flags for them are asymmetric and unmemorable, and it takes an explicit CPU
+architecture flag that duplicates a property EC2 already reports for the chosen instance
+type. Meanwhile the `DescribeInstanceTypes` call that would supply that architecture is
+broken for any instance type newer than the installed SDK (#783). This change namespaces
+the node-group options, removes the architecture flag in favor of derivation, fixes and
+consolidates the instance-type query, and carries a per-group architecture all the way
+through provisioning so mixed-architecture clusters work.
+
+The design draws directly on an existing pattern in the same command. `Init.kt` already
+exposes a dotted flag family for EBS — `--ebs.type`, `--ebs.size`, `--ebs.iops`,
+`--ebs.throughput`, `--ebs.optimized` — implemented as individual `@Option`s whose names
+happen to contain a dot. There is no picocli `@ArgGroup`; the dot is purely a naming
+convention that signals "these belong to the EBS family." The db/app namespacing follows
+that precedent exactly.
+
+## Goals / Non-Goals
+
+**Goals**
+
+- Give the db and app node groups a consistent, learnable option scheme (`--db.*` /
+  `--app.*`) without breaking any existing flag.
+- Derive CPU architecture from the instance type; remove the redundant, error-prone
+  `--arch` flag.
+- Fix #783: decouple instance-type support from the SDK's `InstanceType` enum, and do it
+  once — one `DescribeInstanceTypes` call yielding both instance-store presence and
+  supported architectures.
+- Carry a per-group architecture through to provisioning so a mixed-architecture cluster
+  is provisioned with the right AMI per group.
+- Fail fast, loudly, at `init` when architecture cannot be derived.
+
+**Non-Goals**
+
+- The `--jdk-distro` / Corretto work and any packer / JDK-install / Cassandra-version
+  changes (#796).
+- Migrating persisted state. Clusters are ephemeral; new `InitConfig` fields carry
+  defaults so an old `state.json` still deserializes, and that is sufficient.
+- Reintroducing an architecture override. Derivation is the only path.
+- Changing the `build-image` / packer architecture path, which legitimately builds an
+  AMI for an explicitly chosen architecture.
+
+## Decisions
+
+### D1: Namespaced options as individual `@Option`s, not an `@ArgGroup`
+
+`init` gains `--db.instance-type`, `--app.instance-type`, `--db.count`, `--app.count`,
+each a nullable field with no default (`String?` / `Int?`). Each legacy flag keeps its
+current default and becomes an alias for the same concept:
+
+| Concept            | Legacy flag (keeps default)                 | Namespaced (nullable) |
+| ------------------ | ------------------------------------------- | --------------------- |
+| db instance type   | `--instance` / `-i` (env default)           | `--db.instance-type`  |
+| app instance type  | `--stress-instance` / `-si` / `--si` (env)  | `--app.instance-type` |
+| db count           | `--db` / `--cassandra` / `-c` (default 3)   | `--db.count`          |
+| app count          | `--app` / `--stress` / `-s` (default 0)     | `--app.count`         |
+
+This mirrors the existing `--ebs.*` family, which is a set of plain `@Option`s with dots
+in their names and no `@ArgGroup`. A picocli `@ArgGroup` was considered and rejected: it
+would change how the legacy aliases coexist with the namespaced names, buys nothing here
+(the family is flat, with no mutual-exclusivity or co-occurrence rules to enforce), and
+diverges from the `--ebs.*` precedent the user already knows.
+
+*Trade-off:* two option names now map to one concept, so `--help` lists both. That is the
+cost of not breaking muscle memory and scripts, and it is the same cost the codebase
+already pays for `-i` vs `--instance`.
+
+### D2: Namespaced-wins precedence, implemented order-independently
+
+The resolved value for each concept is computed as `resolved = namespaced ?: legacy`.
+Because the namespaced field is null unless the user set it, and the legacy field always
+holds either the user's value or the default, this rule is:
+
+- **order-independent** — picocli assigns each field regardless of argument order, and
+  the resolution reads fields, not parse order; and
+- **namespaced-wins** — a non-null namespaced value always shadows the legacy field.
+
+`Init` exposes resolved accessors (e.g. `resolvedDbInstanceType`, `resolvedAppCount`),
+and `InitConfig.fromInit` reads those accessors rather than the raw fields. `--help` text
+states that the namespaced form takes precedence.
+
+*Alternative considered — last-flag-wins:* rejected. It would make behavior depend on CLI
+argument order, which is surprising and hard to script against, and picocli does not
+expose per-option parse order without custom handling. `namespaced ?: legacy` is simpler
+and deterministic.
+
+### D3: One filter-based `DescribeInstanceTypes` call (closes #783)
+
+`EC2InstanceService` gains `describeInstanceType(type: String)` returning a small value
+holding `hasInstanceStore: Boolean` and `supportedArchitectures: List<String>`. It issues
+a single `DescribeInstanceTypes` request built with an `instance-type` **filter** whose
+value is the raw instance-type string:
+
+```
+DescribeInstanceTypesRequest.builder()
+    .filters(Filter.builder().name("instance-type").values(type).build())
+    .build()
+```
+
+An empty result means the instance type is unknown in the region and fails fast (D6). The
+call is wrapped in `RetryUtil` (resilience4j) as the existing AWS calls are; exhaustion
+propagates (D6). `hasInstanceStore()` is reimplemented as a thin reader that calls
+`describeInstanceType(type).hasInstanceStore`.
+
+The current code routes the instance type through `InstanceType.fromValue(instanceType)`,
+which returns `null` for any type absent from the installed SDK enum and produces the
+`[null]` error in #783. That path is removed for user-supplied instance types. The
+RunInstances path (`createSingleInstance`) is also moved off `InstanceType.fromValue` onto
+the string-accepting `instanceType(String)` overload so provisioning matches init-time
+validation and no longer couples to the SDK enum.
+
+*Why consolidate rather than add a second call:* architecture and instance-store presence
+come from the same API response for the same instance type. Two calls would double the
+API traffic and leave two places to keep enum-decoupled. One call, one reader each.
+
+### D4: `Arch.fromEc2(...)` mapping
+
+`Arch` gains a `fromEc2(architectures: List<String>): Arch` (or a per-string
+`fromEc2(String)`), mapping EC2's `SupportedArchitectures` values to the enum:
+`x86_64` → `AMD64`, `arm64` → `ARM64`. `i386` and any unrecognized or empty value are
+rejected. When a type reports multiple mappable architectures (rare, but possible), that
+is ambiguous for AMI selection and is rejected naming the type (D6) rather than guessed.
+The `Arch` enum and `PicoArchConverter` remain in the tree — `PicoArchConverter` still
+serves the `build-image` path, and `Arch` is now also the type of the derived, persisted
+per-group value.
+
+### D5: Per-group architecture in state, per-architecture AMI at `up`
+
+`InitConfig.arch: String` (a single global architecture) is replaced by three fields —
+`dbArch`, `appArch`, `controlArch` — each a `String` with a default so older `state.json`
+files still deserialize (no migration; clusters are ephemeral). `Init.execute` derives
+each group's architecture from that group's resolved instance type and stores all three.
+
+`InstanceSpec` gains the resolved AMI for its group (an `amiId`, or the `arch` from which
+`up` resolves the AMI). At `up`, `buildInstanceConfig` resolves one AMI per **distinct**
+architecture across the groups (via the existing `AMIResolver.resolveAmiId`), and attaches
+the matching AMI to each `InstanceSpec`. `createInstancesForType` reads `spec.amiId`
+instead of a single global AMI, and the global `amiId` field is dropped from
+`InstanceProvisioningConfig` (and the intermediate infra-context that carries it).
+
+This is the SOLID fix: architecture stops being a cluster-wide singleton that silently
+misapplies one AMI to heterogeneous nodes, and becomes a property owned by each node
+group. A cluster with an `arm64` db group and an `x86_64` app group provisions each group
+from its own AMI.
+
+*Trade-off:* `up` may now resolve more than one AMI (one per distinct architecture). For
+the common single-architecture cluster this is exactly one resolution, unchanged in cost;
+resolutions are deduplicated by architecture so a three-group same-arch cluster still
+resolves once.
+
+### D6: Fail fast — never silently default architecture
+
+Per the repository rule never to disable functionality or paper over a configuration
+problem:
+
+- **Unknown instance type** — `describeInstanceType` returns an empty result → error at
+  `init`: the instance type is not found in the region. No instances are created.
+- **API unavailable / throttled** — after `RetryUtil` (resilience4j) exhausts, the failure
+  propagates; `init` does not fall back to a default architecture.
+- **Zero or multiple mappable architectures** — `Arch.fromEc2` cannot pick a single
+  architecture → error naming the instance type. Never guessed.
+
+All three surface at `init`, before any EC2 instance is launched, consistent with the
+existing instance-storage validation which also fails fast at init.
+
+### D7: Persistence — Jackson defaults, no migration
+
+`InitConfig` is persisted through the (deprecated but still in use) Jackson path with
+lenient defaults. The new per-group architecture fields (`dbArch`, `appArch`,
+`controlArch`) are added with defaults, so an older `state.json` written before this
+change still deserializes. No migration step is needed because clusters are ephemeral —
+there is no long-lived state to carry forward. New serialization work continues to prefer
+kotlinx.serialization per project convention, but this change does not convert
+`InitConfig`; it only adds defaulted fields to the existing structure.
+
+## Risks / Trade-offs
+
+- **Two names per concept in `--help`.** Accepted; it is the price of not breaking
+  existing flags, and matches the `-i`/`--instance` status quo.
+- **Multiple AMI resolutions at `up`.** Bounded by the number of distinct architectures
+  (at most three), deduplicated, and unchanged for the common single-arch case.
+- **Removing `--arch` is a CLI break.** Intentional. The flag only ever restated the
+  instance type's architecture and was a source of misconfiguration. Clusters are
+  ephemeral; there is no compatibility surface to preserve.
+
+## Migration
+
+None. New `InitConfig` fields carry defaults; older `state.json` files load unchanged.
+The removed `--arch`/`-a`/`--cpu` flag has no replacement — architecture is derived.

--- a/openspec/changes/namespace-db-app-arch/proposal.md
+++ b/openspec/changes/namespace-db-app-arch/proposal.md
@@ -1,0 +1,140 @@
+# Proposal: Namespace db/app init options and auto-derive architecture
+
+## Why
+
+`init`'s node-group options grew organically and read inconsistently. Two groups of
+nodes — the database nodes and the application (stress) nodes — each have an instance
+type and a count, but the flags that set them share no visible structure:
+`--instance`/`-i` sets the db instance type while `--stress-instance`/`--si` sets the
+app instance type; `--db`/`--cassandra`/`-c` sets the db count while
+`--app`/`--stress`/`-s` sets the app count. There is no naming convention a user can
+learn once and apply to both groups. The EBS options already solved this for their own
+family with a dotted `--ebs.*` scheme (`--ebs.type`, `--ebs.size`, `--ebs.iops`, …).
+This change extends that precedent to the db/app groups with `--db.*` / `--app.*`.
+
+Architecture is worse than inconsistent — it is redundant. `init` takes an explicit
+`--arch`/`-a`/`--cpu` flag that the user must keep in agreement with the instance type
+they chose. An `arm64` instance type with the default `AMD64` arch resolves the wrong
+AMI and provisions a cluster that cannot boot. The architecture is already a property
+of the instance type; EC2 reports it through `DescribeInstanceTypes`
+(`SupportedArchitectures`). The flag exists only to restate information AWS already
+holds, and it exists only to be set wrong. This change removes it and derives the
+architecture per node group from the resolved instance type at `init` time.
+
+Deriving architecture requires one `DescribeInstanceTypes` call per distinct instance
+type. That is the same call `hasInstanceStore()` already makes, and today that call is
+broken. It routes the user-supplied instance type through the AWS SDK's `InstanceType`
+enum via `InstanceType.fromValue(...)`, which returns `null` for any instance type not
+yet present in the installed SDK version's enum — so `init -i <new-type>` fails with
+`The following supplied instance types do not exist: [null]` for any instance type
+newer than the SDK. This is **#783**. Rather than make a second, differently-broken
+call for architecture, this change consolidates both facts (instance-store presence and
+supported architectures) into a single filter-based `DescribeInstanceTypes` call that
+passes the instance type as a raw string, decoupling instance-type support from the SDK
+release version. This proposal therefore **closes #783**.
+
+Refs **#773** (this issue; the JDK-distribution half was split to **#796** and is out of
+scope here). Closes **#783**.
+
+## What Changes
+
+**Namespaced db/app options with legacy aliases.** `init` gains four new options —
+`--db.instance-type`, `--app.instance-type`, `--db.count`, `--app.count` — each nullable
+with no default. Every existing flag keeps working as an alias carrying its current
+default: `--instance`/`-i` and `--stress-instance`/`--si` for the instance types,
+`--db`/`--cassandra`/`-c` and `--app`/`--stress`/`-s` for the counts. When both a
+namespaced option and its legacy alias are supplied, **the namespaced form always wins**,
+independent of the order they appear on the command line. This precedence is stated in
+`--help`. Following the `--ebs.*` precedent, the dot is a naming convention only — these
+are individual `@Option`s, not a picocli `@ArgGroup`.
+
+**Architecture auto-derived; `--arch` removed.** The `--arch`/`-a`/`--cpu` option is
+removed entirely — there is no override. At `init`, the architecture of each node group
+is derived from that group's resolved instance type via the EC2 `DescribeInstanceTypes`
+`SupportedArchitectures` field: `x86_64` → AMD64, `arm64` → ARM64; `i386` or an empty
+result is rejected. The derived architecture is persisted per node group in cluster
+state. The separate `build-image` / packer path that builds AMIs for an explicit
+architecture is unchanged, and the `Arch` enum remains as the type of the derived and
+stored value.
+
+**One consolidated `DescribeInstanceTypes` call (closes #783).** A single filter-based
+call per instance type returns both whether the type has local instance store and its
+supported architectures. Instance types are passed as raw strings via an `instance-type`
+filter, never through the SDK's `InstanceType` enum, so any valid EC2 instance type
+works regardless of the installed SDK version. The existing instance-store check becomes
+a thin reader over this consolidated result.
+
+**Per-group architecture through provisioning (mixed-arch clusters).** The single global
+architecture stored in cluster state is replaced by a per-group architecture (db, app,
+control). At `up`, one AMI is resolved per distinct architecture present across the
+groups, and each node group is provisioned with the AMI matching its own architecture.
+A cluster with an `arm64` database group and an `x86_64` application group is a valid,
+correctly-provisioned configuration — today it is not, because a single global AMI is
+applied to every node.
+
+**Fail-fast at init.** Consistent with the repository rule never to disable
+functionality: an unknown instance type (empty `DescribeInstanceTypes` result) fails at
+`init` naming the type and region; a `DescribeInstanceTypes` call that remains
+unavailable or throttled after retry propagates its failure; an instance type whose
+architectures map to zero or more than one supported architecture fails naming the type.
+Architecture is never silently defaulted.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `cluster-lifecycle`: `REQ-CL-001: Cluster Initialization` gains the namespaced
+  `--db.*` / `--app.*` options, the legacy-alias compatibility guarantee, and the
+  namespaced-wins precedence rule. `REQ-CL-002: Infrastructure Provisioning` gains
+  per-group architecture and per-architecture AMI resolution so a mixed-architecture
+  cluster is provisioned correctly. A new requirement, `Architecture derived from
+  instance type`, covers init-time derivation, per-group persistence, no direct override,
+  and fail-fast on an underivable architecture.
+- `instance-storage-validation`: the `Instance store detection via AWS API` requirement
+  is modified so instance types are resolved by an `instance-type` filter rather than
+  the SDK's `InstanceType` enum (closing #783), and so the single `DescribeInstanceTypes`
+  call also reports supported architectures.
+
+### New Capabilities
+
+None. The behavior belongs to two existing capabilities.
+
+## Impact
+
+**Code**
+
+- `commands/Init.kt` — new nullable `--db.*` / `--app.*` options; legacy flags become
+  aliases; `--arch`/`-a`/`--cpu` removed; resolved-value accessors applying
+  namespaced-wins precedence; init-time architecture derivation.
+- `configuration/InitConfig.kt` (in `ClusterState.kt`) — `arch: String` replaced by
+  per-group `dbArch` / `appArch` / `controlArch`; `fromInit` reads the resolved values.
+  New fields carry defaults so older persisted state still loads (clusters are ephemeral;
+  no migration).
+- `configuration/Arch.kt` — `Arch.fromEc2(...)` mapping helper.
+- `services/aws/EC2InstanceService.kt` — `describeInstanceType(type)` returning
+  instance-store presence and supported architectures via one filter-based call;
+  `hasInstanceStore()` becomes a thin reader; no `InstanceType.fromValue` on user input.
+- `services/aws/InstanceSpecFactory.kt` — `InstanceSpec` carries the resolved AMI (or
+  architecture) for its group.
+- `commands/Up.kt` — per-architecture AMI resolution in `buildInstanceConfig`; the
+  global `amiId` on `InstanceProvisioningConfig` is dropped in favor of per-spec AMIs.
+- `services/ClusterProvisioningService.kt` — `createInstancesForType` reads the AMI from
+  the spec.
+
+**Behavior**
+
+- `init -i <new-instance-type>` succeeds for any valid EC2 instance type, including types
+  newer than the installed SDK enum (was `[null]` failure — #783).
+- `init` no longer accepts `--arch`/`-a`/`--cpu`; architecture is derived automatically.
+- A mixed-architecture cluster provisions each group with the correct AMI.
+
+**Docs**
+
+- `docs/` init reference: document `--db.*` / `--app.*`, the legacy aliases and
+  precedence, and the removal of `--arch`.
+- `CLAUDE.md` flag notes as needed.
+
+**Explicitly out of scope**
+
+- `--jdk-distro` / Corretto and any packer / JDK-install / Cassandra-version changes
+  from the old `feature/jdk-distro-app-arch` branch — **#796**.

--- a/openspec/changes/namespace-db-app-arch/specs/cluster-lifecycle/spec.md
+++ b/openspec/changes/namespace-db-app-arch/specs/cluster-lifecycle/spec.md
@@ -1,0 +1,101 @@
+## MODIFIED Requirements
+
+### REQ-CL-001: Cluster Initialization
+
+The system MUST allow users to initialize a cluster configuration specifying a name, node counts, and per-group instance types.
+
+The database and application node groups MUST each be configurable through a namespaced option scheme — a `db` family and an `app` family — covering that group's instance type and count. Every option name that existed before this scheme MUST continue to work as an alias for the same setting, carrying its established default, so no existing invocation breaks.
+
+When both a namespaced option and its legacy alias are supplied for the same setting, the namespaced option MUST take precedence, and this MUST hold regardless of the order the options appear on the command line. The precedence MUST be documented in the command help.
+
+#### Scenario: Initialize a new cluster
+
+- **GIVEN** a configured AWS profile
+- **WHEN** a user initializes a cluster with a name and node count
+- **THEN** cluster configuration is created and persisted locally.
+
+#### Scenario: Re-initialize with different parameters
+
+- **GIVEN** an initialized cluster
+- **WHEN** the user re-initializes with different parameters
+- **THEN** the configuration is updated.
+
+#### Scenario: Namespaced option takes precedence over its legacy alias
+
+- **GIVEN** a user supplies both the namespaced db instance-type option and its legacy alias with different values
+- **WHEN** the cluster is initialized
+- **THEN** the value from the namespaced option is used
+- **AND** this holds regardless of the order the two options were given on the command line.
+
+#### Scenario: Legacy alias still works when the namespaced option is absent
+
+- **GIVEN** a user supplies only a legacy alias (for an instance type or a count)
+- **WHEN** the cluster is initialized
+- **THEN** the legacy alias sets the corresponding value, exactly as before the namespaced scheme existed.
+
+### REQ-CL-002: Infrastructure Provisioning
+
+The system MUST provision EC2 instances in AWS with configurable instance types and counts. The system MUST create a per-cluster data bucket for high-volume storage and CloudWatch metrics.
+
+Each node group MUST be provisioned with a machine image matching that group's own CPU architecture. When node groups in the same cluster have different architectures, each group MUST receive the image for its architecture; a single image MUST NOT be applied across groups of differing architecture.
+
+#### Scenario: Provision EC2 instances
+
+- **GIVEN** an initialized cluster configuration
+- **WHEN** the user provisions the cluster
+- **THEN** EC2 instances are launched and accessible via SSH.
+
+#### Scenario: K3s deployed on provisioned instances
+
+- **GIVEN** provisioned instances
+- **WHEN** provisioning completes
+- **THEN** K3s Kubernetes is deployed on all nodes.
+
+#### Scenario: Mixed-architecture cluster is provisioned per group
+
+- **GIVEN** a cluster whose database group and application group have different CPU architectures
+- **WHEN** the user provisions the cluster
+- **THEN** the database group is provisioned with the image for its architecture
+- **AND** the application group is provisioned with the image for its architecture
+- **AND** each distinct architecture's image is resolved once.
+
+#### Scenario: Per-cluster data bucket created
+
+- **GIVEN** cluster provisioning
+- **WHEN** infrastructure is created
+- **THEN** a per-cluster S3 data bucket named `easy-db-lab-data-<cluster-id>` is created and tagged with cluster metadata.
+
+#### Scenario: CloudWatch metrics on data bucket
+
+- **GIVEN** a per-cluster data bucket
+- **WHEN** provisioning completes
+- **THEN** CloudWatch S3 request metrics are configured on the data bucket.
+
+## ADDED Requirements
+
+### Requirement: Architecture derived from instance type
+
+The system MUST derive each node group's CPU architecture from that group's resolved instance type at initialization time, and MUST persist the derived architecture per node group in cluster state. The system MUST NOT expose any option to set the architecture directly.
+
+Derivation MUST fail fast at initialization, before any EC2 instance is created, when the architecture cannot be determined. The system MUST NOT fall back to a default architecture.
+
+#### Scenario: Architecture is derived from the instance type
+
+- **GIVEN** a user initializes a cluster and specifies an instance type for a node group but does not — and cannot — specify an architecture
+- **WHEN** the cluster is initialized
+- **THEN** the architecture for that node group is derived from the instance type
+- **AND** the derived architecture is persisted per node group in cluster state.
+
+#### Scenario: Each node group may resolve to a different architecture
+
+- **GIVEN** a user specifies a database instance type of one architecture and an application instance type of another
+- **WHEN** the cluster is initialized
+- **THEN** each node group's architecture is derived independently from its own instance type.
+
+#### Scenario: Initialization fails fast when the architecture cannot be derived
+
+- **GIVEN** a user specifies an instance type whose architecture cannot be determined (the instance type is unknown in the region, or it maps to no single supported architecture)
+- **WHEN** the cluster is initialized
+- **THEN** initialization fails with an error naming the instance type
+- **AND** no EC2 instances are created
+- **AND** the system does not fall back to a default architecture.

--- a/openspec/changes/namespace-db-app-arch/specs/instance-storage-validation/spec.md
+++ b/openspec/changes/namespace-db-app-arch/specs/instance-storage-validation/spec.md
@@ -1,0 +1,26 @@
+## MODIFIED Requirements
+
+### Requirement: Instance store detection via AWS API
+
+The system SHALL use the AWS `DescribeInstanceTypes` API to determine whether an instance type has local instance store. The system SHALL NOT use hardcoded lists or pattern-matching on instance type names.
+
+The system SHALL resolve the instance type by an `instance-type` filter carrying the raw instance-type string, and SHALL NOT route the user-supplied instance type through the SDK's fixed `InstanceType` enum. Instance-type support therefore does not depend on the installed SDK version: any valid EC2 instance type is accepted, including a type newer than the SDK.
+
+A single `DescribeInstanceTypes` call SHALL report both whether the instance type has local instance store and the instance type's supported CPU architectures, so both facts are obtained from one query per instance type.
+
+#### Scenario: Querying instance type capabilities
+
+- **WHEN** the system needs to validate an instance type's storage capabilities
+- **THEN** the system SHALL call `DescribeInstanceTypes` with the instance type name
+- **AND** the system SHALL check the `instanceStorageSupported` field to determine if instance store is available.
+
+#### Scenario: Instance type newer than the SDK enum is accepted
+
+- **WHEN** a user requests an instance type not present in the installed SDK's `InstanceType` enum
+- **THEN** instance-store detection and provisioning SHALL both succeed for any valid EC2 type
+- **AND** the system SHALL NOT fail with a `[null]` instance-type error.
+
+#### Scenario: One query yields storage and architecture
+
+- **WHEN** the system queries an instance type's capabilities
+- **THEN** the same `DescribeInstanceTypes` result SHALL provide both the instance-store presence and the supported CPU architectures for that instance type.

--- a/openspec/changes/namespace-db-app-arch/tasks.md
+++ b/openspec/changes/namespace-db-app-arch/tasks.md
@@ -1,0 +1,66 @@
+# Tasks
+
+Ordered by dependency. Practice TDD throughout: write the failing test first. Use AssertJ,
+extend `BaseKoinTest`, use `@TempDir` for temporary directories. No mock-echo tests — every
+test must exercise a decision, transformation, or real failure mode. Never mock
+`TemplateService`. Add class-level KDoc; no wildcard imports; use `RetryUtil` (resilience4j)
+for AWS retries.
+
+## 1. Consolidated instance-type query (closes #783)
+
+- [ ] 1.1 Write a failing test: an instance type not present in the SDK's `InstanceType` enum
+  is resolved successfully — no `[null]` error — for both instance-store detection and
+  architecture, because the query passes the type as an `instance-type` filter string.
+- [ ] 1.2 Add `EC2InstanceService.describeInstanceType(type)` returning a value with
+  `hasInstanceStore` and `supportedArchitectures`, built from a single filter-based
+  `DescribeInstanceTypes` call wrapped in `RetryUtil`. An empty result throws naming the
+  type and region.
+- [ ] 1.3 Reimplement `hasInstanceStore()` as a thin reader over `describeInstanceType`.
+- [ ] 1.4 Move the RunInstances path (`createSingleInstance`) off `InstanceType.fromValue`
+  onto the string-accepting `instanceType(String)` overload; do not reintroduce
+  `InstanceType.fromValue` for user-supplied types anywhere.
+
+## 2. Architecture mapping helper
+
+- [ ] 2.1 Write a failing test for `Arch.fromEc2`: `x86_64` → AMD64, `arm64` → ARM64;
+  `i386`, empty, unrecognized, and multiple-mappable inputs each throw naming the cause.
+- [ ] 2.2 Add `Arch.fromEc2(...)` implementing that mapping.
+
+## 3. Namespaced options and precedence
+
+- [ ] 3.1 Write a failing test: when both a namespaced option and its legacy alias are set,
+  the resolved value is the namespaced one, independent of argument order; when only the
+  legacy flag (or neither) is set, the legacy value / default is used.
+- [ ] 3.2 Add nullable, no-default `@Option`s `--db.instance-type`, `--app.instance-type`,
+  `--db.count`, `--app.count` on `Init`, following the `--ebs.*` individual-`@Option`
+  precedent (no `@ArgGroup`). Keep every legacy flag as an alias with its current default.
+- [ ] 3.3 Add resolved accessors on `Init` (`resolved = namespaced ?: legacy`) and state the
+  namespaced-wins precedence in each option's `--help` description.
+- [ ] 3.4 `InitConfig.fromInit` reads the resolved accessors, not the raw legacy fields.
+
+## 4. Architecture derivation at init; remove `--arch`
+
+- [ ] 4.1 Write a failing test: `init` derives each group's architecture from its resolved
+  instance type via `describeInstanceType`, and an unknown instance type fails at `init`
+  before any provisioning, naming the type and region.
+- [ ] 4.2 Derive `dbArch` / `appArch` / `controlArch` in `Init.execute` and persist them.
+- [ ] 4.3 Replace `InitConfig.arch: String` with defaulted `dbArch` / `appArch` /
+  `controlArch`; confirm an older `state.json` (with the old single `arch`) still loads.
+- [ ] 4.4 Remove the `--arch` / `-a` / `--cpu` option from `Init` (keep `Arch` and
+  `PicoArchConverter` for the `build-image` path).
+
+## 5. Per-architecture AMIs through provisioning
+
+- [ ] 5.1 Write a failing test: a mixed-architecture cluster (db `arm64`, app `x86_64`)
+  provisions each group from the AMI matching its own architecture; distinct architectures
+  are resolved once each and attached per group.
+- [ ] 5.2 Add the resolved AMI (or arch) to `InstanceSpec`; resolve one AMI per distinct
+  architecture in `Up.buildInstanceConfig` and attach it per spec.
+- [ ] 5.3 Have `createInstancesForType` read `spec.amiId`; drop the global `amiId` from
+  `InstanceProvisioningConfig` and its infra-context.
+
+## 6. Documentation
+
+- [ ] 6.1 Update the `init` reference in `docs/` for `--db.*` / `--app.*`, the legacy
+  aliases and precedence, and the removal of `--arch`.
+- [ ] 6.2 Update `CLAUDE.md` flag notes where they describe init options or architecture.

--- a/openspec/changes/namespace-db-app-arch/tasks.md
+++ b/openspec/changes/namespace-db-app-arch/tasks.md
@@ -8,23 +8,23 @@ for AWS retries.
 
 ## 1. Consolidated instance-type query (closes #783)
 
-- [ ] 1.1 Write a failing test: an instance type not present in the SDK's `InstanceType` enum
+- [x] 1.1 Write a failing test: an instance type not present in the SDK's `InstanceType` enum
   is resolved successfully — no `[null]` error — for both instance-store detection and
   architecture, because the query passes the type as an `instance-type` filter string.
-- [ ] 1.2 Add `EC2InstanceService.describeInstanceType(type)` returning a value with
+- [x] 1.2 Add `EC2InstanceService.describeInstanceType(type)` returning a value with
   `hasInstanceStore` and `supportedArchitectures`, built from a single filter-based
   `DescribeInstanceTypes` call wrapped in `RetryUtil`. An empty result throws naming the
   type and region.
-- [ ] 1.3 Reimplement `hasInstanceStore()` as a thin reader over `describeInstanceType`.
-- [ ] 1.4 Move the RunInstances path (`createSingleInstance`) off `InstanceType.fromValue`
+- [x] 1.3 Reimplement `hasInstanceStore()` as a thin reader over `describeInstanceType`.
+- [x] 1.4 Move the RunInstances path (`createSingleInstance`) off `InstanceType.fromValue`
   onto the string-accepting `instanceType(String)` overload; do not reintroduce
   `InstanceType.fromValue` for user-supplied types anywhere.
 
 ## 2. Architecture mapping helper
 
-- [ ] 2.1 Write a failing test for `Arch.fromEc2`: `x86_64` → AMD64, `arm64` → ARM64;
+- [x] 2.1 Write a failing test for `Arch.fromEc2`: `x86_64` → AMD64, `arm64` → ARM64;
   `i386`, empty, unrecognized, and multiple-mappable inputs each throw naming the cause.
-- [ ] 2.2 Add `Arch.fromEc2(...)` implementing that mapping.
+- [x] 2.2 Add `Arch.fromEc2(...)` implementing that mapping.
 
 ## 3. Namespaced options and precedence
 

--- a/openspec/changes/namespace-db-app-arch/tasks.md
+++ b/openspec/changes/namespace-db-app-arch/tasks.md
@@ -40,23 +40,23 @@ for AWS retries.
 
 ## 4. Architecture derivation at init; remove `--arch`
 
-- [ ] 4.1 Write a failing test: `init` derives each group's architecture from its resolved
+- [x] 4.1 Write a failing test: `init` derives each group's architecture from its resolved
   instance type via `describeInstanceType`, and an unknown instance type fails at `init`
   before any provisioning, naming the type and region.
-- [ ] 4.2 Derive `dbArch` / `appArch` / `controlArch` in `Init.execute` and persist them.
-- [ ] 4.3 Replace `InitConfig.arch: String` with defaulted `dbArch` / `appArch` /
+- [x] 4.2 Derive `dbArch` / `appArch` / `controlArch` in `Init.execute` and persist them.
+- [x] 4.3 Replace `InitConfig.arch: String` with defaulted `dbArch` / `appArch` /
   `controlArch`; confirm an older `state.json` (with the old single `arch`) still loads.
-- [ ] 4.4 Remove the `--arch` / `-a` / `--cpu` option from `Init` (keep `Arch` and
+- [x] 4.4 Remove the `--arch` / `-a` / `--cpu` option from `Init` (keep `Arch` and
   `PicoArchConverter` for the `build-image` path).
 
 ## 5. Per-architecture AMIs through provisioning
 
-- [ ] 5.1 Write a failing test: a mixed-architecture cluster (db `arm64`, app `x86_64`)
+- [x] 5.1 Write a failing test: a mixed-architecture cluster (db `arm64`, app `x86_64`)
   provisions each group from the AMI matching its own architecture; distinct architectures
   are resolved once each and attached per group.
-- [ ] 5.2 Add the resolved AMI (or arch) to `InstanceSpec`; resolve one AMI per distinct
+- [x] 5.2 Add the resolved AMI (or arch) to `InstanceSpec`; resolve one AMI per distinct
   architecture in `Up.buildInstanceConfig` and attach it per spec.
-- [ ] 5.3 Have `createInstancesForType` read `spec.amiId`; drop the global `amiId` from
+- [x] 5.3 Have `createInstancesForType` read `spec.amiId`; drop the global `amiId` from
   `InstanceProvisioningConfig` and its infra-context.
 
 ## 6. Documentation

--- a/openspec/changes/namespace-db-app-arch/tasks.md
+++ b/openspec/changes/namespace-db-app-arch/tasks.md
@@ -61,6 +61,6 @@ for AWS retries.
 
 ## 6. Documentation
 
-- [ ] 6.1 Update the `init` reference in `docs/` for `--db.*` / `--app.*`, the legacy
+- [x] 6.1 Update the `init` reference in `docs/` for `--db.*` / `--app.*`, the legacy
   aliases and precedence, and the removal of `--arch`.
-- [ ] 6.2 Update `CLAUDE.md` flag notes where they describe init options or architecture.
+- [x] 6.2 Update `CLAUDE.md` flag notes where they describe init options or architecture.

--- a/openspec/changes/namespace-db-app-arch/tasks.md
+++ b/openspec/changes/namespace-db-app-arch/tasks.md
@@ -28,15 +28,15 @@ for AWS retries.
 
 ## 3. Namespaced options and precedence
 
-- [ ] 3.1 Write a failing test: when both a namespaced option and its legacy alias are set,
+- [x] 3.1 Write a failing test: when both a namespaced option and its legacy alias are set,
   the resolved value is the namespaced one, independent of argument order; when only the
   legacy flag (or neither) is set, the legacy value / default is used.
-- [ ] 3.2 Add nullable, no-default `@Option`s `--db.instance-type`, `--app.instance-type`,
+- [x] 3.2 Add nullable, no-default `@Option`s `--db.instance-type`, `--app.instance-type`,
   `--db.count`, `--app.count` on `Init`, following the `--ebs.*` individual-`@Option`
   precedent (no `@ArgGroup`). Keep every legacy flag as an alias with its current default.
-- [ ] 3.3 Add resolved accessors on `Init` (`resolved = namespaced ?: legacy`) and state the
+- [x] 3.3 Add resolved accessors on `Init` (`resolved = namespaced ?: legacy`) and state the
   namespaced-wins precedence in each option's `--help` description.
-- [ ] 3.4 `InitConfig.fromInit` reads the resolved accessors, not the raw legacy fields.
+- [x] 3.4 `InitConfig.fromInit` reads the resolved accessors, not the raw legacy fields.
 
 ## 4. Architecture derivation at init; remove `--arch`
 

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Init.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Init.kt
@@ -68,15 +68,27 @@ class Init : PicoBaseCommand() {
 
     @Option(
         names = ["--db", "--cassandra", "-c"],
-        description = ["Number of database instances"],
+        description = ["Legacy alias for --db.count. Number of database instances"],
     )
     var cassandraInstances = DEFAULT_CASSANDRA_INSTANCE_COUNT
 
     @Option(
+        names = ["--db.count"],
+        description = ["Number of database instances. Takes precedence over the legacy --db/--cassandra/-c alias"],
+    )
+    var dbCount: Int? = null
+
+    @Option(
         names = ["--app", "--stress", "-s"],
-        description = ["Number of application instances"],
+        description = ["Legacy alias for --app.count. Number of application instances"],
     )
     var stressInstances = 0
+
+    @Option(
+        names = ["--app.count"],
+        description = ["Number of application instances. Takes precedence over the legacy --app/--stress/-s alias"],
+    )
+    var appCount: Int? = null
 
     @Option(
         names = ["--up"],
@@ -86,15 +98,38 @@ class Init : PicoBaseCommand() {
 
     @Option(
         names = ["--instance", "-i"],
-        description = ["Instance Type. Set EASY_DB_LAB_INSTANCE_TYPE to set a default."],
+        description = [
+            "Legacy alias for --db.instance-type. Database instance type. " +
+                "Set EASY_DB_LAB_INSTANCE_TYPE to set a default.",
+        ],
     )
     var instanceType: String = System.getenv("EASY_DB_LAB_INSTANCE_TYPE") ?: "i4i.xlarge"
 
     @Option(
+        names = ["--db.instance-type"],
+        description = [
+            "Database instance type. Takes precedence over the legacy --instance/-i alias.",
+        ],
+    )
+    var dbInstanceType: String? = null
+
+    @Option(
         names = ["--stress-instance", "-si", "--si"],
-        description = ["Stress Instance Type. Set EASY_DB_LAB_STRESS_INSTANCE_TYPE to set a default."],
+        description = [
+            "Legacy alias for --app.instance-type. Application (stress) instance type. " +
+                "Set EASY_DB_LAB_STRESS_INSTANCE_TYPE to set a default.",
+        ],
     )
     var stressInstanceType: String = System.getenv("EASY_DB_LAB_STRESS_INSTANCE_TYPE") ?: "c6id.2xlarge"
+
+    @Option(
+        names = ["--app.instance-type"],
+        description = [
+            "Application (stress) instance type. " +
+                "Takes precedence over the legacy --stress-instance/-si alias.",
+        ],
+    )
+    var appInstanceType: String? = null
 
     @Option(
         names = ["--azs", "--az", "-z"],
@@ -208,6 +243,34 @@ class Init : PicoBaseCommand() {
     )
     var cilium = false
 
+    /**
+     * Resolved number of database instances: the namespaced `--db.count` when supplied, otherwise
+     * the legacy `--db`/`--cassandra`/`-c` alias (or its default). Namespaced always wins.
+     */
+    @get:JsonIgnore
+    val resolvedDbCount: Int get() = dbCount ?: cassandraInstances
+
+    /**
+     * Resolved number of application instances: the namespaced `--app.count` when supplied,
+     * otherwise the legacy `--app`/`--stress`/`-s` alias (or its default). Namespaced always wins.
+     */
+    @get:JsonIgnore
+    val resolvedAppCount: Int get() = appCount ?: stressInstances
+
+    /**
+     * Resolved database instance type: the namespaced `--db.instance-type` when supplied, otherwise
+     * the legacy `--instance`/`-i` alias (or its default). Namespaced always wins.
+     */
+    @get:JsonIgnore
+    val resolvedDbInstanceType: String get() = dbInstanceType ?: instanceType
+
+    /**
+     * Resolved application instance type: the namespaced `--app.instance-type` when supplied,
+     * otherwise the legacy `--stress-instance`/`-si` alias (or its default). Namespaced always wins.
+     */
+    @get:JsonIgnore
+    val resolvedAppInstanceType: String get() = appInstanceType ?: stressInstanceType
+
     override fun execute() {
         validateParameters()
 
@@ -242,8 +305,8 @@ class Init : PicoBaseCommand() {
     }
 
     private fun validateParameters() {
-        require(cassandraInstances > 0) { "Number of Cassandra instances must be positive" }
-        require(stressInstances >= 0) { "Number of stress instances cannot be negative" }
+        require(resolvedDbCount > 0) { "Number of database instances must be positive" }
+        require(resolvedAppCount >= 0) { "Number of application instances cannot be negative" }
         require(ebsSize > 0) { "EBS size must be positive" }
         require(ebsIops >= 0) { "EBS IOPS cannot be negative" }
         require(ebsThroughput >= 0) { "EBS throughput cannot be negative" }

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Init.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Init.kt
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import com.rustyrazorblade.easydblab.annotations.McpCommand
 import com.rustyrazorblade.easydblab.annotations.RequireProfileSetup
 import com.rustyrazorblade.easydblab.commands.converters.PicoAZConverter
-import com.rustyrazorblade.easydblab.commands.converters.PicoArchConverter
 import com.rustyrazorblade.easydblab.commands.mixins.OpenSearchInitMixin
 import com.rustyrazorblade.easydblab.commands.mixins.SparkInitMixin
 import com.rustyrazorblade.easydblab.configuration.Arch
@@ -14,6 +13,7 @@ import com.rustyrazorblade.easydblab.configuration.User
 import com.rustyrazorblade.easydblab.events.Event
 import com.rustyrazorblade.easydblab.network.CidrBlock
 import com.rustyrazorblade.easydblab.services.CommandExecutor
+import com.rustyrazorblade.easydblab.services.aws.EC2InstanceService
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.koin.core.component.inject
 import picocli.CommandLine.Command
@@ -58,10 +58,14 @@ import kotlin.system.exitProcess
 class Init : PicoBaseCommand() {
     private val userConfig: User by inject()
     private val commandExecutor: CommandExecutor by inject()
+    private val ec2InstanceService: EC2InstanceService by inject()
 
     companion object {
         private const val DEFAULT_CASSANDRA_INSTANCE_COUNT = 3
         private const val DEFAULT_EBS_SIZE_GB = 256
+
+        /** Control node instance type. Kept in sync with [InitConfig] control defaults. */
+        const val DEFAULT_CONTROL_INSTANCE_TYPE = "m5d.xlarge"
 
         @JsonIgnore val log = KotlinLogging.logger {}
     }
@@ -191,13 +195,6 @@ class Init : PicoBaseCommand() {
         defaultValue = "test",
     )
     var name = "test"
-
-    @Option(
-        names = ["--arch", "-a", "--cpu"],
-        description = ["CPU architecture"],
-        converter = [PicoArchConverter::class],
-    )
-    var arch: Arch = Arch.AMD64
 
     @Mixin
     var spark = SparkInitMixin()
@@ -345,12 +342,28 @@ class Init : PicoBaseCommand() {
             ClusterState(
                 name = name,
                 versions = mutableMapOf(),
-                initConfig = InitConfig.fromInit(this, userConfig.region),
+                initConfig =
+                    InitConfig.fromInit(
+                        init = this,
+                        region = userConfig.region,
+                        dbArch = deriveArch(resolvedDbInstanceType),
+                        appArch = deriveArch(resolvedAppInstanceType),
+                        controlArch = deriveArch(DEFAULT_CONTROL_INSTANCE_TYPE),
+                    ),
                 tailscaleActive = userConfig.isTailscaleEnabled() && !noTailscale,
             )
         clusterStateManager.save(state)
         return state
     }
+
+    /**
+     * Derives the CPU architecture of an instance type from its EC2 `SupportedArchitectures`.
+     *
+     * Fails fast (before any provisioning) if the instance type is unknown in the region or its
+     * architectures do not resolve to a single [Arch] — the architecture is never defaulted.
+     */
+    private fun deriveArch(instanceType: String): Arch =
+        Arch.fromEc2(ec2InstanceService.describeInstanceType(instanceType).supportedArchitectures)
 
     private fun extractResourceFiles() {
         eventBus.emit(Event.Setup.WritingSetupScript)

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Up.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Up.kt
@@ -382,10 +382,19 @@ class Up(
         baseTags: Map<String, String>,
     ): InstanceProvisioningConfig {
         val existingInstances = ec2InstanceService.findInstancesByClusterId(workingState.clusterId)
-        val dbHasInstanceStore = ec2InstanceService.hasInstanceStore(initConfig.instanceType)
-        val amiByArch = resolveAmisByArch(initConfig)
+        // One DescribeInstanceTypes query reports both instance-store presence and supported
+        // architectures; take instance-store from it rather than a second per-type API call.
+        val dbCapabilities = ec2InstanceService.describeInstanceType(initConfig.instanceType)
+        val launchingGroups = launchingNodeGroups(initConfig)
+        val amiByArch = resolveAmisByArch(initConfig, launchingGroups)
+        logResolvedGroupAmis(launchingGroups, amiByArch)
         val instanceSpecs =
-            instanceSpecFactory.createInstanceSpecs(initConfig, existingInstances, dbHasInstanceStore, amiByArch)
+            instanceSpecFactory.createInstanceSpecs(
+                initConfig,
+                existingInstances,
+                dbCapabilities.hasInstanceStore,
+                amiByArch,
+            )
         return InstanceProvisioningConfig(
             specs = instanceSpecs,
             securityGroupId = securityGroupId,
@@ -397,20 +406,68 @@ class Up(
     }
 
     /**
-     * Resolves one AMI per distinct CPU architecture across the cluster's node groups.
+     * A node group that will launch at least one instance, paired with the instance type and CPU
+     * architecture that drive its AMI selection.
+     */
+    private data class NodeGroupArch(
+        val serverType: ServerType,
+        val instanceType: String,
+        val arch: Arch,
+    )
+
+    /**
+     * The node groups that will actually launch instances, i.e. those with a configured count above
+     * zero. A group with zero nodes (commonly the application group) contributes no architecture, so
+     * `up` never resolves or requires an AMI for an image it will not use.
+     */
+    private fun launchingNodeGroups(initConfig: InitConfig): List<NodeGroupArch> =
+        buildList {
+            if (initConfig.cassandraInstances > 0) {
+                add(NodeGroupArch(ServerType.Cassandra, initConfig.instanceType, Arch.valueOf(initConfig.dbArch)))
+            }
+            if (initConfig.stressInstances > 0) {
+                add(NodeGroupArch(ServerType.Stress, initConfig.stressInstanceType, Arch.valueOf(initConfig.appArch)))
+            }
+            if (initConfig.controlInstances > 0) {
+                add(NodeGroupArch(ServerType.Control, initConfig.controlInstanceType, Arch.valueOf(initConfig.controlArch)))
+            }
+        }
+
+    /**
+     * Resolves one AMI per distinct CPU architecture across the cluster's launching node groups.
      *
      * A mixed-architecture cluster (e.g. an arm64 database group and an x86_64 application group)
      * resolves each distinct architecture exactly once; the resulting map is attached per group so
-     * every node boots from the image matching its own architecture.
+     * every node boots from the image matching its own architecture. Architectures that belong only
+     * to node groups with zero nodes are not resolved, so `up` does not demand an unused image.
      */
-    private fun resolveAmisByArch(initConfig: InitConfig): Map<Arch, String> {
-        val distinctArchs =
-            setOf(initConfig.dbArch, initConfig.appArch, initConfig.controlArch)
-                .map { Arch.valueOf(it) }
-        return distinctArchs.associateWith { arch ->
-            amiResolver.resolveAmiId(initConfig.ami, arch.type).getOrElse { error ->
-                error(error.message ?: "Failed to resolve AMI for architecture $arch")
+    private fun resolveAmisByArch(
+        initConfig: InitConfig,
+        launchingGroups: List<NodeGroupArch>,
+    ): Map<Arch, String> =
+        launchingGroups
+            .map { it.arch }
+            .distinct()
+            .associateWith { arch ->
+                amiResolver.resolveAmiId(initConfig.ami, arch.type).getOrElse { error ->
+                    error(error.message ?: "Failed to resolve AMI for architecture $arch")
+                }
             }
+
+    /**
+     * Logs the per-group architecture/AMI decision on the success path so a mixed-architecture
+     * launch is diagnosable: each launching group's instance type, derived CPU architecture, and the
+     * AMI selected for it.
+     */
+    private fun logResolvedGroupAmis(
+        launchingGroups: List<NodeGroupArch>,
+        amiByArch: Map<Arch, String>,
+    ) {
+        log.info {
+            "Resolved per-group AMIs: " +
+                launchingGroups.joinToString { group ->
+                    "${group.serverType}[${group.instanceType}/${group.arch}]=${amiByArch[group.arch]}"
+                }
         }
     }
 

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Up.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Up.kt
@@ -9,6 +9,7 @@ import com.rustyrazorblade.easydblab.commands.cassandra.WriteConfig
 import com.rustyrazorblade.easydblab.commands.grafana.GrafanaUpdateConfig
 import com.rustyrazorblade.easydblab.commands.mixins.HostsMixin
 import com.rustyrazorblade.easydblab.commands.tailscale.TailscaleStart
+import com.rustyrazorblade.easydblab.configuration.Arch
 import com.rustyrazorblade.easydblab.configuration.ClusterHost
 import com.rustyrazorblade.easydblab.configuration.ClusterState
 import com.rustyrazorblade.easydblab.configuration.InfrastructureState
@@ -313,11 +314,6 @@ class Up(
         val securityGroupId = vpcInfra.securityGroupId
         val igwId = vpcInfra.internetGatewayId
 
-        val amiId =
-            amiResolver.resolveAmiId(initConfig.ami, initConfig.arch).getOrElse { error ->
-                error(error.message ?: "Failed to resolve AMI")
-            }
-
         val baseTags =
             mapOf(
                 "easy_cass_lab" to "1",
@@ -325,7 +321,7 @@ class Up(
             ) + initConfig.tags
 
         val existingHosts = discoverExistingHosts()
-        val instanceConfig = buildInstanceConfig(initConfig, amiId, securityGroupId, subnetIds, baseTags)
+        val instanceConfig = buildInstanceConfig(initConfig, securityGroupId, subnetIds, baseTags)
         val servicesConfig = buildServicesConfig(initConfig, subnetIds, securityGroupId, baseTags)
 
         if (initConfig.opensearchEnabled) {
@@ -381,23 +377,41 @@ class Up(
 
     private fun buildInstanceConfig(
         initConfig: InitConfig,
-        amiId: String,
         securityGroupId: String,
         subnetIds: List<String>,
         baseTags: Map<String, String>,
     ): InstanceProvisioningConfig {
         val existingInstances = ec2InstanceService.findInstancesByClusterId(workingState.clusterId)
         val dbHasInstanceStore = ec2InstanceService.hasInstanceStore(initConfig.instanceType)
-        val instanceSpecs = instanceSpecFactory.createInstanceSpecs(initConfig, existingInstances, dbHasInstanceStore)
+        val amiByArch = resolveAmisByArch(initConfig)
+        val instanceSpecs =
+            instanceSpecFactory.createInstanceSpecs(initConfig, existingInstances, dbHasInstanceStore, amiByArch)
         return InstanceProvisioningConfig(
             specs = instanceSpecs,
-            amiId = amiId,
             securityGroupId = securityGroupId,
             subnetIds = subnetIds,
             tags = baseTags,
             clusterName = initConfig.name,
             userConfig = userConfig,
         )
+    }
+
+    /**
+     * Resolves one AMI per distinct CPU architecture across the cluster's node groups.
+     *
+     * A mixed-architecture cluster (e.g. an arm64 database group and an x86_64 application group)
+     * resolves each distinct architecture exactly once; the resulting map is attached per group so
+     * every node boots from the image matching its own architecture.
+     */
+    private fun resolveAmisByArch(initConfig: InitConfig): Map<Arch, String> {
+        val distinctArchs =
+            setOf(initConfig.dbArch, initConfig.appArch, initConfig.controlArch)
+                .map { Arch.valueOf(it) }
+        return distinctArchs.associateWith { arch ->
+            amiResolver.resolveAmiId(initConfig.ami, arch.type).getOrElse { error ->
+                error(error.message ?: "Failed to resolve AMI for architecture $arch")
+            }
+        }
     }
 
     private fun buildServicesConfig(

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/Arch.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/Arch.kt
@@ -10,4 +10,44 @@ enum class Arch(
 ) {
     AMD64("amd64"),
     ARM64("arm64"),
+    ;
+
+    companion object {
+        /**
+         * Maps the EC2 `SupportedArchitectures` values reported by `DescribeInstanceTypes` onto an
+         * [Arch]. The `x86_64` value maps to [AMD64] and `arm64` maps to [ARM64].
+         *
+         * The instance type's architectures MUST resolve to exactly one [Arch]. An empty list, an
+         * unrecognized value (e.g. `i386`), or a set that maps to more than one architecture is
+         * rejected — the cluster cannot select an AMI for an ambiguous or unknown architecture.
+         *
+         * @param supportedArchitectures EC2 architecture strings (e.g. `["x86_64"]`)
+         * @return the single derived [Arch]
+         * @throws IllegalArgumentException if the architectures do not resolve to exactly one [Arch]
+         */
+        fun fromEc2(supportedArchitectures: List<String>): Arch {
+            require(supportedArchitectures.isNotEmpty()) {
+                "Instance type reported no supported architectures; cannot derive CPU architecture"
+            }
+
+            val mapped =
+                supportedArchitectures
+                    .map { value ->
+                        when (value) {
+                            "x86_64" -> AMD64
+                            "arm64" -> ARM64
+                            else -> throw IllegalArgumentException(
+                                "Unsupported CPU architecture '$value'; only x86_64 and arm64 are supported",
+                            )
+                        }
+                    }.toSet()
+
+            require(mapped.size == 1) {
+                "Instance type maps to multiple CPU architectures $supportedArchitectures; " +
+                    "cannot derive a single architecture"
+            }
+
+            return mapped.first()
+        }
+    }
 }

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/ClusterState.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/ClusterState.kt
@@ -122,10 +122,10 @@ data class InitConfig(
             region: String,
         ): InitConfig =
             InitConfig(
-                cassandraInstances = init.cassandraInstances,
-                stressInstances = init.stressInstances,
-                instanceType = init.instanceType,
-                stressInstanceType = init.stressInstanceType,
+                cassandraInstances = init.resolvedDbCount,
+                stressInstances = init.resolvedAppCount,
+                instanceType = init.resolvedDbInstanceType,
+                stressInstanceType = init.resolvedAppInstanceType,
                 azs = init.azs,
                 ami = init.ami,
                 region = region,

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/ClusterState.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/ClusterState.kt
@@ -94,7 +94,9 @@ data class InitConfig(
     val controlInstances: Int = 1,
     val controlInstanceType: String = "m5d.xlarge",
     val tags: Map<String, String> = mapOf(),
-    val arch: String = "AMD64",
+    val dbArch: String = "AMD64",
+    val appArch: String = "AMD64",
+    val controlArch: String = "AMD64",
     val sparkEnabled: Boolean = false,
     val sparkMasterInstanceType: String = "m5.xlarge",
     val sparkWorkerInstanceType: String = "m5.xlarge",
@@ -113,13 +115,22 @@ data class InitConfig(
          * Factory method to create InitConfig from an Init command instance.
          * Encapsulates the transformation logic in a single location.
          *
+         * Architectures are derived from each group's resolved instance type and passed in, rather
+         * than read from a user flag — the architecture is a property of the instance type.
+         *
          * @param init The Init command instance containing user-specified configuration
          * @param region The AWS region from user configuration
+         * @param dbArch Architecture derived from the resolved database instance type
+         * @param appArch Architecture derived from the resolved application instance type
+         * @param controlArch Architecture derived from the control instance type
          * @return A new InitConfig with values from the Init command
          */
         fun fromInit(
             init: Init,
             region: String,
+            dbArch: Arch,
+            appArch: Arch,
+            controlArch: Arch,
         ): InitConfig =
             InitConfig(
                 cassandraInstances = init.resolvedDbCount,
@@ -137,9 +148,11 @@ data class InitConfig(
                 ebsOptimized = init.ebsOptimized,
                 open = init.open,
                 controlInstances = 1,
-                controlInstanceType = "m5d.xlarge",
+                controlInstanceType = Init.DEFAULT_CONTROL_INSTANCE_TYPE,
                 tags = init.tags,
-                arch = init.arch.name,
+                dbArch = dbArch.name,
+                appArch = appArch.name,
+                controlArch = controlArch.name,
                 sparkEnabled = init.spark.enable,
                 sparkMasterInstanceType = init.spark.masterInstanceType,
                 sparkWorkerInstanceType = init.spark.workerInstanceType,

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/providers/aws/AWSModule.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/providers/aws/AWSModule.kt
@@ -162,6 +162,7 @@ val awsModule =
             EC2InstanceService(
                 get<Ec2Client>(),
                 get<EventBus>(),
+                region = get<Region>().id(),
             )
         }
 

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/ClusterProvisioningService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/ClusterProvisioningService.kt
@@ -25,7 +25,9 @@ import kotlin.concurrent.thread
 /**
  * Infrastructure parameters for instance creation.
  *
- * @property amiId AMI ID to use for instances
+ * The AMI is not part of this context — it is resolved per architecture and carried on each
+ * [InstanceSpec], so mixed-architecture clusters attach the correct image per group.
+ *
  * @property keyName SSH key pair name
  * @property securityGroupId Security group ID
  * @property subnetIds Available subnet IDs
@@ -33,7 +35,6 @@ import kotlin.concurrent.thread
  * @property clusterName Name of the cluster
  */
 data class InfrastructureContext(
-    val amiId: String,
     val keyName: String,
     val securityGroupId: String,
     val subnetIds: List<String>,
@@ -59,8 +60,7 @@ data class ProvisioningResult(
 /**
  * Configuration for provisioning instances.
  *
- * @property specs Instance specifications for each server type
- * @property amiId AMI ID to use for instances
+ * @property specs Instance specifications for each server type, each carrying its own AMI
  * @property securityGroupId Security group for instances
  * @property subnetIds Available subnet IDs
  * @property tags Tags to apply to instances
@@ -69,7 +69,6 @@ data class ProvisioningResult(
  */
 data class InstanceProvisioningConfig(
     val specs: List<InstanceSpec>,
-    val amiId: String,
     val securityGroupId: String,
     val subnetIds: List<String>,
     val tags: Map<String, String>,
@@ -200,7 +199,6 @@ class DefaultClusterProvisioningService(
                         try {
                             val infraContext =
                                 InfrastructureContext(
-                                    amiId = config.amiId,
                                     keyName = config.userConfig.keyName,
                                     securityGroupId = config.securityGroupId,
                                     subnetIds = config.subnetIds,
@@ -371,7 +369,6 @@ class DefaultClusterProvisioningService(
 
     private fun InstanceProvisioningConfig.toInfrastructureContext() =
         InfrastructureContext(
-            amiId = amiId,
             keyName = userConfig.keyName,
             securityGroupId = securityGroupId,
             subnetIds = subnetIds,
@@ -388,7 +385,7 @@ class DefaultClusterProvisioningService(
                 serverType = spec.serverType,
                 count = spec.neededCount,
                 instanceType = spec.instanceType,
-                amiId = infraContext.amiId,
+                amiId = spec.amiId,
                 keyName = infraContext.keyName,
                 securityGroupId = infraContext.securityGroupId,
                 subnetIds = infraContext.subnetIds,

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/aws/EC2InstanceService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/aws/EC2InstanceService.kt
@@ -68,6 +68,12 @@ class EC2InstanceService(
 
         /** Polling interval for checking instance state */
         const val POLL_INTERVAL_MS = 5000L
+
+        /**
+         * Page size for `DescribeInstanceTypes`. The API applies the instance-type filter per page,
+         * so a larger page reduces the number of round-trips needed to reach the matching type.
+         */
+        const val INSTANCE_TYPES_PAGE_SIZE = 100
     }
 
     /**
@@ -391,39 +397,51 @@ class EC2InstanceService(
      * depend on the installed SDK version — any valid EC2 instance type is accepted, including a
      * type newer than the SDK (closes #783; previously such types failed with a `[null]` error).
      *
-     * A single call reports both whether the type has local instance store and its supported CPU
-     * architectures, so both facts are obtained from one query per instance type.
+     * The call reports both whether the type has local instance store and its supported CPU
+     * architectures, so both facts are obtained from the same query.
+     *
+     * `DescribeInstanceTypes` applies the instance-type filter **per page**, so a matching type can
+     * sit behind an empty page that still carries a `nextToken`. This follows `nextToken` across
+     * pages and only reports "not found" once every page is exhausted with no match — reading only
+     * the first page would misreport a common type (e.g. `i4i.xlarge`) as unknown.
      *
      * @param instanceType EC2 instance type (e.g., "i3.xlarge", "c5.2xlarge")
      * @return the instance type's capabilities
-     * @throws IllegalStateException if the type is unknown in the region (empty result)
+     * @throws IllegalStateException if the type is unknown in the region (no match across all pages)
      */
     fun describeInstanceType(instanceType: String): InstanceTypeCapabilities {
-        val request =
-            DescribeInstanceTypesRequest
-                .builder()
-                .filters(
-                    Filter
-                        .builder()
-                        .name("instance-type")
-                        .values(instanceType)
-                        .build(),
-                ).build()
+        var nextToken: String? = null
+        do {
+            val request =
+                DescribeInstanceTypesRequest
+                    .builder()
+                    .filters(
+                        Filter
+                            .builder()
+                            .name("instance-type")
+                            .values(instanceType)
+                            .build(),
+                    ).maxResults(INSTANCE_TYPES_PAGE_SIZE)
+                    .nextToken(nextToken)
+                    .build()
 
-        val response =
-            RetryUtil.withAwsRetry("describe-instance-type-$instanceType") {
-                ec2Client.describeInstanceTypes(request)
+            val response =
+                RetryUtil.withAwsRetry("describe-instance-type-$instanceType") {
+                    ec2Client.describeInstanceTypes(request)
+                }
+
+            val typeInfo = response.instanceTypes().firstOrNull()
+            if (typeInfo != null) {
+                return InstanceTypeCapabilities(
+                    hasInstanceStore = typeInfo.instanceStorageSupported() == true,
+                    supportedArchitectures =
+                        typeInfo.processorInfo()?.supportedArchitecturesAsStrings().orEmpty(),
+                )
             }
+            nextToken = response.nextToken()
+        } while (!nextToken.isNullOrEmpty())
 
-        val typeInfo =
-            response.instanceTypes().firstOrNull()
-                ?: error("Instance type '$instanceType' not found in region $region")
-
-        return InstanceTypeCapabilities(
-            hasInstanceStore = typeInfo.instanceStorageSupported() == true,
-            supportedArchitectures =
-                typeInfo.processorInfo()?.supportedArchitecturesAsStrings().orEmpty(),
-        )
+        error("Instance type '$instanceType' not found in region $region")
     }
 
     /**

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/aws/EC2InstanceService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/aws/EC2InstanceService.kt
@@ -427,16 +427,6 @@ class EC2InstanceService(
     }
 
     /**
-     * Checks whether the given EC2 instance type has local instance store (NVMe) volumes.
-     *
-     * Thin reader over [describeInstanceType].
-     *
-     * @param instanceType EC2 instance type (e.g., "i3.xlarge", "c5.2xlarge")
-     * @return true if the instance type has instance store, false otherwise
-     */
-    fun hasInstanceStore(instanceType: String): Boolean = describeInstanceType(instanceType).hasInstanceStore
-
-    /**
      * Finds all running instances belonging to a cluster by ClusterId tag.
      *
      * Used to discover existing infrastructure before creating new instances,

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/aws/EC2InstanceService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/aws/EC2InstanceService.kt
@@ -22,7 +22,6 @@ import software.amazon.awssdk.services.ec2.model.HttpTokensState
 import software.amazon.awssdk.services.ec2.model.IamInstanceProfileSpecification
 import software.amazon.awssdk.services.ec2.model.InstanceMetadataOptionsRequest
 import software.amazon.awssdk.services.ec2.model.InstanceStateName
-import software.amazon.awssdk.services.ec2.model.InstanceType
 import software.amazon.awssdk.services.ec2.model.ResourceType
 import software.amazon.awssdk.services.ec2.model.RunInstancesRequest
 import software.amazon.awssdk.services.ec2.model.Tag
@@ -30,6 +29,20 @@ import software.amazon.awssdk.services.ec2.model.TagSpecification
 import software.amazon.awssdk.services.ec2.model.VolumeType
 import software.amazon.awssdk.services.ec2.waiters.Ec2Waiter
 import java.time.Duration
+
+/**
+ * Capabilities of an EC2 instance type derived from a single `DescribeInstanceTypes` query.
+ *
+ * Consolidates the two facts the tool needs about an instance type — whether it has local instance
+ * store, and which CPU architectures it supports — so both are obtained from one API call.
+ *
+ * @property hasInstanceStore true if the instance type has local (NVMe) instance store volumes
+ * @property supportedArchitectures EC2 `SupportedArchitectures` strings (e.g. `["x86_64"]`)
+ */
+data class InstanceTypeCapabilities(
+    val hasInstanceStore: Boolean,
+    val supportedArchitectures: List<String>,
+)
 
 /**
  * Service for creating and managing EC2 instances.
@@ -41,6 +54,7 @@ import java.time.Duration
 class EC2InstanceService(
     private val ec2Client: Ec2Client,
     private val eventBus: EventBus,
+    private val region: String,
     private val pollInterval: Duration = Duration.ofMillis(POLL_INTERVAL_MS),
 ) {
     companion object {
@@ -105,7 +119,7 @@ class EC2InstanceService(
             RunInstancesRequest
                 .builder()
                 .imageId(config.amiId)
-                .instanceType(InstanceType.fromValue(config.instanceType))
+                .instanceType(config.instanceType)
                 .minCount(1)
                 .maxCount(1)
                 .keyName(config.keyName)
@@ -370,19 +384,31 @@ class EC2InstanceService(
     }
 
     /**
-     * Checks whether the given EC2 instance type has local instance store (NVMe) volumes.
+     * Queries the capabilities of an EC2 instance type in one `DescribeInstanceTypes` call.
      *
-     * Uses the DescribeInstanceTypes API to query instance type capabilities.
+     * The instance type is passed as an `instance-type` filter carrying the raw string, never
+     * routed through the SDK's fixed `InstanceType` enum. Instance-type support therefore does not
+     * depend on the installed SDK version — any valid EC2 instance type is accepted, including a
+     * type newer than the SDK (closes #783; previously such types failed with a `[null]` error).
+     *
+     * A single call reports both whether the type has local instance store and its supported CPU
+     * architectures, so both facts are obtained from one query per instance type.
      *
      * @param instanceType EC2 instance type (e.g., "i3.xlarge", "c5.2xlarge")
-     * @return true if the instance type has instance store, false otherwise
+     * @return the instance type's capabilities
+     * @throws IllegalStateException if the type is unknown in the region (empty result)
      */
-    fun hasInstanceStore(instanceType: String): Boolean {
+    fun describeInstanceType(instanceType: String): InstanceTypeCapabilities {
         val request =
             DescribeInstanceTypesRequest
                 .builder()
-                .instanceTypes(InstanceType.fromValue(instanceType))
-                .build()
+                .filters(
+                    Filter
+                        .builder()
+                        .name("instance-type")
+                        .values(instanceType)
+                        .build(),
+                ).build()
 
         val response =
             RetryUtil.withAwsRetry("describe-instance-type-$instanceType") {
@@ -391,10 +417,24 @@ class EC2InstanceService(
 
         val typeInfo =
             response.instanceTypes().firstOrNull()
-                ?: error("Instance type $instanceType not found")
+                ?: error("Instance type '$instanceType' not found in region $region")
 
-        return typeInfo.instanceStorageSupported() == true
+        return InstanceTypeCapabilities(
+            hasInstanceStore = typeInfo.instanceStorageSupported() == true,
+            supportedArchitectures =
+                typeInfo.processorInfo()?.supportedArchitecturesAsStrings().orEmpty(),
+        )
     }
+
+    /**
+     * Checks whether the given EC2 instance type has local instance store (NVMe) volumes.
+     *
+     * Thin reader over [describeInstanceType].
+     *
+     * @param instanceType EC2 instance type (e.g., "i3.xlarge", "c5.2xlarge")
+     * @return true if the instance type has instance store, false otherwise
+     */
+    fun hasInstanceStore(instanceType: String): Boolean = describeInstanceType(instanceType).hasInstanceStore
 
     /**
      * Finds all running instances belonging to a cluster by ClusterId tag.

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/aws/InstanceSpecFactory.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/aws/InstanceSpecFactory.kt
@@ -1,5 +1,6 @@
 package com.rustyrazorblade.easydblab.services.aws
 
+import com.rustyrazorblade.easydblab.configuration.Arch
 import com.rustyrazorblade.easydblab.configuration.InitConfig
 import com.rustyrazorblade.easydblab.configuration.ServerType
 import com.rustyrazorblade.easydblab.providers.aws.DiscoveredInstance
@@ -17,6 +18,7 @@ import com.rustyrazorblade.easydblab.providers.aws.EBSConfig
  * @property existingCount Number of instances that already exist
  * @property instanceType EC2 instance type (e.g., "m5.large")
  * @property ebsConfig Optional EBS configuration for attached storage
+ * @property amiId AMI matching this group's own CPU architecture
  */
 data class InstanceSpec(
     val serverType: ServerType,
@@ -24,6 +26,7 @@ data class InstanceSpec(
     val existingCount: Int,
     val instanceType: String,
     val ebsConfig: EBSConfig?,
+    val amiId: String,
 ) {
     /**
      * Number of additional instances needed to reach the configured count.
@@ -45,6 +48,7 @@ interface InstanceSpecFactory {
      * @param initConfig The cluster initialization configuration
      * @param existingInstances Map of existing instances by server type
      * @param dbHasInstanceStore Whether the database instance type has local instance store
+     * @param amiByArch AMI id resolved for each distinct CPU architecture in the cluster
      * @return List of instance specifications for Cassandra, Stress, and Control nodes
      * @throws IllegalArgumentException if database instance type has no instance store and no EBS configured
      */
@@ -52,6 +56,7 @@ interface InstanceSpecFactory {
         initConfig: InitConfig,
         existingInstances: Map<ServerType, List<DiscoveredInstance>>,
         dbHasInstanceStore: Boolean,
+        amiByArch: Map<Arch, String>,
     ): List<InstanceSpec>
 
     /**
@@ -71,6 +76,7 @@ class DefaultInstanceSpecFactory : InstanceSpecFactory {
         initConfig: InitConfig,
         existingInstances: Map<ServerType, List<DiscoveredInstance>>,
         dbHasInstanceStore: Boolean,
+        amiByArch: Map<Arch, String>,
     ): List<InstanceSpec> {
         val ebsConfig = createEbsConfig(initConfig)
 
@@ -83,6 +89,12 @@ class DefaultInstanceSpecFactory : InstanceSpecFactory {
         val existingStressCount = existingInstances[ServerType.Stress]?.size ?: 0
         val existingControlCount = existingInstances[ServerType.Control]?.size ?: 0
 
+        fun amiFor(arch: String): String {
+            val resolved = Arch.valueOf(arch)
+            return amiByArch[resolved]
+                ?: error("No AMI resolved for architecture $resolved")
+        }
+
         return listOf(
             InstanceSpec(
                 serverType = ServerType.Cassandra,
@@ -90,6 +102,7 @@ class DefaultInstanceSpecFactory : InstanceSpecFactory {
                 existingCount = existingCassandraCount,
                 instanceType = initConfig.instanceType,
                 ebsConfig = ebsConfig,
+                amiId = amiFor(initConfig.dbArch),
             ),
             InstanceSpec(
                 serverType = ServerType.Stress,
@@ -97,6 +110,7 @@ class DefaultInstanceSpecFactory : InstanceSpecFactory {
                 existingCount = existingStressCount,
                 instanceType = initConfig.stressInstanceType,
                 ebsConfig = null,
+                amiId = amiFor(initConfig.appArch),
             ),
             InstanceSpec(
                 serverType = ServerType.Control,
@@ -104,6 +118,7 @@ class DefaultInstanceSpecFactory : InstanceSpecFactory {
                 existingCount = existingControlCount,
                 instanceType = initConfig.controlInstanceType,
                 ebsConfig = null,
+                amiId = amiFor(initConfig.controlArch),
             ),
         )
     }

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/aws/InstanceSpecFactory.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/aws/InstanceSpecFactory.kt
@@ -89,7 +89,13 @@ class DefaultInstanceSpecFactory : InstanceSpecFactory {
         val existingStressCount = existingInstances[ServerType.Stress]?.size ?: 0
         val existingControlCount = existingInstances[ServerType.Control]?.size ?: 0
 
-        fun amiFor(arch: String): String {
+        // A group with no configured instances never launches, so it needs no image; only groups
+        // that will launch require an AMI resolved for their architecture.
+        fun amiFor(
+            arch: String,
+            configuredCount: Int,
+        ): String {
+            if (configuredCount <= 0) return ""
             val resolved = Arch.valueOf(arch)
             return amiByArch[resolved]
                 ?: error("No AMI resolved for architecture $resolved")
@@ -102,7 +108,7 @@ class DefaultInstanceSpecFactory : InstanceSpecFactory {
                 existingCount = existingCassandraCount,
                 instanceType = initConfig.instanceType,
                 ebsConfig = ebsConfig,
-                amiId = amiFor(initConfig.dbArch),
+                amiId = amiFor(initConfig.dbArch, initConfig.cassandraInstances),
             ),
             InstanceSpec(
                 serverType = ServerType.Stress,
@@ -110,7 +116,7 @@ class DefaultInstanceSpecFactory : InstanceSpecFactory {
                 existingCount = existingStressCount,
                 instanceType = initConfig.stressInstanceType,
                 ebsConfig = null,
-                amiId = amiFor(initConfig.appArch),
+                amiId = amiFor(initConfig.appArch, initConfig.stressInstances),
             ),
             InstanceSpec(
                 serverType = ServerType.Control,
@@ -118,7 +124,7 @@ class DefaultInstanceSpecFactory : InstanceSpecFactory {
                 existingCount = existingControlCount,
                 instanceType = initConfig.controlInstanceType,
                 ebsConfig = null,
-                amiId = amiFor(initConfig.controlArch),
+                amiId = amiFor(initConfig.controlArch, initConfig.controlInstances),
             ),
         )
     }

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/commands/InitTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/commands/InitTest.kt
@@ -180,6 +180,53 @@ class InitTest : BaseKoinTest() {
     }
 
     @Nested
+    inner class NamespacedPrecedence {
+        @Test
+        fun `namespaced db instance-type wins over legacy alias regardless of order`() {
+            val namespacedFirst = Init()
+            picocli.CommandLine(namespacedFirst).parseArgs(
+                "--db.instance-type", "arm.big", "--instance", "legacy.small",
+            )
+            assertThat(namespacedFirst.resolvedDbInstanceType).isEqualTo("arm.big")
+
+            val legacyFirst = Init()
+            picocli.CommandLine(legacyFirst).parseArgs(
+                "--instance", "legacy.small", "--db.instance-type", "arm.big",
+            )
+            assertThat(legacyFirst.resolvedDbInstanceType).isEqualTo("arm.big")
+        }
+
+        @Test
+        fun `namespaced app count wins over legacy alias regardless of order`() {
+            val namespacedFirst = Init()
+            picocli.CommandLine(namespacedFirst).parseArgs("--app.count", "7", "--app", "2")
+            assertThat(namespacedFirst.resolvedAppCount).isEqualTo(7)
+
+            val legacyFirst = Init()
+            picocli.CommandLine(legacyFirst).parseArgs("--app", "2", "--app.count", "7")
+            assertThat(legacyFirst.resolvedAppCount).isEqualTo(7)
+        }
+
+        @Test
+        fun `legacy alias sets the value when the namespaced option is absent`() {
+            val command = Init()
+            picocli.CommandLine(command).parseArgs("--cassandra", "5", "--stress-instance", "z1.big")
+            assertThat(command.resolvedDbCount).isEqualTo(5)
+            assertThat(command.resolvedAppInstanceType).isEqualTo("z1.big")
+        }
+
+        @Test
+        fun `defaults are used when neither namespaced nor legacy is set`() {
+            val command = Init()
+            picocli.CommandLine(command).parseArgs()
+            assertThat(command.resolvedDbCount).isEqualTo(command.cassandraInstances)
+            assertThat(command.resolvedAppCount).isEqualTo(command.stressInstances)
+            assertThat(command.resolvedDbInstanceType).isEqualTo(command.instanceType)
+            assertThat(command.resolvedAppInstanceType).isEqualTo(command.stressInstanceType)
+        }
+    }
+
+    @Nested
     inner class ExistingVpc {
         @Test
         fun `execute sets existing VPC ID when provided`() {

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/commands/InitTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/commands/InitTest.kt
@@ -194,13 +194,19 @@ class InitTest : BaseKoinTest() {
         fun `namespaced db instance-type wins over legacy alias regardless of order`() {
             val namespacedFirst = Init()
             picocli.CommandLine(namespacedFirst).parseArgs(
-                "--db.instance-type", "arm.big", "--instance", "legacy.small",
+                "--db.instance-type",
+                "arm.big",
+                "--instance",
+                "legacy.small",
             )
             assertThat(namespacedFirst.resolvedDbInstanceType).isEqualTo("arm.big")
 
             val legacyFirst = Init()
             picocli.CommandLine(legacyFirst).parseArgs(
-                "--instance", "legacy.small", "--db.instance-type", "arm.big",
+                "--instance",
+                "legacy.small",
+                "--db.instance-type",
+                "arm.big",
             )
             assertThat(legacyFirst.resolvedDbInstanceType).isEqualTo("arm.big")
         }

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/commands/InitTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/commands/InitTest.kt
@@ -5,6 +5,8 @@ import com.rustyrazorblade.easydblab.configuration.ClusterStateManager
 import com.rustyrazorblade.easydblab.output.BufferedOutputHandler
 import com.rustyrazorblade.easydblab.output.OutputHandler
 import com.rustyrazorblade.easydblab.services.TemplateService
+import com.rustyrazorblade.easydblab.services.aws.EC2InstanceService
+import com.rustyrazorblade.easydblab.services.aws.InstanceTypeCapabilities
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.AfterEach
@@ -13,6 +15,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.koin.core.module.Module
 import org.koin.dsl.module
+import org.mockito.kotlin.any
 import org.mockito.kotlin.argThat
 import org.mockito.kotlin.atLeastOnce
 import org.mockito.kotlin.mock
@@ -22,12 +25,14 @@ import java.io.File
 
 class InitTest : BaseKoinTest() {
     private lateinit var mockClusterStateManager: ClusterStateManager
+    private lateinit var mockEc2InstanceService: EC2InstanceService
     private lateinit var outputHandler: BufferedOutputHandler
 
     override fun additionalTestModules(): List<Module> =
         listOf(
             module {
                 single<ClusterStateManager> { mockClusterStateManager }
+                single { mockEc2InstanceService }
                 single { TemplateService(get(), get()) }
             },
         )
@@ -35,9 +40,13 @@ class InitTest : BaseKoinTest() {
     @BeforeEach
     fun setupMocks() {
         mockClusterStateManager = mock()
+        mockEc2InstanceService = mock()
         outputHandler = getKoin().get<OutputHandler>() as BufferedOutputHandler
 
         whenever(mockClusterStateManager.exists()).thenReturn(false)
+        // Default: every instance type is x86_64 with instance store.
+        whenever(mockEc2InstanceService.describeInstanceType(any()))
+            .thenReturn(InstanceTypeCapabilities(hasInstanceStore = true, supportedArchitectures = listOf("x86_64")))
     }
 
     @AfterEach
@@ -223,6 +232,51 @@ class InitTest : BaseKoinTest() {
             assertThat(command.resolvedAppCount).isEqualTo(command.stressInstances)
             assertThat(command.resolvedDbInstanceType).isEqualTo(command.instanceType)
             assertThat(command.resolvedAppInstanceType).isEqualTo(command.stressInstanceType)
+        }
+    }
+
+    @Nested
+    inner class ArchitectureDerivation {
+        @Test
+        fun `derives each group architecture independently from its resolved instance type`() {
+            whenever(mockEc2InstanceService.describeInstanceType("arm.db"))
+                .thenReturn(InstanceTypeCapabilities(hasInstanceStore = true, supportedArchitectures = listOf("arm64")))
+            whenever(mockEc2InstanceService.describeInstanceType("x86.app"))
+                .thenReturn(InstanceTypeCapabilities(hasInstanceStore = false, supportedArchitectures = listOf("x86_64")))
+
+            val command = Init()
+            command.clean = true
+            command.instanceType = "arm.db"
+            command.stressInstanceType = "x86.app"
+            command.execute()
+
+            verify(mockClusterStateManager).save(
+                argThat {
+                    initConfig?.dbArch == "ARM64" &&
+                        initConfig?.appArch == "AMD64" &&
+                        initConfig?.controlArch == "AMD64"
+                },
+            )
+        }
+
+        @Test
+        fun `fails fast when the instance type is unknown in the region naming the type and region`() {
+            whenever(mockEc2InstanceService.describeInstanceType("bogus.type"))
+                .thenThrow(IllegalStateException("Instance type 'bogus.type' not found in region us-west-2"))
+
+            val command = Init()
+            command.clean = true
+            command.instanceType = "bogus.type"
+
+            assertThatThrownBy { command.execute() }
+                .isInstanceOf(IllegalStateException::class.java)
+                .hasMessageContaining("bogus.type")
+                .hasMessageContaining("us-west-2")
+
+            // No cluster state saved with instance config when derivation fails.
+            verify(mockClusterStateManager, org.mockito.kotlin.never()).save(
+                argThat { initConfig != null },
+            )
         }
     }
 

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/commands/UpTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/commands/UpTest.kt
@@ -2,6 +2,7 @@ package com.rustyrazorblade.easydblab.commands
 
 import com.rustyrazorblade.easydblab.BaseKoinTest
 import com.rustyrazorblade.easydblab.Version
+import com.rustyrazorblade.easydblab.configuration.Arch
 import com.rustyrazorblade.easydblab.configuration.ClusterHost
 import com.rustyrazorblade.easydblab.configuration.ClusterState
 import com.rustyrazorblade.easydblab.configuration.ClusterStateManager
@@ -31,6 +32,7 @@ import com.rustyrazorblade.easydblab.services.aws.AwsS3BucketService
 import com.rustyrazorblade.easydblab.services.aws.DefaultInstanceSpecFactory
 import com.rustyrazorblade.easydblab.services.aws.EC2InstanceService
 import com.rustyrazorblade.easydblab.services.aws.InstanceSpecFactory
+import com.rustyrazorblade.easydblab.services.aws.InstanceTypeCapabilities
 import com.rustyrazorblade.easydblab.services.aws.OpenSearchService
 import com.rustyrazorblade.easydblab.ssh.Response
 import org.assertj.core.api.Assertions.assertThat
@@ -213,7 +215,8 @@ class UpTest : BaseKoinTest() {
         )
 
         whenever(mockEc2InstanceService.findInstancesByClusterId(any())).thenReturn(emptyMap())
-        whenever(mockEc2InstanceService.hasInstanceStore(any())).thenReturn(true)
+        whenever(mockEc2InstanceService.describeInstanceType(any()))
+            .thenReturn(InstanceTypeCapabilities(hasInstanceStore = true, supportedArchitectures = listOf("x86_64")))
 
         whenever(mockAmiResolver.resolveAmiId(any(), any())).thenReturn(Result.success("ami-123"))
 
@@ -343,6 +346,41 @@ class UpTest : BaseKoinTest() {
         assertThat(outputHandler.errors).isEmpty()
         verify(mockK8sService, never()).labelNode(any(), eq("db0"), any())
         verify(mockK8sService).labelNode(eq(testControlHost), eq("app0"), any())
+    }
+
+    @Test
+    fun `up does not resolve an AMI for the application architecture when there are zero app nodes`() {
+        // A mixed-arch spec whose only arm64 group is the application group, sized to zero. `up`
+        // must not demand (nor resolve) an arm64 image it will never launch.
+        whenever(mockClusterStateManager.load()).thenReturn(
+            ClusterState(
+                name = "test-cluster",
+                versions = mutableMapOf(),
+                tailscaleActive = true,
+                initConfig =
+                    InitConfig(
+                        cassandraInstances = 1,
+                        stressInstances = 0,
+                        controlInstances = 1,
+                        dbArch = "AMD64",
+                        appArch = "ARM64",
+                        controlArch = "AMD64",
+                        cidr = "10.0.0.0/16",
+                        name = "test-cluster",
+                    ),
+            ),
+        )
+        whenever(mockClusterProvisioningService.provisionAll(any(), any(), any(), any())).thenReturn(
+            ProvisioningResult(
+                hosts = mapOf(ServerType.Control to listOf(testControlHost), ServerType.Cassandra to listOf(testDbHost)),
+                errors = emptyMap(),
+            ),
+        )
+
+        assertThatCode { newUp().execute() }.doesNotThrowAnyException()
+
+        verify(mockAmiResolver, never()).resolveAmiId(any(), eq(Arch.ARM64.type))
+        verify(mockAmiResolver).resolveAmiId(any(), eq(Arch.AMD64.type))
     }
 
     // =========================================================================

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/configuration/ArchTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/configuration/ArchTest.kt
@@ -1,0 +1,49 @@
+package com.rustyrazorblade.easydblab.configuration
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests for [Arch.fromEc2], which maps the EC2 `SupportedArchitectures` values reported by
+ * `DescribeInstanceTypes` onto the project's [Arch] enum. The mapping must be exact: an instance
+ * type whose supported architectures do not resolve to exactly one [Arch] is an error, because the
+ * cluster cannot pick an AMI for an ambiguous or unknown architecture.
+ */
+class ArchTest {
+    @Test
+    fun `maps x86_64 to AMD64`() {
+        assertThat(Arch.fromEc2(listOf("x86_64"))).isEqualTo(Arch.AMD64)
+    }
+
+    @Test
+    fun `maps arm64 to ARM64`() {
+        assertThat(Arch.fromEc2(listOf("arm64"))).isEqualTo(Arch.ARM64)
+    }
+
+    @Test
+    fun `rejects i386 naming the value`() {
+        assertThatThrownBy { Arch.fromEc2(listOf("i386")) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("i386")
+    }
+
+    @Test
+    fun `rejects an empty architecture list`() {
+        assertThatThrownBy { Arch.fromEc2(emptyList()) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun `rejects an unrecognized architecture naming the value`() {
+        assertThatThrownBy { Arch.fromEc2(listOf("sparc")) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("sparc")
+    }
+
+    @Test
+    fun `rejects a list that maps to more than one architecture`() {
+        assertThatThrownBy { Arch.fromEc2(listOf("x86_64", "arm64")) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+    }
+}

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/services/ClusterProvisioningServiceTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/services/ClusterProvisioningServiceTest.kt
@@ -74,6 +74,7 @@ class ClusterProvisioningServiceTest {
                     existingCount = 0,
                     instanceType = "m5.large",
                     ebsConfig = null,
+                    amiId = "ami-12345",
                 )
             val config = createInstanceConfig(specs = listOf(spec))
 
@@ -99,6 +100,7 @@ class ClusterProvisioningServiceTest {
                     existingCount = 3,
                     instanceType = "m5.large",
                     ebsConfig = null,
+                    amiId = "ami-12345",
                 )
             val config = createInstanceConfig(specs = listOf(spec))
 
@@ -127,6 +129,7 @@ class ClusterProvisioningServiceTest {
                     existingCount = 3,
                     instanceType = "m5.large",
                     ebsConfig = null,
+                    amiId = "ami-12345",
                 )
             val config = createInstanceConfig(specs = listOf(spec))
 
@@ -159,6 +162,7 @@ class ClusterProvisioningServiceTest {
                     existingCount = 0,
                     instanceType = "m5.large",
                     ebsConfig = null,
+                    amiId = "ami-12345",
                 )
             val config = createInstanceConfig(specs = listOf(spec))
 
@@ -180,6 +184,7 @@ class ClusterProvisioningServiceTest {
                     existingCount = 0,
                     instanceType = "m5.large",
                     ebsConfig = null,
+                    amiId = "ami-12345",
                 )
             val stressSpec =
                 InstanceSpec(
@@ -188,6 +193,7 @@ class ClusterProvisioningServiceTest {
                     existingCount = 0,
                     instanceType = "c5.large",
                     ebsConfig = null,
+                    amiId = "ami-12345",
                 )
             val config = createInstanceConfig(specs = listOf(cassandraSpec, stressSpec))
 
@@ -210,6 +216,7 @@ class ClusterProvisioningServiceTest {
                     existingCount = 1,
                     instanceType = "m5.large",
                     ebsConfig = null,
+                    amiId = "ami-12345",
                 )
             val config = createInstanceConfig(specs = listOf(spec))
 
@@ -238,6 +245,7 @@ class ClusterProvisioningServiceTest {
                         existingCount = 0,
                         instanceType = "m5.large",
                         ebsConfig = null,
+                        amiId = "ami-12345",
                     ),
                 )
             val instanceConfig = createInstanceConfig(specs = specs)
@@ -276,6 +284,7 @@ class ClusterProvisioningServiceTest {
                         existingCount = 0,
                         instanceType = "m5.large",
                         ebsConfig = null,
+                        amiId = "ami-12345",
                     ),
                 )
             val instanceConfig = createInstanceConfig(specs = specs)
@@ -314,6 +323,7 @@ class ClusterProvisioningServiceTest {
                         existingCount = 0,
                         instanceType = "m5.large",
                         ebsConfig = null,
+                        amiId = "ami-12345",
                     ),
                 )
             val instanceConfig = createInstanceConfig(specs = specs)
@@ -353,6 +363,7 @@ class ClusterProvisioningServiceTest {
                     existingCount = 0,
                     instanceType = "m5.large",
                     ebsConfig = null,
+                    amiId = "ami-12345",
                 )
             val instanceConfig = createInstanceConfig(specs = listOf(controlSpec))
             val initConfig = createInitConfig(sparkEnabled = true, controlInstances = 1)
@@ -394,6 +405,7 @@ class ClusterProvisioningServiceTest {
                         existingCount = 0,
                         instanceType = "m5.large",
                         ebsConfig = null,
+                        amiId = "ami-12345",
                     ),
                 )
             val instanceConfig = createInstanceConfig(specs = specs)
@@ -490,7 +502,6 @@ class ClusterProvisioningServiceTest {
     private fun createInstanceConfig(specs: List<InstanceSpec>): InstanceProvisioningConfig =
         InstanceProvisioningConfig(
             specs = specs,
-            amiId = "ami-12345",
             securityGroupId = "sg-12345",
             subnetIds = listOf("subnet-1", "subnet-2"),
             tags = mapOf("ClusterId" to "test-cluster"),

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/services/ClusterProvisioningServiceTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/services/ClusterProvisioningServiceTest.kt
@@ -25,8 +25,10 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argThat
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
@@ -205,6 +207,42 @@ class ClusterProvisioningServiceTest {
             assertThat(result.errors).isEmpty()
             assertThat(result.hosts[ServerType.Cassandra]).hasSize(3)
             assertThat(result.hosts[ServerType.Stress]).hasSize(2)
+        }
+
+        @Test
+        fun `routes each spec's own amiId to that server type's instance creation`() {
+            // Distinct AMIs per group — the whole point of per-spec routing. If provisioning
+            // collapsed back to a single shared AMI, both configs would carry the same id and one
+            // of these assertions would fail.
+            val dbSpec =
+                InstanceSpec(
+                    serverType = ServerType.Cassandra,
+                    configuredCount = 1,
+                    existingCount = 0,
+                    instanceType = "m5.large",
+                    ebsConfig = null,
+                    amiId = "ami-aaaa",
+                )
+            val appSpec =
+                InstanceSpec(
+                    serverType = ServerType.Stress,
+                    configuredCount = 1,
+                    existingCount = 0,
+                    instanceType = "m6g.large",
+                    ebsConfig = null,
+                    amiId = "ami-bbbb",
+                )
+            val config = createInstanceConfig(specs = listOf(dbSpec, appSpec))
+
+            setupMockInstanceCreation()
+
+            service.provisionInstances(config, emptyMap()) { _, _ -> }
+
+            val captor = argumentCaptor<InstanceCreationConfig>()
+            verify(ec2InstanceService, times(2)).createInstances(captor.capture())
+            val amiIdByType = captor.allValues.associate { it.serverType to it.amiId }
+            assertThat(amiIdByType[ServerType.Cassandra]).isEqualTo("ami-aaaa")
+            assertThat(amiIdByType[ServerType.Stress]).isEqualTo("ami-bbbb")
         }
 
         @Test

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/services/aws/EC2InstanceServiceTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/services/aws/EC2InstanceServiceTest.kt
@@ -464,6 +464,71 @@ internal class EC2InstanceServiceTest {
         assertThat(result.supportedArchitectures).containsExactly("x86_64")
     }
 
+    @Test
+    fun `describeInstanceType follows nextToken past an empty first page to find the type`() {
+        // EC2 applies the instance-type filter per page, so a common type can sit behind an empty
+        // first page that still carries a nextToken. Reading only the first page would misreport
+        // the type as "not found" — the bug this reproduces.
+        val emptyFirstPage =
+            DescribeInstanceTypesResponse
+                .builder()
+                .instanceTypes(emptyList())
+                .nextToken("page-2-token")
+                .build()
+        val matchingTypeInfo =
+            InstanceTypeInfo
+                .builder()
+                .instanceType("i4i.xlarge")
+                .instanceStorageSupported(true)
+                .processorInfo(ProcessorInfo.builder().supportedArchitecturesWithStrings("x86_64").build())
+                .build()
+        val secondPage =
+            DescribeInstanceTypesResponse
+                .builder()
+                .instanceTypes(matchingTypeInfo)
+                .build()
+
+        whenever(mockEc2Client.describeInstanceTypes(any<DescribeInstanceTypesRequest>()))
+            .thenReturn(emptyFirstPage, secondPage)
+
+        val result = ec2InstanceService.describeInstanceType("i4i.xlarge")
+
+        assertThat(result.hasInstanceStore).isTrue()
+        assertThat(result.supportedArchitectures).containsExactly("x86_64")
+
+        // Two pages fetched; the second request carried the first page's nextToken.
+        val captor = argumentCaptor<DescribeInstanceTypesRequest>()
+        verify(mockEc2Client, times(2)).describeInstanceTypes(captor.capture())
+        assertThat(captor.firstValue.nextToken()).isNull()
+        assertThat(captor.secondValue.nextToken()).isEqualTo("page-2-token")
+    }
+
+    @Test
+    fun `describeInstanceType throws only after exhausting all pages without a match`() {
+        val firstEmptyPage =
+            DescribeInstanceTypesResponse
+                .builder()
+                .instanceTypes(emptyList())
+                .nextToken("page-2-token")
+                .build()
+        val lastEmptyPage =
+            DescribeInstanceTypesResponse
+                .builder()
+                .instanceTypes(emptyList())
+                .build()
+
+        whenever(mockEc2Client.describeInstanceTypes(any<DescribeInstanceTypesRequest>()))
+            .thenReturn(firstEmptyPage, lastEmptyPage)
+
+        assertThatThrownBy { ec2InstanceService.describeInstanceType("nonexistent.type") }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("nonexistent.type")
+            .hasMessageContaining("us-west-2")
+
+        // The error is raised only after both pages are consulted, not on the empty first page.
+        verify(mockEc2Client, times(2)).describeInstanceTypes(any<DescribeInstanceTypesRequest>())
+    }
+
     private fun createInstance(
         instanceId: String,
         serverType: String,

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/services/aws/EC2InstanceServiceTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/services/aws/EC2InstanceServiceTest.kt
@@ -4,6 +4,7 @@ import com.rustyrazorblade.easydblab.configuration.ServerType
 import com.rustyrazorblade.easydblab.providers.aws.DiscoveredInstance
 import com.rustyrazorblade.easydblab.providers.aws.InstanceCreationConfig
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
@@ -22,6 +23,7 @@ import software.amazon.awssdk.services.ec2.model.InstanceStateName
 import software.amazon.awssdk.services.ec2.model.InstanceStorageInfo
 import software.amazon.awssdk.services.ec2.model.InstanceTypeInfo
 import software.amazon.awssdk.services.ec2.model.Placement
+import software.amazon.awssdk.services.ec2.model.ProcessorInfo
 import software.amazon.awssdk.services.ec2.model.Reservation
 import software.amazon.awssdk.services.ec2.model.RunInstancesRequest
 import software.amazon.awssdk.services.ec2.model.RunInstancesResponse
@@ -34,6 +36,7 @@ internal class EC2InstanceServiceTest {
             mockEc2Client,
             com.rustyrazorblade.easydblab.events
                 .EventBus(),
+            region = "us-west-2",
         )
 
     @Test
@@ -391,6 +394,51 @@ internal class EC2InstanceServiceTest {
         ).describeInstanceStatus(
             any<software.amazon.awssdk.services.ec2.model.DescribeInstanceStatusRequest>(),
         )
+    }
+
+    @Test
+    fun `describeInstanceType resolves a type not present in the SDK enum via an instance-type filter`() {
+        // A type the SDK's InstanceType enum does not know about. Routing it through
+        // InstanceType.fromValue would yield UNKNOWN_TO_SDK_VERSION and a "[null]" API error.
+        val newType = "x99.someday.metal"
+        val typeInfo =
+            InstanceTypeInfo
+                .builder()
+                .instanceType(newType)
+                .instanceStorageSupported(true)
+                .processorInfo(
+                    ProcessorInfo.builder().supportedArchitecturesWithStrings("arm64").build(),
+                ).build()
+
+        whenever(mockEc2Client.describeInstanceTypes(any<DescribeInstanceTypesRequest>()))
+            .thenReturn(DescribeInstanceTypesResponse.builder().instanceTypes(typeInfo).build())
+
+        val result = ec2InstanceService.describeInstanceType(newType)
+
+        assertThat(result.hasInstanceStore).isTrue()
+        assertThat(result.supportedArchitectures).containsExactly("arm64")
+
+        // Verify the request used an instance-type filter carrying the raw string,
+        // not the SDK's InstanceType enum.
+        val captor = argumentCaptor<DescribeInstanceTypesRequest>()
+        verify(mockEc2Client).describeInstanceTypes(captor.capture())
+        val request = captor.firstValue
+        assertThat(request.instanceTypes()).isEmpty()
+        assertThat(request.filters()).anySatisfy { filter ->
+            assertThat(filter.name()).isEqualTo("instance-type")
+            assertThat(filter.values()).containsExactly(newType)
+        }
+    }
+
+    @Test
+    fun `describeInstanceType throws naming the type and region when the result is empty`() {
+        whenever(mockEc2Client.describeInstanceTypes(any<DescribeInstanceTypesRequest>()))
+            .thenReturn(DescribeInstanceTypesResponse.builder().instanceTypes(emptyList()).build())
+
+        assertThatThrownBy { ec2InstanceService.describeInstanceType("bogus.type") }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("bogus.type")
+            .hasMessageContaining("us-west-2")
     }
 
     @Test

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/services/aws/EC2InstanceServiceTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/services/aws/EC2InstanceServiceTest.kt
@@ -20,7 +20,6 @@ import software.amazon.awssdk.services.ec2.model.DescribeInstancesResponse
 import software.amazon.awssdk.services.ec2.model.Instance
 import software.amazon.awssdk.services.ec2.model.InstanceState
 import software.amazon.awssdk.services.ec2.model.InstanceStateName
-import software.amazon.awssdk.services.ec2.model.InstanceStorageInfo
 import software.amazon.awssdk.services.ec2.model.InstanceTypeInfo
 import software.amazon.awssdk.services.ec2.model.Placement
 import software.amazon.awssdk.services.ec2.model.ProcessorInfo
@@ -442,33 +441,13 @@ internal class EC2InstanceServiceTest {
     }
 
     @Test
-    fun `hasInstanceStore should return true for instance type with instance store`() {
-        val typeInfo =
-            InstanceTypeInfo
-                .builder()
-                .instanceType("i3.xlarge")
-                .instanceStorageSupported(true)
-                .instanceStorageInfo(InstanceStorageInfo.builder().totalSizeInGB(950L).build())
-                .build()
-
-        val response =
-            DescribeInstanceTypesResponse
-                .builder()
-                .instanceTypes(typeInfo)
-                .build()
-
-        whenever(mockEc2Client.describeInstanceTypes(any<DescribeInstanceTypesRequest>())).thenReturn(response)
-
-        assertThat(ec2InstanceService.hasInstanceStore("i3.xlarge")).isTrue()
-    }
-
-    @Test
-    fun `hasInstanceStore should return false for instance type without instance store`() {
+    fun `describeInstanceType reports no instance store for a type without local storage`() {
         val typeInfo =
             InstanceTypeInfo
                 .builder()
                 .instanceType("c5.2xlarge")
                 .instanceStorageSupported(false)
+                .processorInfo(ProcessorInfo.builder().supportedArchitecturesWithStrings("x86_64").build())
                 .build()
 
         val response =
@@ -479,7 +458,10 @@ internal class EC2InstanceServiceTest {
 
         whenever(mockEc2Client.describeInstanceTypes(any<DescribeInstanceTypesRequest>())).thenReturn(response)
 
-        assertThat(ec2InstanceService.hasInstanceStore("c5.2xlarge")).isFalse()
+        val result = ec2InstanceService.describeInstanceType("c5.2xlarge")
+
+        assertThat(result.hasInstanceStore).isFalse()
+        assertThat(result.supportedArchitectures).containsExactly("x86_64")
     }
 
     private fun createInstance(

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/services/aws/InstanceSpecFactoryTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/services/aws/InstanceSpecFactoryTest.kt
@@ -48,6 +48,34 @@ class InstanceSpecFactoryTest {
             assertThat(specs.find { it.serverType == ServerType.Stress }!!.amiId).isEqualTo("ami-amd64")
             assertThat(specs.find { it.serverType == ServerType.Control }!!.amiId).isEqualTo("ami-amd64")
         }
+
+        @Test
+        fun `does not require an AMI for a node group sized to zero`() {
+            // Only an amd64 AMI is resolved; the arm64 application group is sized to zero, so its
+            // (unresolved) architecture must not be required.
+            val amdOnly = mapOf(Arch.AMD64 to "ami-amd64")
+            val initConfig =
+                createInitConfig(
+                    cassandraInstances = 3,
+                    stressInstances = 0,
+                    controlInstances = 1,
+                    dbArch = "AMD64",
+                    appArch = "ARM64",
+                    controlArch = "AMD64",
+                )
+
+            val specs =
+                factory.createInstanceSpecs(
+                    initConfig,
+                    emptyMap(),
+                    dbHasInstanceStore = true,
+                    amiByArch = amdOnly,
+                )
+
+            assertThat(specs.find { it.serverType == ServerType.Cassandra }!!.amiId).isEqualTo("ami-amd64")
+            assertThat(specs.find { it.serverType == ServerType.Control }!!.amiId).isEqualTo("ami-amd64")
+            assertThat(specs.find { it.serverType == ServerType.Stress }!!.amiId).isEmpty()
+        }
     }
 
     @Nested

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/services/aws/InstanceSpecFactoryTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/services/aws/InstanceSpecFactoryTest.kt
@@ -1,5 +1,6 @@
 package com.rustyrazorblade.easydblab.services.aws
 
+import com.rustyrazorblade.easydblab.configuration.Arch
 import com.rustyrazorblade.easydblab.configuration.InitConfig
 import com.rustyrazorblade.easydblab.configuration.ServerType
 import com.rustyrazorblade.easydblab.providers.aws.DiscoveredInstance
@@ -15,9 +16,38 @@ import org.junit.jupiter.api.Test
 class InstanceSpecFactoryTest {
     private lateinit var factory: InstanceSpecFactory
 
+    private val amiByArch = mapOf(Arch.AMD64 to "ami-amd64", Arch.ARM64 to "ami-arm64")
+
     @BeforeEach
     fun setup() {
         factory = DefaultInstanceSpecFactory()
+    }
+
+    @Nested
+    inner class PerArchitectureAmi {
+        @Test
+        fun `attaches the AMI matching each group's own architecture in a mixed-arch cluster`() {
+            val initConfig =
+                createInitConfig(
+                    instanceType = "arm.db",
+                    stressInstanceType = "x86.app",
+                    dbArch = "ARM64",
+                    appArch = "AMD64",
+                    controlArch = "AMD64",
+                )
+
+            val specs =
+                factory.createInstanceSpecs(
+                    initConfig,
+                    emptyMap(),
+                    dbHasInstanceStore = true,
+                    amiByArch = amiByArch,
+                )
+
+            assertThat(specs.find { it.serverType == ServerType.Cassandra }!!.amiId).isEqualTo("ami-arm64")
+            assertThat(specs.find { it.serverType == ServerType.Stress }!!.amiId).isEqualTo("ami-amd64")
+            assertThat(specs.find { it.serverType == ServerType.Control }!!.amiId).isEqualTo("ami-amd64")
+        }
     }
 
     @Nested
@@ -31,7 +61,7 @@ class InstanceSpecFactoryTest {
                     controlInstances = 1,
                 )
 
-            val specs = factory.createInstanceSpecs(initConfig, emptyMap(), dbHasInstanceStore = true)
+            val specs = factory.createInstanceSpecs(initConfig, emptyMap(), dbHasInstanceStore = true, amiByArch = amiByArch)
 
             assertThat(specs).hasSize(3)
             assertThat(specs.map { it.serverType }).containsExactly(
@@ -50,7 +80,7 @@ class InstanceSpecFactoryTest {
                     controlInstances = 1,
                 )
 
-            val specs = factory.createInstanceSpecs(initConfig, emptyMap(), dbHasInstanceStore = true)
+            val specs = factory.createInstanceSpecs(initConfig, emptyMap(), dbHasInstanceStore = true, amiByArch = amiByArch)
 
             val cassandraSpec = specs.find { it.serverType == ServerType.Cassandra }!!
             val stressSpec = specs.find { it.serverType == ServerType.Stress }!!
@@ -83,7 +113,7 @@ class InstanceSpecFactoryTest {
                         ),
                 )
 
-            val specs = factory.createInstanceSpecs(initConfig, existingInstances, dbHasInstanceStore = true)
+            val specs = factory.createInstanceSpecs(initConfig, existingInstances, dbHasInstanceStore = true, amiByArch = amiByArch)
 
             val cassandraSpec = specs.find { it.serverType == ServerType.Cassandra }!!
             val stressSpec = specs.find { it.serverType == ServerType.Stress }!!
@@ -117,7 +147,7 @@ class InstanceSpecFactoryTest {
                         ),
                 )
 
-            val specs = factory.createInstanceSpecs(initConfig, existingInstances, dbHasInstanceStore = true)
+            val specs = factory.createInstanceSpecs(initConfig, existingInstances, dbHasInstanceStore = true, amiByArch = amiByArch)
 
             val cassandraSpec = specs.find { it.serverType == ServerType.Cassandra }!!
             val stressSpec = specs.find { it.serverType == ServerType.Stress }!!
@@ -135,7 +165,7 @@ class InstanceSpecFactoryTest {
                     controlInstanceType = "t3.medium",
                 )
 
-            val specs = factory.createInstanceSpecs(initConfig, emptyMap(), dbHasInstanceStore = true)
+            val specs = factory.createInstanceSpecs(initConfig, emptyMap(), dbHasInstanceStore = true, amiByArch = amiByArch)
 
             val cassandraSpec = specs.find { it.serverType == ServerType.Cassandra }!!
             val stressSpec = specs.find { it.serverType == ServerType.Stress }!!
@@ -154,7 +184,7 @@ class InstanceSpecFactoryTest {
                     ebsSize = 100,
                 )
 
-            val specs = factory.createInstanceSpecs(initConfig, emptyMap(), dbHasInstanceStore = true)
+            val specs = factory.createInstanceSpecs(initConfig, emptyMap(), dbHasInstanceStore = true, amiByArch = amiByArch)
 
             val cassandraSpec = specs.find { it.serverType == ServerType.Cassandra }!!
             val stressSpec = specs.find { it.serverType == ServerType.Stress }!!
@@ -172,7 +202,7 @@ class InstanceSpecFactoryTest {
         fun `should succeed when instance type has instance store and no EBS`() {
             val initConfig = createInitConfig(ebsType = "NONE")
 
-            val specs = factory.createInstanceSpecs(initConfig, emptyMap(), dbHasInstanceStore = true)
+            val specs = factory.createInstanceSpecs(initConfig, emptyMap(), dbHasInstanceStore = true, amiByArch = amiByArch)
 
             assertThat(specs).hasSize(3)
             assertThat(specs.find { it.serverType == ServerType.Cassandra }!!.ebsConfig).isNull()
@@ -182,7 +212,7 @@ class InstanceSpecFactoryTest {
         fun `should succeed when instance type has no instance store but EBS is configured`() {
             val initConfig = createInitConfig(ebsType = "gp3", ebsSize = 200)
 
-            val specs = factory.createInstanceSpecs(initConfig, emptyMap(), dbHasInstanceStore = false)
+            val specs = factory.createInstanceSpecs(initConfig, emptyMap(), dbHasInstanceStore = false, amiByArch = amiByArch)
 
             assertThat(specs).hasSize(3)
             assertThat(specs.find { it.serverType == ServerType.Cassandra }!!.ebsConfig).isNotNull
@@ -193,7 +223,7 @@ class InstanceSpecFactoryTest {
             val initConfig = createInitConfig(instanceType = "c5.2xlarge", ebsType = "NONE")
 
             assertThatThrownBy {
-                factory.createInstanceSpecs(initConfig, emptyMap(), dbHasInstanceStore = false)
+                factory.createInstanceSpecs(initConfig, emptyMap(), dbHasInstanceStore = false, amiByArch = amiByArch)
             }.isInstanceOf(IllegalArgumentException::class.java)
                 .hasMessageContaining("c5.2xlarge")
                 .hasMessageContaining("no local instance store")
@@ -281,6 +311,9 @@ class InstanceSpecFactoryTest {
         ebsSize: Int = 100,
         ebsIops: Int = 0,
         ebsThroughput: Int = 0,
+        dbArch: String = "AMD64",
+        appArch: String = "AMD64",
+        controlArch: String = "AMD64",
     ): InitConfig =
         InitConfig(
             cassandraInstances = cassandraInstances,
@@ -295,6 +328,9 @@ class InstanceSpecFactoryTest {
             ebsThroughput = ebsThroughput,
             controlInstances = controlInstances,
             controlInstanceType = controlInstanceType,
+            dbArch = dbArch,
+            appArch = appArch,
+            controlArch = controlArch,
         )
 
     /**


### PR DESCRIPTION
Closes #799
Closes #783

Implements the owner-approved OpenSpec change `namespace-db-app-arch`.

## What
- **Namespaced `--db.*`/`--app.*` init options** (`--db.instance-type`, `--app.instance-type`, `--db.count`, `--app.count`) following the flat `--ebs.*` `@Option` precedent. Legacy flags (`--instance`/`-i`, `--stress-instance`/`--si`, `--db`/`-c`, `--app`/`-s`) remain aliases with their defaults; **namespaced form wins when both are given, independent of argument order**.
- **Architecture auto-derived per node group** from the resolved instance type via a single filter-based EC2 `describe-instance-types` call; **the `--arch`/`-a`/`--cpu` flag is removed**. Derivation fails fast (unknown/ambiguous type errors at `init`, before provisioning); never silently defaults.
- **Closes #783** — one consolidated `describeInstanceType` call returns both instance-store presence and supported architectures, routed by an `instance-type` filter carrying the raw string (no `InstanceType.fromValue` SDK-enum coupling / `[null]` bug).
- **Real mixed-arch provisioning** — per-group `dbArch`/`appArch`/`controlArch` persisted in state; `amiId` moved onto each `InstanceSpec`; one AMI resolved per distinct architecture that actually launches; the global `amiId` bottleneck dropped. Groups sized to zero don't demand an unused image.

## Review
Reviewed by the five-lens panel (spec-conformance, correctness, security, test-rigor, observability) — approved, no blockers/majors. Findings surfaced during review were fixed in-branch: the 0-app-node AMI edge case, a redundant per-init describe call, a success-path arch/AMI log line, and an added provisioning test asserting per-spec `amiId` routing (the load-bearing mixed-arch line).

## Testing
The fast **unit tier ran locally** (green: InitTest, ArchTest, EC2InstanceServiceTest, InstanceSpecFactoryTest, UpTest, ClusterProvisioningServiceTest); the **full suite runs in CI** on this PR (test + quality + claude-review all green). ktlint + detekt clean on JDK 21.