### PR TITLE
ci: tag nightly Cassandra images with the stable version label

### DIFF
--- a/.github/workflows/build-cassandra-ref.yml
+++ b/.github/workflows/build-cassandra-ref.yml
@@ -262,6 +262,9 @@ jobs:
           IMAGE_REPO: ${{ needs.resolve.outputs.image_repo }}
           SHA_TAG: ${{ needs.resolve.outputs.sha_tag }}
           REF_TAG: ${{ needs.resolve.outputs.ref_tag }}
+          # Stable version label (e.g. 5.0-HEAD, 6.0-HEAD, trunk) from a matrix
+          # caller. Blank for direct/fork callers that don't pass stable_version.
+          STABLE_VERSION: ${{ inputs.stable_version }}
           BASE_IMAGE: ${{ needs.resolve.outputs.base_image }}
           TARBALL_NAME: ${{ needs.resolve.outputs.tarball_name }}
           # OCI provenance inputs (issue #767) — stamp the image so `docker
@@ -274,6 +277,18 @@ jobs:
           set -euo pipefail
           # RFC-3339 UTC build timestamp for org.opencontainers.image.created.
           created="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+          # Always tag the immutable :sha-<short> and moving :<ref> tags. When a
+          # matrix caller supplies a stable_version, ADD a third stable tag
+          # (:5.0-HEAD / :6.0-HEAD / :trunk) so there is a stable pull URL that
+          # matches the tarball naming. Sanitize it with the SAME transform as
+          # ref_tag (tag-invalid chars -> '-', cap 128) for defensiveness; the
+          # 5.0-HEAD/6.0-HEAD/trunk values pass through unchanged. Guarded on
+          # non-empty so direct/fork callers are completely unaffected.
+          tag_args=(--tag "${IMAGE_REPO}:${SHA_TAG}" --tag "${IMAGE_REPO}:${REF_TAG}")
+          if [[ -n "$STABLE_VERSION" ]]; then
+            version_tag="$(echo "$STABLE_VERSION" | sed 's/[^a-zA-Z0-9._-]/-/g' | cut -c1-128)"
+            tag_args+=(--tag "${IMAGE_REPO}:${version_tag}")
+          fi
           docker build \
             --build-arg BASE_IMAGE="$BASE_IMAGE" \
             --build-arg TARBALL="$TARBALL_NAME" \
@@ -282,8 +297,7 @@ jobs:
             --build-arg OCI_VERSION="$OCI_VERSION" \
             --build-arg OCI_CREATED="$created" \
             --build-arg OCI_REF_NAME="$OCI_REF_NAME" \
-            --tag "${IMAGE_REPO}:${SHA_TAG}" \
-            --tag "${IMAGE_REPO}:${REF_TAG}" \
+            "${tag_args[@]}" \
             .github/cassandra-image
 
       # Gate the publish on a real smoke test against the locally-built image.
@@ -383,10 +397,18 @@ jobs:
           IMAGE_REPO: ${{ needs.resolve.outputs.image_repo }}
           SHA_TAG: ${{ needs.resolve.outputs.sha_tag }}
           REF_TAG: ${{ needs.resolve.outputs.ref_tag }}
+          STABLE_VERSION: ${{ inputs.stable_version }}
         run: |
           set -euo pipefail
           docker push "${IMAGE_REPO}:${SHA_TAG}"
           docker push "${IMAGE_REPO}:${REF_TAG}"
+          # Also push the stable version tag when a matrix caller supplied one.
+          # Same sanitization as the build step; guarded so direct/fork callers
+          # (empty STABLE_VERSION) push only :sha and :ref.
+          if [[ -n "$STABLE_VERSION" ]]; then
+            version_tag="$(echo "$STABLE_VERSION" | sed 's/[^a-zA-Z0-9._-]/-/g' | cut -c1-128)"
+            docker push "${IMAGE_REPO}:${version_tag}"
+          fi
 
       # Create the release only after the smoke test passed and the image pushed.
       - name: Create per-build release with tarball
