### PR TITLE
fix(tidb kit): update helm repo to charts.pingcap.com (#826)

### DIFF
--- a/src/main/resources/com/rustyrazorblade/easydblab/kits/tidb/kit.yaml
+++ b/src/main/resources/com/rustyrazorblade/easydblab/kits/tidb/kit.yaml
@@ -51,7 +51,7 @@ args:
 install:
   - type: helm-repo
     name: pingcap
-    url: https://charts.pingcap.org
+    url: https://charts.pingcap.com/
   - type: manifest-url
     url: https://raw.githubusercontent.com/pingcap/tidb-operator/v1.6.5/manifests/crd.yaml
   - type: namespace


### PR DESCRIPTION
Closes #826

PingCAP's old chart repo `charts.pingcap.org` is dead (NXDOMAIN); the repository moved to `charts.pingcap.com`. One-line fix — `tidb-operator` v1.6.5 and the CRD URL are unchanged.

Verified live on a fresh cluster (AMI built from current `main`): `kit install tidb` → `tidb start` (operator installs from charts.pingcap.com, TiDBCluster CR applied, all pods Ready) → `tidb sql "SELECT 1"` returns `1`.