### PR TITLE
perf(networking): Cilium ENI native routing as opt-in --cni=cilium datapath

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -327,7 +327,7 @@ The cluster runs a full observability stack on the control node. When modifying 
 
 All observability K8s resources are built programmatically using Fabric8 manifest builders in `configuration/` subpackages. No raw YAML files remain in the core observability stack. See [`configuration/CLAUDE.md`](src/main/kotlin/com/rustyrazorblade/easydblab/configuration/CLAUDE.md) for detailed builder documentation.
 
-**CNI**: K3s uses Cilium (not Flannel) with Hubble enabled for L7 network visibility and Prometheus metrics at `localhost:9965`.
+**CNI**: K3s uses its built-in Flannel overlay by default. Cilium ENI native routing (no encapsulation; pods get VPC-routable ENI secondary IPs) is selectable via `--cni=cilium` at init. When Cilium is selected, Hubble is enabled for L7 network visibility and Prometheus metrics at `localhost:9965`.
 
 **Collectors** (run on cluster nodes): OTel Collector, Fluent Bit (journald), Grafana Alloy (eBPF profiling), Beyla (L7 RED metrics), ebpf_exporter (TCP/block I/O/VFS), YACE (CloudWatch), MAAC agent (Cassandra metrics)
 

--- a/openspec/changes/cilium-native-routing/.openspec.yaml
+++ b/openspec/changes/cilium-native-routing/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-20

