### PR TITLE
Stamp OCI image labels on the build-cassandra-ref image

### DIFF
--- a/.github/cassandra-image/Dockerfile
+++ b/.github/cassandra-image/Dockerfile
@@ -20,6 +20,15 @@
 #                  which is in the 3.6-3.13 range cqlsh 5.0+ supports.
 #   TARBALL        path (relative to build context) to the
 #                  apache-cassandra-<version>-bin.tar.gz to inject.
+#
+# OCI provenance build args (see the LABEL block below and issue #767). The
+# workflow resolves each of these and passes them so `docker inspect` traces the
+# image back to the exact Cassandra source commit:
+#   OCI_REVISION   git SHA of the built Cassandra source ref.
+#   OCI_SOURCE     source repo URL (https://github.com/<repo>).
+#   OCI_VERSION    resolved Cassandra base.version (e.g. 6.0-alpha2).
+#   OCI_CREATED    RFC-3339 build timestamp.
+#   OCI_REF_NAME   the source ref (e.g. cassandra-6.0).
 
 ARG BASE_IMAGE=eclipse-temurin:17-jre-noble
 
@@ -89,6 +98,26 @@ VOLUME /var/lib/cassandra
 COPY docker-entrypoint.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 ENTRYPOINT ["docker-entrypoint.sh"]
+
+# Standard OCI image labels (issue #767). Placed last so the per-build values
+# (revision, created timestamp) never invalidate the cache of the expensive apt
+# and tarball-extraction layers above. The dynamic values are wired in from the
+# build-cassandra-ref workflow via --build-arg.
+ARG OCI_REVISION
+ARG OCI_SOURCE=https://github.com/apache/cassandra
+ARG OCI_VERSION
+ARG OCI_CREATED
+ARG OCI_REF_NAME
+LABEL org.opencontainers.image.title="Apache Cassandra" \
+      org.opencontainers.image.description="Apache Cassandra built from source by easy-db-lab" \
+      org.opencontainers.image.url="https://cassandra.apache.org" \
+      org.opencontainers.image.documentation="https://cassandra.apache.org/doc/latest/" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.source="${OCI_SOURCE}" \
+      org.opencontainers.image.revision="${OCI_REVISION}" \
+      org.opencontainers.image.version="${OCI_VERSION}" \
+      org.opencontainers.image.created="${OCI_CREATED}" \
+      org.opencontainers.image.ref.name="${OCI_REF_NAME}"
 
 # 7000: intra-node communication
 # 7001: TLS intra-node communication

--- a/.github/workflows/build-cassandra-ref.yml
+++ b/.github/workflows/build-cassandra-ref.yml
@@ -264,11 +264,24 @@ jobs:
           REF_TAG: ${{ needs.resolve.outputs.ref_tag }}
           BASE_IMAGE: ${{ needs.resolve.outputs.base_image }}
           TARBALL_NAME: ${{ needs.resolve.outputs.tarball_name }}
+          # OCI provenance inputs (issue #767) — stamp the image so `docker
+          # inspect` traces it back to the exact Cassandra source commit.
+          OCI_REVISION: ${{ needs.resolve.outputs.sha }}
+          OCI_SOURCE: https://github.com/${{ inputs.repo }}
+          OCI_VERSION: ${{ needs.resolve.outputs.version }}
+          OCI_REF_NAME: ${{ inputs.ref }}
         run: |
           set -euo pipefail
+          # RFC-3339 UTC build timestamp for org.opencontainers.image.created.
+          created="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
           docker build \
             --build-arg BASE_IMAGE="$BASE_IMAGE" \
             --build-arg TARBALL="$TARBALL_NAME" \
+            --build-arg OCI_REVISION="$OCI_REVISION" \
+            --build-arg OCI_SOURCE="$OCI_SOURCE" \
+            --build-arg OCI_VERSION="$OCI_VERSION" \
+            --build-arg OCI_CREATED="$created" \
+            --build-arg OCI_REF_NAME="$OCI_REF_NAME" \
             --tag "${IMAGE_REPO}:${SHA_TAG}" \
             --tag "${IMAGE_REPO}:${REF_TAG}" \
             .github/cassandra-image


### PR DESCRIPTION
Closes #767

Stamps the Cassandra container images produced by `build-cassandra-ref` with the standard `org.opencontainers.image.*` labels so every image is self-describing and traceable back to its exact source commit.

## Changes

- **`.github/cassandra-image/Dockerfile`** — declares five OCI `ARG`s (`OCI_REVISION`, `OCI_SOURCE`, `OCI_VERSION`, `OCI_CREATED`, `OCI_REF_NAME`) and emits a `LABEL org.opencontainers.image.*` block. Placed last (after `ENTRYPOINT`) so the per-build revision/timestamp never invalidate the cache of the expensive apt and tarball-extraction layers.
- **`.github/workflows/build-cassandra-ref.yml`** — the publish job's "Build image locally" step computes an RFC-3339 UTC build timestamp and passes the values the workflow already resolves as `--build-arg`s: `needs.resolve.outputs.sha` (revision), `https://github.com/${{ inputs.repo }}` (source), `needs.resolve.outputs.version` (version), and `inputs.ref` (ref.name).

## Label set (10)

| Label | Value |
| --- | --- |
| `revision` | git SHA of the built Cassandra source ref |
| `source` | `https://github.com/<repo>` (default apache/cassandra) |
| `version` | resolved Cassandra `base.version` |
| `created` | RFC-3339 build timestamp |
| `ref.name` | the source ref (e.g. `cassandra-6.0`) |
| `title` | Apache Cassandra |
| `description` | Apache Cassandra built from source by easy-db-lab |
| `url` | https://cassandra.apache.org |
| `documentation` | https://cassandra.apache.org/doc/latest/ |
| `licenses` | Apache-2.0 |

The main CLI image (jib / `publish-container.yml`) is intentionally out of scope per the issue.

## Verification

Built a minimal image reproducing the exact ARG/LABEL block with dummy build-args and confirmed via `docker inspect` that all ten labels render with correct substitution (revision = passed SHA, version = 6.0-alpha2, created = RFC-3339 timestamp, etc.). Workflow YAML validated with a parser.

https://claude.ai/code/session_01CAGsFgrT7NRvgyb1KQKiGo