@@ -415,6 +437,7 @@ jobs:
           IMAGE_REPO: ${{ needs.resolve.outputs.image_repo }}
           SHA_TAG: ${{ needs.resolve.outputs.sha_tag }}
           REF_TAG: ${{ needs.resolve.outputs.ref_tag }}
+          STABLE_VERSION: ${{ inputs.stable_version }}
           VERSION: ${{ needs.resolve.outputs.version }}
           SHA: ${{ needs.resolve.outputs.sha }}
           RELEASE_TAG: ${{ needs.resolve.outputs.release_tag }}
@@ -431,6 +454,11 @@ jobs:
             echo "| Commit | \`${SHA}\` |"
             echo "| Image (immutable) | \`${IMAGE_REPO}:${SHA_TAG}\` |"
             echo "| Image (ref) | \`${IMAGE_REPO}:${REF_TAG}\` |"
+            # Only present when a matrix caller supplied a stable_version.
+            if [[ -n "$STABLE_VERSION" ]]; then
+              version_tag="$(echo "$STABLE_VERSION" | sed 's/[^a-zA-Z0-9._-]/-/g' | cut -c1-128)"
+              echo "| Image (version) | \`${IMAGE_REPO}:${version_tag}\` |"
+            fi
             echo "| Tarball | ${tarball_url} |"
             echo ""
             echo "Pull: \`docker pull ${IMAGE_REPO}:${SHA_TAG}\`"

--- a/docs/development/building-cassandra-refs.md
+++ b/docs/development/building-cassandra-refs.md
@@ -73,8 +73,12 @@ Authentication to GHCR uses the repository's `GITHUB_TOKEN`
 ## Where the artifacts land
 
 - **Image**: `ghcr.io/<owner>/<repo>/cassandra`, tagged with both an immutable
-  `sha-<short>` tag and a moving sanitized-ref tag. The `latest` tag is reserved
-  for the main CLI image and is **never** produced here.
+  `sha-<short>` tag and a moving sanitized-ref tag. When the build is driven by
+  the nightly matrix (`build-cassandra-set.yml`), each image also gets a stable
+  version-label tag (`5.0-HEAD`, `6.0-HEAD`, `trunk`) that matches the tarball
+  naming, giving a stable pull URL that always points at the latest build for
+  that line. The `latest` tag is reserved for the main CLI image and is
+  **never** produced here.
 - **Tarball**: `apache-cassandra-<version>-<short-sha>-bin.tar.gz`, attached to a
   GitHub release tagged `cassandra-<version>-<short-sha>`.
 


### PR DESCRIPTION
Closes #824

Adds the stable version label (`5.0-HEAD` / `6.0-HEAD` / `trunk`) as a **third image tag** on nightly Cassandra builds, alongside the existing immutable `:sha-<short>` and moving `:<ref>` tags — so there are stable, consistently-named pull URLs matching the tarball convention:
```
ghcr.io/rustyrazorblade/easy-db-lab/cassandra:5.0-HEAD
ghcr.io/rustyrazorblade/easy-db-lab/cassandra:6.0-HEAD
ghcr.io/rustyrazorblade/easy-db-lab/cassandra:trunk
```

## Change (build-cassandra-ref.yml)
- Thread `stable_version` into the build + push steps as `STABLE_VERSION`.
- Build via a `tag_args` array; when `STABLE_VERSION` is non-empty, append `--tag ${IMAGE_REPO}:${version_tag}` (sanitized with the same `sed`/`cut` transform as `ref_tag`).
- Push the version tag under the same non-empty guard.
- Add an "Image (version)" row to the run summary when present.

## Safety
- Purely **additive** — `:sha-<short>` and `:<ref>` tags are unchanged.
- **Guarded on non-empty** `stable_version`, so direct/fork callers (no `stable_version`) push only `:sha` and `:ref` — no empty `:` tag, no behavior change (relevant to #765).

Direct change — no OpenSpec. Docker-side twin of #821/#822.