### PR TITLE
test: migrate SharedLocalStack off deprecated LocalStackContainer API

### DIFF
--- a/src/integrationTest/kotlin/com/rustyrazorblade/easydblab/SharedLocalStack.kt
+++ b/src/integrationTest/kotlin/com/rustyrazorblade/easydblab/SharedLocalStack.kt
@@ -1,8 +1,7 @@
 package com.rustyrazorblade.easydblab
 
-import org.testcontainers.containers.localstack.LocalStackContainer
-import org.testcontainers.containers.localstack.LocalStackContainer.Service
 import org.testcontainers.containers.wait.strategy.Wait
+import org.testcontainers.localstack.LocalStackContainer
 import org.testcontainers.utility.DockerImageName
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
@@ -30,15 +29,15 @@ import software.amazon.awssdk.services.sts.StsClient
  * calls `.stop()`.
  *
  * The container enables the union of services the six tests need — S3, STS, and
- * EC2 — and exposes ready-to-use AWS SDK clients (each pointed at the matching
- * LocalStack endpoint with the container's credentials). Because one EC2 and one
+ * EC2 — and exposes ready-to-use AWS SDK clients (each pointed at the container's
+ * single LocalStack endpoint with the container's credentials). Because one EC2 and one
  * S3 backend are now shared across classes, tests must scope their assertions to
  * the resources they create rather than asserting on global container state.
  */
 object SharedLocalStack {
     private val container: LocalStackContainer by lazy {
         LocalStackContainer(DockerImageName.parse("localstack/localstack:3.0"))
-            .withServices(Service.S3, Service.STS, Service.EC2)
+            .withServices("s3", "sts", "ec2")
             .waitingFor(Wait.forHttp("/_localstack/health").forStatusCode(200))
             .apply { start() }
     }
@@ -58,7 +57,7 @@ object SharedLocalStack {
     fun s3Client(): S3Client =
         S3Client
             .builder()
-            .endpointOverride(container.getEndpointOverride(Service.S3))
+            .endpointOverride(container.endpoint)
             .region(Region.of(container.region))
             .credentialsProvider(credentialsProvider())
             .forcePathStyle(true)
@@ -70,7 +69,7 @@ object SharedLocalStack {
     fun stsClient(): StsClient =
         StsClient
             .builder()
-            .endpointOverride(container.getEndpointOverride(Service.STS))
+            .endpointOverride(container.endpoint)
             .region(Region.of(container.region))
             .credentialsProvider(credentialsProvider())
             .build()
@@ -81,7 +80,7 @@ object SharedLocalStack {
     fun ec2Client(): Ec2Client =
         Ec2Client
             .builder()
-            .endpointOverride(container.getEndpointOverride(Service.EC2))
+            .endpointOverride(container.endpoint)
             .region(Region.of(container.region))
             .credentialsProvider(credentialsProvider())
             .build()


### PR DESCRIPTION
Closes #781

Migrates `SharedLocalStack` from the deprecated `org.testcontainers.containers.localstack.LocalStackContainer` to the non-deprecated `org.testcontainers.localstack.LocalStackContainer` (testcontainers 2.0.5). This is a behavioral API change, not a package move:

- **Services**: the removed `LocalStackContainer.Service` enum is replaced by `withServices(String...)` — `Service.S3, Service.STS, Service.EC2` becomes `"s3", "sts", "ec2"`.
- **Endpoints**: per-service `getEndpointOverride(Service)` is replaced by the single `getEndpoint()`; the S3, STS, and EC2 SDK clients now all point at the container's one shared endpoint. KDoc updated to reflect this.

With warnings-as-errors on (#753/#780), the old deprecated API would fail the build, so no lingering deprecation remains.

Verified by running the six LocalStack-backed integration tests under Docker on JDK 21 (`SetupProfileIntegrationTest`, `AMIServiceIntegrationTest`, `ClusterBackupServiceS3IntegrationTest`, `AwsInfrastructureServiceIntegrationTest`, `EC2VpcServiceIntegrationTest`, `S3ObjectStoreIntegrationTest`) — 71 tests, all passing. `ktlintFormat` and `detekt` also pass.