### PR TITLE
build: correct the TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE rationale for Docker Desktop (#761)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -305,10 +305,12 @@ tasks.withType<Test>().configureEach {
     doFirst {
         environment("EASY_DB_LAB_PROFILE", "default")
         environment("TESTCONTAINERS_RYUK_DISABLED", "true")
-        // Rancher Desktop (and other Lima-based Docker runtimes) expose the Docker socket
-        // at a host-userspace path (e.g. ~/.rd/docker.sock) that cannot be bind-mounted
-        // inside containers from within the Lima VM. /var/run/docker.sock is the canonical
-        // path that resolves correctly inside the VM.
+        // Docker Desktop runs the daemon inside a Linux VM and its default context points
+        // DOCKER_HOST at a per-user host socket (e.g. ~/.docker/run/docker.sock). That path
+        // only exists on the host, not inside the VM where containers run, so any
+        // TestContainers component that bind-mounts the Docker socket into a container must
+        // use the canonical in-VM path. This pins that mount source to /var/run/docker.sock,
+        // which resolves correctly inside the Docker VM.
         environment("TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE", "/var/run/docker.sock")
 
         println("========================================")


### PR DESCRIPTION
Closes #761

Replaces the stale Rancher Desktop / Lima rationale on the `TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE = /var/run/docker.sock` setting with one that accurately reflects the current Docker Desktop toolchain. The setting itself is unchanged (still `/var/run/docker.sock`, the canonical in-VM socket path).

**Open question (kept as follow-up, not acted on):** the override may be a no-op under Docker Desktop — Ryuk is already disabled here (`TESTCONTAINERS_RYUK_DISABLED=true`) and no integration container bind-mounts the host Docker socket (LocalStack is S3-only on 3.0, K3sContainer is privileged but mounts no host socket, Cassandra/Redis don't either). Not dropped without verifying the integration tier runs cleanly without it across dev Docker contexts.