--- a/openspec/changes/cilium-native-routing/design.md
+++ b/openspec/changes/cilium-native-routing/design.md
@@ -1,0 +1,88 @@
+## Context
+
+Cilium is installed by `DefaultCiliumService.install(controlHost: Host)` (`services/CiliumService.kt:11,23`), which shells `cilium install --set …` on the control node via `remoteOps.executeRemotely`. It currently runs Cilium 1.19.4 in VXLAN tunnel mode. The install is gated behind `--cilium` (opt-in; Flannel is the default). The goal is to flip the default to Cilium **ENI IPAM native routing** (no encapsulation), the only multi-AZ-safe no-encap datapath on AWS.
+
+The design below was verified against the worktree code; three research assumptions were corrected (noted inline).
+
+## Goals / Non-Goals
+
+**Goals**
+- Default CNI is Cilium ENI native routing; pods get VPC-routable IPs; cross-AZ pod-to-pod works with no tunnel.
+- Fix the two blocking bugs (Hubble brace expansion; IMDS hop-limit on worker nodes).
+- Keep Flannel selectable as a first-class fallback via `--cni=flannel`.
+
+**Non-Goals**
+- Enabling `kubeProxyReplacement` (kept OFF this cut — deliberate scope boundary).
+- Any IAM / security-group / AMI / K3s-launch change (all verified already sufficient).
+- Backwards compatibility for old state files beyond Jackson's lenient default handling (clusters are ephemeral).
+
+## Decisions
+
+### Decision 1 — CNI selection: `--cni=<cilium|flannel>` enum option, default `flannel` (OWNER-DECIDED)
+
+The owner chose a single enum-valued option over a boolean flag. `--cni=cilium|flannel`, **default `flannel`**:
+- Mutually exclusive by construction (one value), self-documenting, and extensible to future CNIs (e.g. Calico) with no new flags.
+- PicoCLI validates the value natively against the `CniMode` enum (invalid value → error listing the allowed set).
+- **Default stays `flannel` this patch (owner decision).** This patch lands Cilium ENI native routing as a correct, opt-in datapath (`--cni=cilium`); the default remains Flannel until native routing is proven on live multi-AZ clusters. Flipping the default to `cilium` is the separate, stabilization-gated follow-up **#819**.
+
+Backed by:
+```kotlin
+enum class CniMode { Cilium, Flannel }
+```
+`InitConfig.ciliumEnabled: Boolean` (`ClusterState.kt:111`) is **replaced** by `InitConfig.cni: CniMode = CniMode.Flannel`. `useCustomCni = (cni == CniMode.Cilium)`. Jackson serializes the enum by name; the default applies to older/short state files. `InitConfig.fromInit` (`ClusterState.kt:167`) maps from the `--cni` value. Rejected: keep-and-invert the boolean (`--cilium` default true) — awkward UX (Flannel = `--no-cilium`), not extensible.
+
+### Decision 2 — Thread the VPC CIDR from state, not through the call stack (CORRECTED)
+
+Research assumed a top-level `ClusterState.cidr`; there is none. The CIDR is `InitConfig.cidr: String?` (`ClusterState.kt:110`), resolved during `up` (`Up.resolveCidr()`, `:237-243`) and **persisted back into `workingState.initConfig`** (`Up.kt:307-310`) before node setup. So at `installCilium()` time it is reliably `workingState.initConfig?.cidr` (non-null after `provisionInfrastructure`). `CiliumService.install()` gains a `vpcCidr: String` parameter; `Up.installCilium()` reads it from state and passes it — no param threaded down through `setupInstancesIfNeeded`.
+
+```kotlin
+// CiliumService
+fun install(controlHost: Host, vpcCidr: String): Result<Unit>
+
+// Up.installCilium()
+val vpcCidr = requireNotNull(workingState.initConfig?.cidr) {
+    "VPC CIDR must be resolved before Cilium install"
+}
+ciliumService.install(controlHost.toHost(), vpcCidr).getOrThrow()
+```
+
+### Decision 3 — ENI native `--set` flag set (Cilium 1.19.4) — Variant A, corrected after live test
+
+Replace the current VXLAN `--set` block with:
+`ipam.mode=eni`, `eni.enabled=true`, `routingMode=native`, `endpointRoutes.enabled=true`, `enableIPv4Masquerade=true`, `egressMasqueradeInterfaces=ens+`, `kubeProxyReplacement=false`, `bpf.hostLegacyRouting=true`, `ipv4NativeRoutingCIDR=$vpcCidr`, `k8sServiceHost=${controlHost.private}`, `k8sServicePort=6443`, `operator.replicas=1`, `hubble.relay.enabled=true`, `hubble.ui.enabled=true`, `hubble.metrics.enabled='{dns,drop,tcp,flow,port-distribution,icmp,http}'`.
+
+- **Drop** `tunnelProtocol=vxlan` and `routingMode=tunnel`.
+- **Do NOT** set `autoDirectNodeRoutes` — it only routes within a single L2/subnet and breaks cross-AZ; unnecessary in ENI mode because the VPC routes pod IPs.
+- **Set `egressMasqueradeInterfaces=ens+`** — a LIVE AWS test proved the earlier "do NOT set it" position wrong: in ENI mode Cilium requires a **named** egress masquerade interface, and with it empty the agent **panics** (`Egress masquerading interfaces cannot be empty…`). The `ens+` wildcard covers the Nitro primary NIC (`ens5`) plus ENI secondaries — correct on Nitro (do not hardcode `eth0`), and masquerading is done via **iptables**, not BPF. `+` is not a shell metacharacter, so it renders unquoted safely over the SSH command.
+- **Set `kubeProxyReplacement=false` explicitly** — see Decision 5. The prior config never pinned it, which effectively enabled BPF masquerade / BPF host routing on the primary NIC and **blackholed the node's own inbound SSH:22 and kube-apiserver:6443** (confirmed by cilium/cilium#46010 on 1.19.4). This was the second failure the live test hit.
+- **Set `bpf.hostLegacyRouting=true`** — keep host networking on the kernel stack so node SSH / API-server reachability is preserved.
+- **MUST NOT set `bpf.masquerade`** — enabling BPF masquerade on the Nitro primary NIC is precisely what broke host networking. Masquerade is handled by iptables via `egressMasqueradeInterfaces`.
+- **Single-quote** the Hubble metrics brace list — the current unquoted form is brace-expanded by the remote shell and breaks `cilium install`.
+
+### Decision 4 — IMDS hop-limit on all node types
+
+`EC2InstanceService` (`:146-155`) wraps the `metadataOptions(httpPutResponseHopLimit(2), httpTokens(REQUIRED), httpEndpoint(enabled))` builder call in `if (serverType == ServerType.Control)`. Lift it out of the guard so every instance gets hop-limit 2. This is the root fix that lets the cilium-operator allocate ENIs regardless of which node it lands on. Rejected alternative: pin the operator to the control node via `nodeSelector` + toleration — more moving parts, and hop-limit 2 on workers is independently correct.
+
+### Decision 5 — kube-proxy retained (kubeProxyReplacement EXPLICITLY OFF)
+
+Keep K3s's kube-proxy this cut. Isolates the ENI datapath change and avoids re-opening the historical agent→API bootstrap-interception concern in the same change. `start-k3s-server.sh` already runs `--flannel-backend=none --disable-network-policy` under `useCustomCni`; no script change. Enabling `kubeProxyReplacement` (and `--disable-kube-proxy`) is a deliberate fast-follow.
+
+**Now enforced, not merely intended.** The original config never passed `kubeProxyReplacement=false`, so Cilium's default effectively enabled it — turning on BPF masquerade / BPF host routing on the Nitro primary NIC and blackholing the node's own SSH:22 and apiserver:6443 (cilium/cilium#46010). A live AWS test hit exactly this. The flag is now set to `false` explicitly so the datapath stays on iptables + K3s kube-proxy and host networking is preserved. `kubeProxyReplacement=false` does **not** trigger the #46010 blackhole.
+
+## Verified no-change (confirm-only)
+
+- **IAM** — `AWSPolicy.kt:171` grants `ec2:*` (superset of all ENI actions). PASS, no change.
+- **Security groups** — `InfrastructureConfig.forCluster()` opens all-port TCP (`:171-178`) and UDP (`:179-186`) across the VPC CIDR. PASS. Caveat: no ICMP rule → live validation uses curl/nc, never ping.
+- **K3s launch** — flannel disabled under `useCustomCni` (`start-k3s-server.sh:37`). PASS.
+- **CNI-first ordering** — `K3sClusterService.setupCluster()` runs `onServerReady` after server start but before agents join (`:154-171`). Already correct; no reordering.
+- **AMI** — unchanged.
+
+## Risks / Trade-offs
+
+- **ENI IP capacity** — each pod consumes one VPC IP from the node's AZ subnet; density is capped by instance ENI limits (i4i.xlarge ≈ 45 pods/node) and subnet free IPs (/24 ≈ 251). Adequate for lab clusters; noted for large fan-outs.
+- **All-or-nothing datapath, low-risk rollout** — per owner, native works or we pick a different tool; no VXLAN half-step is retained. This patch keeps Flannel as the default so the ENI datapath is opt-in until proven; #819 flips the default once it's trusted.
+- **State field replacement** — replacing `ciliumEnabled` with `cni` changes the persisted shape; ephemeral clusters mean no migration is owed, and Jackson applies the default to older files.
+
+## Migration
+
+None. Ephemeral clusters; new field defaults apply automatically.

--- a/openspec/changes/cilium-native-routing/proposal.md
+++ b/openspec/changes/cilium-native-routing/proposal.md
@@ -1,0 +1,38 @@
+## Why
+
+The cluster runs Cilium purely to get eBPF's low-overhead datapath — but `CiliumService` installs it in **VXLAN tunnel mode** (`tunnelProtocol=vxlan` + `routingMode=tunnel`), which re-encapsulates every packet and throws away the performance that is the entire reason for using Cilium. VXLAN was chosen originally only to sidestep a worker-bootstrap deadlock (Cilium's eBPF intercepting the K3s agent's TCP to the API server during join).
+
+On AWS, the multi-AZ-safe way to run Cilium with **no encapsulation** is **ENI IPAM mode**: pods get real VPC-routable secondary IPs on the node's ENIs, so cross-AZ pod traffic is routed by the VPC itself — no tunnel, no `autoDirectNodeRoutes` (which only works within one L2 domain and breaks across AZs). This change lands Cilium ENI native routing as a correct, **opt-in** datapath selected with `--cni=cilium`; the default stays **Flannel** to de-risk the rollout. Flipping the default to Cilium once it is proven on live clusters is the deliberately-separate follow-up **#819**.
+
+Two blocking bugs must be fixed for this to work at all:
+- **The `--cilium` path is currently broken end-to-end.** `hubble.metrics.enabled={dns,drop,...}` is passed **unquoted** to a remote shell, so bash brace-expands it into seven separate tokens and `cilium install` never receives a valid value. This has meant `--cilium` never installed successfully since it landed — it went unnoticed because Cilium is opt-in and Flannel is the default.
+- **The cilium-operator can deadlock on IMDS.** The IMDS hop-limit is raised to 2 only for the control node; db/app nodes keep the AWS default of 1, so the (non-hostNetwork) cilium-operator pod cannot reach IMDS if it schedules on a db node → no credentials → no ENIs → **no pod on the cluster gets an IP**.
+
+## What Changes
+
+- `CiliumService.install()` gains a `vpcCidr` parameter and installs Cilium **1.19.4** in ENI IPAM native-routing mode: `ipam.mode=eni`, `eni.enabled=true`, `routingMode=native`, `endpointRoutes.enabled=true`, `enableIPv4Masquerade=true`, `egressMasqueradeInterfaces=ens+`, `kubeProxyReplacement=false`, `bpf.hostLegacyRouting=true`, `ipv4NativeRoutingCIDR=<vpcCidr>`, `k8sServiceHost=<control private IP>`, `k8sServicePort=6443`, `operator.replicas=1`, Hubble relay/ui/metrics. VXLAN/tunnel flags removed. A LIVE AWS test corrected the flag set: ENI mode requires a **named** egress masquerade interface (`egressMasqueradeInterfaces=ens+`, iptables masquerade over the Nitro primary NIC `ens5` + ENI secondaries) or the agent panics; `kubeProxyReplacement` is pinned **false** and `bpf.hostLegacyRouting=true`, and `bpf.masquerade` is **not** set, avoiding the BPF-host-routing blackhole of the node's own SSH:22 / apiserver:6443 (cilium/cilium#46010). The Hubble metrics brace list is **single-quoted** to fix the expansion bug.
+- The VPC CIDR is read from `workingState.initConfig?.cidr` (resolved and persisted before node setup) at the `Up.installCilium()` call site and passed to `install()`.
+- IMDS `metadataOptions` (hop-limit 2, IMDSv2 required) is applied to **all** node types, not just the control node.
+- A new `--cni=<cilium|flannel>` init option (default `flannel`) replaces the boolean `--cilium` flag. It is backed by a `CniMode` enum persisted in `InitConfig`, is mutually exclusive by construction, and is extensible to future CNIs. `--cni=cilium` selects Cilium ENI native routing; `--cni=flannel` (the default) selects K3s's built-in Flannel. The default-to-Cilium flip is deferred to #819.
+- `kubeProxyReplacement` is now set to **false explicitly** (previously intended off but never enforced) — K3s's kube-proxy continues to service Services. This isolates the ENI datapath change from a second large variable, moots the historical agent→API bootstrap-interception concern, and — critically — avoids the BPF-host-routing blackhole of node SSH/API that the unpinned default caused on the live test (cilium/cilium#46010).
+- Docs corrected: the observability CLAUDE.md line "K3s uses Cilium (not Flannel)" is currently false (Flannel is and remains the default this patch); it is rewritten to describe reality — Flannel is the default datapath, and Cilium ENI native routing is selectable via `--cni=cilium`.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `networking`: adds a pod-network datapath requirement — Cilium ENI IPAM native routing (no encapsulation) is a supported datapath selectable via `--cni=cilium`; Flannel remains the default (`--cni=flannel`). REQ-NET-005 (SOCKS invariant) is untouched.
+
+## Impact
+
+- `services/CiliumService.kt` — `install()` signature + ENI native `--set` flags + Hubble brace-quote fix + rationale comment
+- `commands/Up.kt` — `installCilium()` reads the resolved VPC CIDR and passes it; CNI gating reads the `CniMode` field
+- `commands/Init.kt` — `--cilium` boolean replaced by `--cni=<cilium|flannel>` (default `flannel`)
+- `configuration/ClusterState.kt` — new `CniMode` enum; `InitConfig.ciliumEnabled: Boolean` replaced by `InitConfig.cni: CniMode = CniMode.Cilium`; `InitConfig.fromInit` maps from `--cni`
+- `services/aws/EC2InstanceService.kt` — IMDS `metadataOptions` applied to all node types (hop-limit 2)
+- `src/test/.../services/CiliumServiceTest.kt` — assert ENI native flags, absence of VXLAN, single-quoted Hubble metrics, CIDR threading
+- `src/test/.../services/aws/EC2InstanceServiceTest.kt` — new: assert hop-limit 2 / IMDSv2 required for db, app, and control specs
+- `src/test/.../configuration/` (or Init/UpTest) — `fromInit` default `cilium`, `--cni=flannel` mapping
+- `openspec/specs/networking/spec.md` — add REQ-NET-007
+- `CLAUDE.md` — observability CNI line
+- **No change** (verified): `providers/aws/AWSPolicy.kt` (already grants `ec2:*`, a superset of ENI actions), `configuration/InfrastructureConfig.kt` (already opens all intra-VPC TCP/UDP — note: no ICMP, so live tests use curl/nc not ping), K3s launch scripts (flannel already disabled under `useCustomCni`), the AMI.

--- a/openspec/changes/cilium-native-routing/specs/networking/spec.md
+++ b/openspec/changes/cilium-native-routing/specs/networking/spec.md
@@ -1,0 +1,41 @@
+## ADDED Requirements
+
+### Requirement: Pod-network datapath (Cilium ENI native routing, selectable)
+The system SHALL support Cilium in ENI IPAM native-routing mode as a selectable pod-network datapath with no encapsulation. When selected, pods SHALL receive VPC-routable IPv4 addresses allocated as secondary IPs on their node's ENIs, so cross-AZ pod-to-pod traffic is routed by the VPC without a tunnel. The CNI SHALL be selectable via `--cni=<cilium|flannel>` at init time; the default SHALL be `flannel` (K3s's built-in datapath). When Cilium is selected, kube-proxy is retained (Cilium's kube-proxy replacement is not enabled). This requirement does not alter REQ-NET-005 (SOCKS proxy) behavior. (Flipping the default to `cilium` is tracked separately.)
+
+#### Scenario: Default provision uses Flannel
+- **WHEN** a cluster is provisioned with no `--cni` option
+- **THEN** the cluster uses K3s's built-in Flannel datapath
+
+#### Scenario: --cni=cilium uses ENI native routing
+- **WHEN** a cluster is provisioned with `--cni=cilium`
+- **THEN** Cilium runs in ENI IPAM native-routing mode (`routing-mode: native`, no VXLAN tunnel) AND all worker-node K3s agents reach Ready without the API-server i/o-timeout bootstrap deadlock
+
+#### Scenario: Cilium pods receive VPC-routable ENI IPs per AZ
+- **GIVEN** a cluster provisioned with `--cni=cilium`
+- **WHEN** the cluster is up
+- **THEN** `kubectl get ciliumnode` shows ENIs with allocated IPs on each node AND each pod's IP falls within its own node's AZ subnet CIDR
+
+#### Scenario: Cross-AZ pod-to-pod routing without a tunnel
+- **GIVEN** a `--cni=cilium` cluster with a pod on a node in AZ-a and a pod on a node in AZ-b
+- **WHEN** the AZ-a pod connects to the AZ-b pod by its pod IP (via curl/nc; ICMP is not permitted by the security group)
+- **THEN** the connection succeeds, routed by the VPC with no encapsulation
+
+#### Scenario: Cilium pod reaches a ClusterIP service and an external address
+- **GIVEN** a `--cni=cilium` cluster
+- **WHEN** a pod connects to a ClusterIP service, and separately to an external URL
+- **THEN** both succeed (Services via retained kube-proxy; egress via masquerade)
+
+#### Scenario: cilium-operator on a worker node can allocate ENIs
+- **GIVEN** a `--cni=cilium` cluster where the cilium-operator pod is scheduled on a db/app (worker) node
+- **WHEN** it requests EC2 credentials from IMDS to allocate ENIs
+- **THEN** IMDS is reachable (worker nodes launch with IMDS hop-limit 2) AND ENIs are allocated so pods receive IPs
+
+#### Scenario: OS leaves Cilium's secondary ENIs unmanaged
+- **GIVEN** a node whose cilium-operator has attached a secondary ENI (ens6+) at runtime for pod IP allocation
+- **WHEN** systemd-networkd evaluates the newly attached interface
+- **THEN** the base AMI's `/etc/systemd/network/06-cilium-eni-unmanaged.network` drop-in (sorting ahead of cloud-init's `10-netplan-*`) marks ens6+ `Unmanaged=yes` so the OS does NOT DHCP it or add a competing default route, while the `05-cilium-eni-primary.network` drop-in keeps the primary ENI (ens5) OS-managed via DHCP — so the host stays single-homed and the node's IMDS, egress, and kubelet→apiserver paths keep working
+
+#### Scenario: Invalid CNI value is rejected
+- **WHEN** the user passes `--cni=<unsupported>`
+- **THEN** init fails with an error listing the allowed values (`cilium`, `flannel`)

