### PR TITLE
ci: standardize nightly Cassandra 6.0 artifact to 6.0-HEAD

### DIFF
--- a/.github/workflows/build-cassandra-set.yml
+++ b/.github/workflows/build-cassandra-set.yml
@@ -38,13 +38,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Quote every version: an unquoted 6.0 is a YAML float that GitHub
+          # Quote every version. The `-HEAD` labels are plain strings, but a bare
+          # numeric version (e.g. an unquoted 6.0) is a YAML float that GitHub
           # Actions stringifies to "6", producing apache-cassandra-6-bin.tar.gz
-          # instead of the apache-cassandra-6.0-bin.tar.gz the versions file needs.
+          # instead of the apache-cassandra-6.0-HEAD-bin.tar.gz the versions file
+          # references — so keep every version quoted regardless.
           - ref: cassandra-5.0
             version: "5.0-HEAD"
           - ref: cassandra-6.0
-            version: "6.0"
+            version: "6.0-HEAD"
           - ref: trunk
             version: "trunk"
     uses: ./.github/workflows/build-cassandra-ref.yml
@@ -123,7 +125,7 @@ jobs:
             are published under the moving `:cassandra-<ref>` tag.
 
             - **5.0-HEAD**: Latest from `cassandra-5.0` branch
-            - **6.0**: Latest from `cassandra-6.0` branch
+            - **6.0-HEAD**: Latest from `cassandra-6.0` branch
             - **trunk**: Latest from `trunk` branch
 
             ### Stable Download URLs
@@ -132,7 +134,7 @@ jobs:
 
             ```
             https://github.com/${{ github.repository }}/releases/download/nightly/apache-cassandra-5.0-HEAD-bin.tar.gz
-            https://github.com/${{ github.repository }}/releases/download/nightly/apache-cassandra-6.0-bin.tar.gz
+            https://github.com/${{ github.repository }}/releases/download/nightly/apache-cassandra-6.0-HEAD-bin.tar.gz
             https://github.com/${{ github.repository }}/releases/download/nightly/apache-cassandra-trunk-bin.tar.gz
             ```
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -196,7 +196,7 @@ easy-db-lab cassandra use <version> [options]
 | `--java` | Java version to use |
 | `--hosts` | Filter to specific hosts |
 
-Versions: 3.0, 3.11, 4.0, 4.1, 5.0, 5.0-HEAD, trunk
+Versions: 3.0, 3.11, 4.0, 4.1, 5.0, 5.0-HEAD, 6.0-HEAD, trunk
 
 ### cassandra write-config
 

--- a/docs/user-guide/installing-cassandra.md
+++ b/docs/user-guide/installing-cassandra.md
@@ -14,6 +14,7 @@ easy-db-lab supports the following Cassandra versions:
 | 4.1 | 11 | Current LTS |
 | 5.0 | 11 | **Latest stable (recommended)** |
 | 5.0-HEAD | 11 | Nightly build from 5.0 branch |
+| 6.0-HEAD | 21 | Nightly build from 6.0 branch |
 | trunk | 17 | Development branch |
 
 ## Quick Start

--- a/docs/user-guide/tutorial.md
+++ b/docs/user-guide/tutorial.md
@@ -161,7 +161,7 @@ This command:
 - Downloads configuration files to your local directory
 - Applies any existing patch configuration
 
-Available versions: 3.0, 3.11, 4.0, 4.1, 5.0, 5.0-HEAD, trunk
+Available versions: 3.0, 3.11, 4.0, 4.1, 5.0, 5.0-HEAD, 6.0-HEAD, trunk
 
 ### Step 2: Customize Configuration (Optional)
 

--- a/packer/cassandra/cassandra_versions.yaml
+++ b/packer/cassandra/cassandra_versions.yaml
@@ -29,8 +29,8 @@
   java: "11"
   python: "3.11.9"
 
-- version: "6.0"
-  url: https://github.com/rustyrazorblade/easy-db-lab/releases/download/nightly/apache-cassandra-6.0-bin.tar.gz
+- version: "6.0-HEAD"
+  url: https://github.com/rustyrazorblade/easy-db-lab/releases/download/nightly/apache-cassandra-6.0-HEAD-bin.tar.gz
   java: "21"
   python: "3.11.9"
 

--- a/packer/cassandra/cassandra_versions.yaml
+++ b/packer/cassandra/cassandra_versions.yaml
@@ -1,4 +1,3 @@
----
 # the version uniquely identifes the cassandra version
 # and will be used as the name in /usr/local/cassandra-<version>
 


### PR DESCRIPTION
Closes #821

Standardizes the nightly Cassandra **6.0** artifact naming to **6.0-HEAD**, matching the existing `5.0-HEAD` convention, and makes it selectable via the versions file.

## Changes
- **`.github/workflows/build-cassandra-set.yml`** — matrix `version: "6.0"` → `"6.0-HEAD"` (ref stays `cassandra-6.0`); release description and stable URL updated to `apache-cassandra-6.0-HEAD-bin.tar.gz`; reconciled the quote-every-version comment.
- **`packer/cassandra/cassandra_versions.yaml`** (authoritative source) — the existing `6.0` nightly entry (java 21) renamed **in place** to `6.0-HEAD` with the updated URL. Kept `python: "3.11.9"` and unquoted URL to match file style.
- **docs** (`installing-cassandra.md`, `tutorial.md`, `commands.md`) — added `6.0-HEAD` to the version lists to keep docs in sync.

## Notes
- **JDK selection is unaffected.** `resolve-build-plan.sh` keys JDK on the source tree's `build.xml` `base.version` (read at build time), not the matrix `stable_version` — which only names the artifact. `6.0-HEAD` still builds on JDK 21, identical to how `5.0-HEAD` works today. Resolver unit tests (22) pass; `CassandraVersionTest` passes on JDK 21.
- Nothing references the old `apache-cassandra-6.0-bin.tar.gz` anywhere anymore. `5.0-HEAD` and `trunk` untouched (trunk standardization intentionally out of scope).
- Correction vs the issue text: the authoritative versions file already had a `6.0` nightly entry (the 'missing entry' I first reported was read from a stale generated copy in the repo root), so this is a rename, not an addition.

Lightweight direct change — no OpenSpec. Unit/resolver checks ran locally; CI runs the full suite.