### PR TITLE
fix(otel): stamp host.name on OTLP metrics so per-node counters don't collapse

### DIFF
--- a/src/main/resources/com/rustyrazorblade/easydblab/configuration/otel/otel-collector-config.yaml
+++ b/src/main/resources/com/rustyrazorblade/easydblab/configuration/otel/otel-collector-config.yaml
@@ -276,10 +276,14 @@ service:
       receivers: [hostmetrics, prometheus]
       processors: [resource/cluster, resourcedetection, k8sattributes, batch]
       exporters: [prometheusremotewrite]
-    # Remote metrics via OTLP (e.g., Spark nodes) — stamp cluster label to match local metrics
+    # Metrics received via OTLP from node-local workloads (e.g. the cqlite-flight DaemonSet,
+    # Spark nodes). resourcedetection stamps host.name so each node's counters form a distinct
+    # series — without it, per-pod cumulative counters collapse into one identity, VictoriaMetrics
+    # reads their staggered start-times as constant resets, and rate()/increase() extrapolate a
+    # ~1000x-inflated ramp (observed on cqlite_rpc_requests_total in the v0.15 flight soak).
     metrics/otlp:
       receivers: [otlp]
-      processors: [resource/cluster, batch]
+      processors: [resource/cluster, resourcedetection, batch]
       exporters: [prometheusremotewrite]
     logs/local:
       receivers: [filelog/system, filelog/tools, filelog/cassandra]


### PR DESCRIPTION
## Problem

The OTel collector's `metrics/otlp` pipeline — which the node-local `cqlite-flight` DaemonSet (and other OTLP metric sources) feed — ran only `[resource/cluster, batch]`, with **no `resourcedetection`**. Metrics from every node therefore arrived with identical resource attributes and **no per-node label**, so VictoriaMetrics merged all N nodes' series into a single identity.

Because each node's counters are independent cumulative series with staggered start-times, the merged series jumps backwards constantly. `rate()`/`increase()` read every backward step as a counter reset and extrapolate a fresh 0→N ramp — producing **~1000×-inflated, ever-climbing values** on the CQLite Flight RPC dashboard.

Observed during the v0.15 flight soak:
- `cqlite_rpc_requests_total` plotted **~2.35M req/s** while real throughput was **~39 qps**.
- The `errors/sec` panels were inflated the same way.
- `resets(cqlite_rpc_requests_total[90m])` returned **90** on a counter that should never reset.
- The metric had 3 underlying series (one per flight pod) but no label distinguished them.

The counter *data* was correct throughout (raw per-collection increments were clean and monotonic); only the `rate()`/`increase()`-derived panels were affected.

## Fix

Add `resourcedetection` to the `metrics/otlp` pipeline so each node-local collector stamps `host.name`, giving every node a distinct series. This matches the `metrics/local` pipeline and the EMR collector config, which already run `resourcedetection`.

```diff
     metrics/otlp:
       receivers: [otlp]
-      processors: [resource/cluster, batch]
+      processors: [resource/cluster, resourcedetection, batch]
       exporters: [prometheusremotewrite]
```

## Verification

Applied live on a running cluster (patched the ConfigMap, restarted `ds/otel-collector`):
- Metrics gained `host_name=db0/db1/db2`.
- `sum(rate(cqlite_rpc_requests_total{status="ok",method="do_get"}[1m])) by (host_name)` read **db0 63 / db1 125 / db2 257 = ~445 do_get/s** — sane, no longer millions; the fan-out skew is even visible in the split.
- `errors/sec` read ~7.45/s.
- Counter data itself unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)