--- a/openspec/changes/cilium-native-routing/tasks.md
+++ b/openspec/changes/cilium-native-routing/tasks.md
@@ -1,0 +1,39 @@
+## 1. Data model and CNI selection
+
+- [x] 1.1 Add `enum class CniMode { Cilium, Flannel }` in `configuration/ClusterState.kt` (class-level KDoc)
+- [x] 1.2 Replace `InitConfig.ciliumEnabled: Boolean` with `InitConfig.cni: CniMode = CniMode.Flannel` (default Flannel this patch; #819 flips it)
+- [x] 1.3 Replace `Init.cilium: Boolean` with `Init.cni: CniMode = CniMode.Flannel` as `@Option(names = ["--cni"])` (default `flannel`; PicoCLI validates against the enum) in `commands/Init.kt`
+- [x] 1.4 Update `InitConfig.fromInit` (`ClusterState.kt`) to map from `init.cni`
+- [x] 1.5 Update every `ciliumEnabled` read (esp. `Up.startK3sOnAllNodes()` / `useCustomCni` gating) to `cni == CniMode.Cilium`
+
+## 2. Cilium ENI native routing
+
+- [x] 2.1 Change `CiliumService.install` signature (interface + `DefaultCiliumService`) to `install(controlHost: Host, vpcCidr: String): Result<Unit>`
+- [x] 2.2 Replace the `--set` block with ENI native flags: `ipam.mode=eni`, `eni.enabled=true`, `routingMode=native`, `endpointRoutes.enabled=true`, `enableIPv4Masquerade=true`, `egressMasqueradeInterfaces=ens+`, `kubeProxyReplacement=false`, `bpf.hostLegacyRouting=true`, `ipv4NativeRoutingCIDR=$vpcCidr`, `k8sServiceHost=${controlHost.private}`, `k8sServicePort=6443`, `operator.replicas=1`, `hubble.relay.enabled=true`, `hubble.ui.enabled=true` (CORRECTED after a live AWS test — see design.md Decision 3: ENI mode requires a named `egressMasqueradeInterfaces` or the agent panics, and `kubeProxyReplacement` must be pinned `false` or it silently enables a BPF host-routing blackhole of the node's own SSH/API-server traffic)
+- [x] 2.3 Single-quote the Hubble metrics value: `hubble.metrics.enabled='{dns,drop,tcp,flow,port-distribution,icmp,http}'` (fixes the brace-expansion bug)
+- [x] 2.4 Remove `tunnelProtocol=vxlan` and `routingMode=tunnel`; do NOT add `autoDirectNodeRoutes` (only routes within a single L2 domain, breaks cross-AZ) — `egressMasqueradeInterfaces` and `kubeProxyReplacement` ARE required, per the correction in 2.2
+- [x] 2.5 Replace the VXLAN-rationale comment with an ENI/native-routing rationale
+- [x] 2.6 Update `Up.installCilium()` to read `workingState.initConfig?.cidr` (requireNotNull) and pass it to `install()`
+
+## 3. IMDS hop limit for all nodes
+
+- [x] 3.1 In `EC2InstanceService` (`~:146-155`), lift the `metadataOptions(httpPutResponseHopLimit(2), httpTokens(REQUIRED), httpEndpoint enabled)` block out of the `if (serverType == ServerType.Control)` guard so all node types receive it
+- [x] 3.2 Update the now-stale "Control nodes need…" comment
+
+## 4. Tests (unit tier)
+
+- [x] 4.1 `CiliumServiceTest`: assert the install command contains `ipam.mode=eni`, `eni.enabled=true`, `routingMode=native`, `endpointRoutes.enabled=true`, `enableIPv4Masquerade=true`, and `ipv4NativeRoutingCIDR=<the cidr arg>`; assert it does NOT contain `tunnelProtocol=vxlan` or `routingMode=tunnel`
+- [x] 4.2 `CiliumServiceTest`: regression test that the Hubble metrics value is single-quoted (`hubble.metrics.enabled='{`) — the brace bug
+- [x] 4.3 `CiliumServiceTest`: pass a distinct CIDR and assert it appears verbatim in the command (guards threading)
+- [x] 4.4 `EC2InstanceServiceTest` (new): capture `RunInstancesRequest` for db, app, and control specs; assert each has `metadataOptions().httpPutResponseHopLimit() == 2` and `httpTokens() == REQUIRED`
+- [x] 4.5 `InitConfig.fromInit` test: default `cni == CniMode.Flannel`; `--cni=cilium` → `CniMode.Cilium`
+
+## 5. Docs and spec
+
+- [x] 5.1 Correct the observability CNI line in `CLAUDE.md` to describe reality — Flannel is the default datapath, Cilium ENI native routing is selectable via `--cni=cilium` (do NOT claim Cilium is the default; that lands in #819); grep confirms no `docs/` CNI mentions to update
+- [x] 5.2 Ensure `openspec/specs/networking/spec.md` REQ-NET-007 is reflected (spec delta applied at archive)
+
+## 6. Verification
+
+- [x] 6.1 Run `./gradlew ktlintFormat && ./gradlew test && ./gradlew detekt` on JDK 21 — all pass
+- [ ] 6.2 Live cross-AZ validation (1 control + 2 db nodes in different AZs) — see acceptance scenarios: default `up` → native (no VXLAN), all agents Ready, `ciliumnode` shows ENIs+IPs per node, each pod IP in its node's AZ subnet, cross-AZ pod→pod by pod IP (curl/nc), pod→ClusterIP, pod→external URL, Hubble flows; operator-on-db-node allocates ENIs (IMDS fix)

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Init.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Init.kt
@@ -240,7 +240,7 @@ class Init : PicoBaseCommand() {
         names = ["--cni"],
         description = [
             "Pod-network CNI: 'flannel' (default) uses K3s's built-in Flannel overlay; " +
-                "'cilium' uses Cilium (opt-in, installed in the standard VXLAN-tunnel mode).",
+                "'cilium' uses Cilium ENI native routing (no encapsulation).",
         ],
         converter = [PicoCniModeConverter::class],
     )

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Up.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Up.kt
@@ -699,10 +699,14 @@ class Up(
         }
     }
 
-    /** Installs Cilium as the K3s CNI on the control node. */
+    /** Installs Cilium as the K3s CNI on the control node in ENI native-routing mode. */
     private fun installCilium() {
         val controlHosts = workingState.hosts[ServerType.Control] ?: emptyList()
-        ciliumService.install(controlHosts.first().toHost()).getOrThrow()
+        val vpcCidr =
+            requireNotNull(workingState.initConfig?.cidr) {
+                "VPC CIDR must be resolved before installing Cilium"
+            }
+        ciliumService.install(controlHosts.first().toHost(), vpcCidr).getOrThrow()
     }
 
     /** Starts K3s server on control node and joins Cassandra/Stress nodes as agents. */

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/ClusterState.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/ClusterState.kt
@@ -43,8 +43,9 @@ enum class InfrastructureStatus {
  *
  * The datapath is mutually exclusive by construction — a cluster runs exactly one CNI.
  * [Flannel] is K3s's built-in VXLAN-overlay CNI (the current default). [Cilium] selects
- * Cilium (see [com.rustyrazorblade.easydblab.services.CiliumService]). Modeled as an enum
- * rather than a boolean so future datapaths can be added without another flag.
+ * Cilium in ENI IPAM native-routing mode, where pods receive VPC-routable secondary IPs
+ * so cross-AZ traffic is routed by the VPC without encapsulation. Modeled as an enum rather
+ * than a boolean so future datapaths can be added without another flag.
  */
 enum class CniMode {
     Cilium,

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/CiliumService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/CiliumService.kt
@@ -8,7 +8,10 @@ import com.rustyrazorblade.easydblab.providers.ssh.RemoteOperationsService
 import io.github.oshai.kotlinlogging.KotlinLogging
 
 interface CiliumService {
-    fun install(controlHost: Host): Result<Unit>
+    fun install(
+        controlHost: Host,
+        vpcCidr: String,
+    ): Result<Unit>
 }
 
 class DefaultCiliumService(
@@ -20,42 +23,76 @@ class DefaultCiliumService(
         private const val CILIUM_VERSION = "1.19.4"
     }
 
-    override fun install(controlHost: Host): Result<Unit> =
+    override fun install(
+        controlHost: Host,
+        vpcCidr: String,
+    ): Result<Unit> =
         runCatching {
             eventBus.emit(Event.Cilium.Installing)
             eventBus.emit(Event.Cilium.InstallingChart)
 
-            // VXLAN tunnel mode: Cilium encapsulates pod traffic rather than installing
-            // native host routes. In native routing mode, Cilium's own eBPF programs
-            // intercept the agent's outbound TCP to the API server during bootstrap,
-            // causing an i/o timeout before the agent can finish initialization.
-            // VXLAN avoids this by keeping host-to-host traffic outside eBPF interception.
+            // ENI IPAM native routing: pods receive real VPC-routable secondary IPs on the
+            // node's ENIs, so cross-AZ pod traffic is routed by the VPC itself — no
+            // encapsulation. This is the multi-AZ-safe way to run Cilium with no tunnel
+            // (autoDirectNodeRoutes only works within a single L2 domain and breaks across
+            // AZs). ipv4NativeRoutingCIDR marks the VPC CIDR as directly routable so traffic
+            // to those IPs is not masqueraded. Masquerade stays enabled for egress to the
+            // internet. Native routing (VPC-routable ENI pod IPs, no encapsulation) is the
+            // actual performance win here and is unchanged.
+            //
+            // egressMasqueradeInterfaces=ens+ : ENI mode requires a NAMED egress masquerade
+            // interface — with it empty the agent panics ("Egress masquerading interfaces
+            // cannot be empty..."). The wildcard ens+ matches the Nitro primary NIC (ens5)
+            // plus ENI secondaries; masquerading is done via iptables (not BPF). Do not
+            // hardcode eth0 — that is wrong on Nitro instances.
+            //
+            // kubeProxyReplacement=false : explicitly OFF so K3s keeps its own kube-proxy.
+            // Enabling it turns on BPF masquerade / BPF host routing on the primary NIC,
+            // which blackholes the node's own inbound SSH:22 and kube-apiserver:6443 (see
+            // cilium/cilium#46010 on 1.19.4). A live AWS test hit exactly this. Leaving it
+            // false — and NOT setting bpf.masquerade — avoids the host-networking blackhole.
+            //
+            // bpf.hostLegacyRouting=true : keep host networking on the kernel stack so node
+            // SSH / API-server reachability is preserved.
             //
             // Direct API server endpoint so worker-node agents don't use the ClusterIP,
             // which requires Cilium itself to route — a bootstrap deadlock.
             val command =
                 buildList {
+                    fun set(kv: String) {
+                        add("--set")
+                        add(kv)
+                    }
+
                     add("KUBECONFIG=${Constants.K3s.REMOTE_KUBECONFIG}")
                     add("cilium")
                     add("install")
                     add("--version")
                     add(CILIUM_VERSION)
-                    add("--set")
-                    add("k8sServiceHost=${controlHost.private}")
-                    add("--set")
-                    add("k8sServicePort=6443")
-                    add("--set")
-                    add("tunnelProtocol=vxlan")
-                    add("--set")
-                    add("routingMode=tunnel")
-                    add("--set")
-                    add("operator.replicas=1")
-                    add("--set")
-                    add("hubble.relay.enabled=true")
-                    add("--set")
-                    add("hubble.ui.enabled=true")
-                    add("--set")
-                    add("hubble.metrics.enabled={dns,drop,tcp,flow,port-distribution,icmp,http}")
+                    set("ipam.mode=eni")
+                    set("eni.enabled=true")
+                    set("routingMode=native")
+                    set("endpointRoutes.enabled=true")
+                    set("enableIPv4Masquerade=true")
+                    // ENI mode requires a named egress masquerade interface or the agent
+                    // panics. ens+ wildcard covers the Nitro primary NIC (ens5) + ENI
+                    // secondaries; masquerading via iptables. '+' is not a shell metachar,
+                    // so it renders unquoted safely over the SSH command.
+                    set("egressMasqueradeInterfaces=ens+")
+                    // Explicitly off: keep K3s kube-proxy and avoid Cilium's BPF host
+                    // routing, which blackholes node SSH:22 / apiserver:6443 (cilium#46010).
+                    set("kubeProxyReplacement=false")
+                    // Host networking stays on the kernel stack so node SSH/API stay reachable.
+                    set("bpf.hostLegacyRouting=true")
+                    set("ipv4NativeRoutingCIDR=$vpcCidr")
+                    set("k8sServiceHost=${controlHost.private}")
+                    set("k8sServicePort=6443")
+                    set("operator.replicas=1")
+                    set("hubble.relay.enabled=true")
+                    set("hubble.ui.enabled=true")
+                    // Single-quoted so the remote shell does not brace-expand the list into
+                    // seven separate tokens (which fed cilium install an invalid value).
+                    set("hubble.metrics.enabled='{dns,drop,tcp,flow,port-distribution,icmp,http}'")
                 }.joinToString(" ")
 
             remoteOps.executeRemotely(controlHost, command)

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/commands/InitTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/commands/InitTest.kt
@@ -288,6 +288,32 @@ class InitTest : BaseKoinTest() {
     }
 
     @Nested
+    inner class CniSelection {
+        @Test
+        fun `defaults the persisted CNI to Flannel`() {
+            val command = Init()
+            command.clean = true
+            command.execute()
+
+            verify(mockClusterStateManager).save(
+                argThat { initConfig?.cni == CniMode.Flannel },
+            )
+        }
+
+        @Test
+        fun `persists Cilium when --cni cilium is selected`() {
+            val command = Init()
+            command.clean = true
+            command.cni = CniMode.Cilium
+            command.execute()
+
+            verify(mockClusterStateManager).save(
+                argThat { initConfig?.cni == CniMode.Cilium },
+            )
+        }
+    }
+
+    @Nested
     inner class ExistingVpc {
         @Test
         fun `execute sets existing VPC ID when provided`() {

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/commands/UpTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/commands/UpTest.kt
@@ -233,7 +233,7 @@ class UpTest : BaseKoinTest() {
             .thenReturn(Result.success(Unit))
 
         whenever(mockK3sClusterService.setupCluster(any())).thenReturn(K3sSetupResult(serverStarted = true))
-        whenever(mockCiliumService.install(any())).thenReturn(Result.success(Unit))
+        whenever(mockCiliumService.install(any(), any())).thenReturn(Result.success(Unit))
 
         whenever(mockK8sService.labelNode(any(), any(), any())).thenReturn(Result.success(Unit))
         whenever(mockK8sService.ensureLocalStorageClass(any())).thenReturn(Result.success(Unit))
@@ -265,6 +265,8 @@ class UpTest : BaseKoinTest() {
         controlInstances: Int = 1,
         cassandraInstances: Int = 1,
         stressInstances: Int = 1,
+        cni: CniMode = CniMode.Flannel,
+        cidr: String? = "10.0.0.0/16",
     ): ClusterState =
         ClusterState(
             name = "test-cluster",
@@ -275,8 +277,9 @@ class UpTest : BaseKoinTest() {
                     cassandraInstances = cassandraInstances,
                     stressInstances = stressInstances,
                     controlInstances = controlInstances,
-                    cidr = "10.0.0.0/16",
+                    cidr = cidr,
                     name = "test-cluster",
+                    cni = cni,
                 ),
         )
 
@@ -308,43 +311,6 @@ class UpTest : BaseKoinTest() {
         verify(mockK8sService).labelNode(eq(testControlHost), eq("app0"), any())
         verify(mockK8sService).ensureLocalStorageClass(eq(testControlHost))
         verify(mockK8sService).ensureLocalStorageWfcClass(eq(testControlHost))
-    }
-
-    // =========================================================================
-    // Group: CNI selection (`--cni`, replacing the old `--cilium` boolean)
-    // =========================================================================
-
-    @Test
-    fun `up starts K3s with Flannel by default and never installs Cilium`() {
-        assertThatCode { newUp().execute() }.doesNotThrowAnyException()
-
-        val configCaptor = argumentCaptor<K3sClusterConfig>()
-        verify(mockK3sClusterService).setupCluster(configCaptor.capture())
-        assertThat(configCaptor.firstValue.useCustomCni).isFalse()
-        assertThat(configCaptor.firstValue.onServerReady == null).isTrue()
-
-        verify(mockCiliumService, never()).install(any())
-    }
-
-    @Test
-    fun `up starts K3s with a custom CNI and installs Cilium via onServerReady when cni is Cilium`() {
-        val ciliumState = happyState()
-        whenever(mockClusterStateManager.load()).thenReturn(
-            ciliumState.copy(initConfig = ciliumState.initConfig?.copy(cni = CniMode.Cilium)),
-        )
-
-        assertThatCode { newUp().execute() }.doesNotThrowAnyException()
-
-        val configCaptor = argumentCaptor<K3sClusterConfig>()
-        verify(mockK3sClusterService).setupCluster(configCaptor.capture())
-        val config = configCaptor.firstValue
-        assertThat(config.useCustomCni).isTrue()
-
-        val onServerReady = config.onServerReady
-        assertThat(onServerReady == null).isFalse()
-        onServerReady?.invoke()
-
-        verify(mockCiliumService).install(testControlHost.toHost())
     }
 
     // =========================================================================
@@ -632,6 +598,82 @@ class UpTest : BaseKoinTest() {
             .hasMessageContaining("connection refused")
 
         verify(mockK3sClusterService, never()).setupCluster(any())
+    }
+
+    // =========================================================================
+    // Group 7: Cilium CNI installation on the server-ready hook
+    // =========================================================================
+
+    /**
+     * Stubs [K3sClusterService.setupCluster] to invoke the config's `onServerReady` hook, as the
+     * real implementation does once the K3s server is up. Without this, the mock would swallow the
+     * callback and the Cilium install side effect would never fire — masking the branch under test.
+     */
+    private fun setupClusterInvokingServerReadyHook() {
+        whenever(mockK3sClusterService.setupCluster(any())).thenAnswer { invocation ->
+            val config = invocation.arguments[0] as K3sClusterConfig
+            config.onServerReady?.invoke()
+            K3sSetupResult(serverStarted = true)
+        }
+    }
+
+    @Test
+    fun `up installs Cilium with the control host and resolved VPC CIDR when cni is Cilium`() {
+        whenever(mockClusterStateManager.load()).thenReturn(happyState(cni = CniMode.Cilium))
+        whenever(mockCiliumService.install(any(), any())).thenReturn(Result.success(Unit))
+        setupClusterInvokingServerReadyHook()
+
+        assertThatCode { newUp().execute() }.doesNotThrowAnyException()
+
+        val hostCaptor = argumentCaptor<Host>()
+        val cidrCaptor = argumentCaptor<String>()
+        verify(mockCiliumService).install(hostCaptor.capture(), cidrCaptor.capture())
+        assertThat(hostCaptor.firstValue.alias).isEqualTo("control0")
+        assertThat(hostCaptor.firstValue.private).isEqualTo("10.0.0.1")
+        assertThat(cidrCaptor.firstValue).isEqualTo("10.0.0.0/16")
+    }
+
+    @Test
+    fun `up wires the K3s cluster for a custom CNI only when cni is Cilium`() {
+        whenever(mockClusterStateManager.load()).thenReturn(happyState(cni = CniMode.Cilium))
+        whenever(mockCiliumService.install(any(), any())).thenReturn(Result.success(Unit))
+        setupClusterInvokingServerReadyHook()
+
+        newUp().execute()
+
+        val configCaptor = argumentCaptor<K3sClusterConfig>()
+        verify(mockK3sClusterService).setupCluster(configCaptor.capture())
+        assertThat(configCaptor.firstValue.useCustomCni).isTrue()
+        assertThat(configCaptor.firstValue.onServerReady != null).isTrue()
+    }
+
+    @Test
+    fun `up never installs Cilium and uses the default CNI when cni is Flannel`() {
+        // happyState defaults to Flannel.
+        assertThatCode { newUp().execute() }.doesNotThrowAnyException()
+
+        verify(mockCiliumService, never()).install(any(), any())
+        val configCaptor = argumentCaptor<K3sClusterConfig>()
+        verify(mockK3sClusterService).setupCluster(configCaptor.capture())
+        assertThat(configCaptor.firstValue.useCustomCni).isFalse()
+        assertThat(configCaptor.firstValue.onServerReady == null).isTrue()
+    }
+
+    @Test
+    fun `up auto-resolves an unset VPC CIDR and installs Cilium with the selected block`() {
+        // When init left the CIDR unset, `up` auto-selects one before installing Cilium — so the
+        // install must receive that resolved block, never a null. This is why installCilium's
+        // requireNotNull guard cannot fire through a full run: the CIDR is always resolved first.
+        whenever(mockClusterStateManager.load()).thenReturn(happyState(cni = CniMode.Cilium, cidr = null))
+        whenever(mockVpcService.listAllVpcCidrs()).thenReturn(emptyList())
+        whenever(mockCiliumService.install(any(), any())).thenReturn(Result.success(Unit))
+        setupClusterInvokingServerReadyHook()
+
+        newUp().execute()
+
+        val cidrCaptor = argumentCaptor<String>()
+        verify(mockCiliumService).install(any(), cidrCaptor.capture())
+        assertThat(cidrCaptor.firstValue).isNotBlank()
     }
 
     /**

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/commands/converters/PicoCniModeConverterTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/commands/converters/PicoCniModeConverterTest.kt
@@ -11,14 +11,12 @@ class PicoCniModeConverterTest {
 
     @Test
     fun `converts cilium to CniMode Cilium`() {
-        val result = converter.convert("cilium")
-        assertThat(result).isEqualTo(CniMode.Cilium)
+        assertThat(converter.convert("cilium")).isEqualTo(CniMode.Cilium)
     }
 
     @Test
     fun `converts flannel to CniMode Flannel`() {
-        val result = converter.convert("flannel")
-        assertThat(result).isEqualTo(CniMode.Flannel)
+        assertThat(converter.convert("flannel")).isEqualTo(CniMode.Flannel)
     }
 
     @Test
@@ -40,10 +38,10 @@ class PicoCniModeConverterTest {
     }
 
     @Test
-    fun `throws TypeConversionException for invalid CNI`() {
-        assertThatThrownBy { converter.convert("calico") }
+    fun `throws TypeConversionException for invalid cni`() {
+        assertThatThrownBy { converter.convert("foo") }
             .isInstanceOf(TypeConversionException::class.java)
-            .hasMessageContaining("Invalid CNI: calico")
+            .hasMessageContaining("Invalid CNI: foo")
             .hasMessageContaining("cilium or flannel")
     }
 
@@ -52,6 +50,7 @@ class PicoCniModeConverterTest {
         assertThatThrownBy { converter.convert("") }
             .isInstanceOf(TypeConversionException::class.java)
             .hasMessageContaining("Invalid CNI")
+            .hasMessageContaining("cilium or flannel")
     }
 
     @Test
@@ -59,5 +58,6 @@ class PicoCniModeConverterTest {
         assertThatThrownBy { converter.convert("   ") }
             .isInstanceOf(TypeConversionException::class.java)
             .hasMessageContaining("Invalid CNI")
+            .hasMessageContaining("cilium or flannel")
     }
 }

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/services/CiliumServiceTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/services/CiliumServiceTest.kt
@@ -67,9 +67,11 @@ class CiliumServiceTest : BaseKoinTest() {
             eventBus = getKoin().get(),
         )
 
+    private val vpcCidr = "10.0.0.0/16"
+
     @Test
-    fun `install calls executeRemotely with cilium install command`() {
-        makeService().install(controlHost)
+    fun `install issues cilium install with ENI native-routing flags and no VXLAN tunnel`() {
+        makeService().install(controlHost, vpcCidr)
 
         val commandCaptor = argumentCaptor<String>()
         verify(mockRemoteOps).executeRemotely(eq(controlHost), commandCaptor.capture(), any(), any())
@@ -79,17 +81,49 @@ class CiliumServiceTest : BaseKoinTest() {
         assertThat(command).contains("--version 1.19.4")
         assertThat(command).contains("k8sServiceHost=${controlHost.private}")
         assertThat(command).contains("k8sServicePort=6443")
-        assertThat(command).contains("tunnelProtocol=vxlan")
-        assertThat(command).contains("routingMode=tunnel")
+        assertThat(command).contains("ipam.mode=eni")
+        assertThat(command).contains("eni.enabled=true")
+        assertThat(command).contains("routingMode=native")
+        assertThat(command).contains("endpointRoutes.enabled=true")
+        assertThat(command).contains("enableIPv4Masquerade=true")
+        assertThat(command).contains("egressMasqueradeInterfaces=ens+")
+        assertThat(command).contains("kubeProxyReplacement=false")
+        assertThat(command).contains("bpf.hostLegacyRouting=true")
+        assertThat(command).contains("ipv4NativeRoutingCIDR=$vpcCidr")
         assertThat(command).contains("operator.replicas=1")
         assertThat(command).contains("hubble.relay.enabled=true")
         assertThat(command).contains("hubble.ui.enabled=true")
-        assertThat(command).contains("hubble.metrics.enabled=")
+        assertThat(command).doesNotContain("bpf.masquerade")
+        assertThat(command).doesNotContain("tunnelProtocol=vxlan")
+        assertThat(command).doesNotContain("routingMode=tunnel")
+    }
+
+    @Test
+    fun `install single-quotes the Hubble metrics list so the remote shell does not brace-expand it`() {
+        makeService().install(controlHost, vpcCidr)
+
+        val commandCaptor = argumentCaptor<String>()
+        verify(mockRemoteOps).executeRemotely(eq(controlHost), commandCaptor.capture(), any(), any())
+
+        val command = commandCaptor.firstValue
+        assertThat(command).contains("hubble.metrics.enabled='{dns,drop,tcp,flow,port-distribution,icmp,http}'")
+    }
+
+    @Test
+    fun `install threads the provided VPC CIDR verbatim into the native-routing flag`() {
+        val distinctCidr = "172.31.0.0/16"
+
+        makeService().install(controlHost, distinctCidr)
+
+        val commandCaptor = argumentCaptor<String>()
+        verify(mockRemoteOps).executeRemotely(eq(controlHost), commandCaptor.capture(), any(), any())
+
+        assertThat(commandCaptor.firstValue).contains("ipv4NativeRoutingCIDR=$distinctCidr")
     }
 
     @Test
     fun `install emits Installing, InstallingChart, and Installed events on success`() {
-        makeService().install(controlHost)
+        makeService().install(controlHost, vpcCidr)
 
         assertThat(emittedEvents).contains(Event.Cilium.Installing)
         assertThat(emittedEvents).contains(Event.Cilium.InstallingChart)
@@ -101,7 +135,7 @@ class CiliumServiceTest : BaseKoinTest() {
         whenever(mockRemoteOps.executeRemotely(any(), any(), any(), any()))
             .doThrow(RuntimeException("cilium install failed"))
 
-        val result = makeService().install(controlHost)
+        val result = makeService().install(controlHost, vpcCidr)
 
         assertThat(result.isFailure).isTrue()
         val failedEvents = emittedEvents.filterIsInstance<Event.Cilium.InstallFailed>()


### PR DESCRIPTION
Closes #805

Draft — implementation in progress. The unit tier runs locally; the full suite runs in CI on each push.

Lands Cilium ENI IPAM native routing as an **opt-in** datapath, selected via `--cni=<cilium|flannel>` (default `flannel`). Default-to-Cilium flip is tracked in #819.

**Scope update (post-rebase onto #858):** the base-AMI packer script (`configure_cilium_eni_networkd.sh` + `base.pkr.hcl`/`docker-compose.yml`/`README.md` wiring), the IMDS hop-limit-2 fix applied to all node types (`EC2InstanceService.kt`), and the `--cni=<cilium|flannel>` enum flag itself (`CniMode` in `ClusterState.kt`, `PicoCniModeConverter`, `Init.kt`/`Up.kt` wiring) landed separately via #858 and are no longer part of this diff.

What remains here is just the actual, still-unvalidated Cilium install logic:
- `CiliumService.install()`'s ENI native-routing flag set (`ipam.mode=eni`, `routingMode=native`, `ipv4NativeRoutingCIDR`, `kubeProxyReplacement=false` pinning, iptables masquerade, the Hubble metrics brace-quoting fix)
- the two-argument `install(controlHost, vpcCidr)` signature
- `Up.installCilium()`'s VPC-CIDR threading into that call
- `CiliumServiceTest.kt` and the `Up`/`Init` test coverage for the above
- the `openspec/changes/cilium-native-routing/` design docs

Live cross-AZ validation (design doc task 6.2) is still outstanding — that's the risk this PR hasn't yet proven out.