### PR TITLE
fix(ignite3 kit): harden cluster-init against slow-pull/readiness race (#830)

### DIFF
--- a/src/main/resources/com/rustyrazorblade/easydblab/kits/ignite3/cluster-init-job.yaml.template
+++ b/src/main/resources/com/rustyrazorblade/easydblab/kits/ignite3/cluster-init-job.yaml.template
@@ -4,8 +4,12 @@ metadata:
   name: cluster-init
   namespace: default
 spec:
-  backoffLimit: 0
-  activeDeadlineSeconds: 120
+  # backoffLimit + activeDeadlineSeconds are the outer safety net; the container's
+  # own retry loop is the primary mechanism. If the whole Pod dies mid-init (node
+  # eviction, OOM), the Job restarts it — and `cluster init` is idempotent (a re-run
+  # against an already-initialized cluster still exits 0), so retries are safe.
+  backoffLimit: 5
+  activeDeadlineSeconds: 600
   template:
     spec:
       restartPolicy: Never
@@ -17,8 +21,29 @@ spec:
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
-            - -ec
+            - -c
             - |
-              /opt/ignite3cli/bin/ignite3 cluster init \
-                --name=ignite \
-                --url=http://ignite-svc-headless:10300
+              # Self-retrying, idempotent cluster init. `cluster init` fails while REST
+              # (:10300) is not yet bound or peers have not finished discovery on :3344;
+              # once both are ready it succeeds (exit 0). It is idempotent: a re-run
+              # against an already-initialized cluster also exits 0. As a belt-and-braces
+              # fallback we also treat a live `cluster status` reporting "status: active"
+              # as success — note the exact substring "status: active", because the
+              # pre-init status line is "status: not initialized" (matching a bare
+              # "initialized" would false-positive).
+              URL=http://ignite-svc-headless:10300
+              for i in $(seq 1 60); do
+                if /opt/ignite3cli/bin/ignite3 cluster init --name=ignite --url="${URL}"; then
+                  echo "cluster init succeeded"
+                  exit 0
+                fi
+                if /opt/ignite3cli/bin/ignite3 cluster status --url="${URL}" 2>/dev/null \
+                     | grep -qi 'status: active'; then
+                  echo "cluster already initialized"
+                  exit 0
+                fi
+                echo "cluster init attempt ${i}/60 failed (REST not ready or peers not yet discovered); retrying in 5s..."
+                sleep 5
+              done
+              echo "ERROR: cluster init did not succeed after retries" >&2
+              exit 1

--- a/src/main/resources/com/rustyrazorblade/easydblab/kits/ignite3/kit.yaml
+++ b/src/main/resources/com/rustyrazorblade/easydblab/kits/ignite3/kit.yaml
@@ -78,13 +78,13 @@ start:
     script: |
       #!/usr/bin/env bash
       set -euo pipefail
+      # Wait only for the pods to be CREATED, not Ready. Readiness now means the
+      # SQL port (10800) is open, which does not happen until AFTER `cluster init`.
+      # Gating init on Ready would deadlock. The headless service publishes
+      # not-Ready addresses, so the init Job can reach :10300 on not-Ready pods.
       echo "Waiting for Ignite 3 pods to be created..."
       until kubectl get pods -l app=ignite -n default --no-headers 2>/dev/null | grep -q .; do sleep 5; done
-      echo "Pods found, waiting for Ready..."
-      kubectl wait --for=condition=Ready pods \
-        -l app=ignite \
-        --namespace default \
-        --timeout=300s
+      echo "Pods found."
 
   - type: manifest
     template: cluster-init-job.yaml
@@ -94,7 +94,23 @@ start:
     name: cluster-init
     condition: Complete
     namespace: default
-    timeout: 120s
+    # The init Job self-retries internally (~300s of attempts) and the outer Job
+    # retries the Pod up to backoffLimit times, so give the wait a generous ceiling.
+    timeout: 600s
+
+  - type: shell
+    script: |
+      #!/usr/bin/env bash
+      set -euo pipefail
+      # Now that cluster init has completed, readiness is meaningful: a Ready pod
+      # has its SQL port (10800) open and can serve queries. Gate nodeport/OTLP
+      # setup on real SQL-readiness so downstream steps hit live nodes.
+      echo "Waiting for Ignite 3 pods to become Ready (SQL port open)..."
+      kubectl wait --for=condition=Ready pods \
+        -l app=ignite \
+        --namespace default \
+        --timeout=300s
+      echo "Pods Ready."
 
   - type: manifest
     template: nodeport-service.yaml

--- a/src/main/resources/com/rustyrazorblade/easydblab/kits/ignite3/statefulset.yaml.template
+++ b/src/main/resources/com/rustyrazorblade/easydblab/kits/ignite3/statefulset.yaml.template
@@ -38,17 +38,37 @@ spec:
               containerPort: 10800
             - name: discovery
               containerPort: 3344
-          # Readiness probes the REST port (10300), which opens as soon as the node
-          # process starts — BEFORE cluster init. The client/SQL connector (10800) does
-          # NOT open until `cluster init` runs, and init is gated behind pods being Ready,
-          # so probing 10800 here would deadlock. 10300 lets pods go Ready pre-init; the
-          # cluster-init Job (and its wait-for-Complete) is the real "cluster ready" gate.
-          readinessProbe:
+          # Probe design (init is decoupled from readiness):
+          #   startup/liveness -> REST (10300): the process/REST endpoint is up.
+          #   readiness        -> SQL  (10800): the node can serve SQL, which only
+          #                       opens AFTER `cluster init`.
+          # The runtime image (apacheignite/ignite:__IGNITE_VERSION__) is NOT baked into
+          # the AMI, so a cold node may pull the image and boot the JVM slowly. The image
+          # pull happens before the container starts and is not counted against any probe;
+          # the startupProbe then gives REST up to ~600s (60 x 10s) to bind before
+          # liveness/readiness begin. livenessProbe restarts a node whose REST wedges after
+          # startup. readinessProbe on 10800 means pods stay NotReady until cluster init
+          # completes — which is fine now: init runs against not-Ready pods (headless svc
+          # publishes not-Ready addresses), and the post-init Ready gate in kit.yaml is the
+          # real "cluster can serve SQL" barrier.
+          startupProbe:
             tcpSocket:
               port: 10300
-            initialDelaySeconds: 15
+            periodSeconds: 10
+            failureThreshold: 60
+            timeoutSeconds: 2
+          livenessProbe:
+            tcpSocket:
+              port: 10300
             periodSeconds: 10
             failureThreshold: 6
+            timeoutSeconds: 2
+          readinessProbe:
+            tcpSocket:
+              port: 10800
+            periodSeconds: 10
+            failureThreshold: 6
+            timeoutSeconds: 2
           volumeMounts:
             - name: config-vol
               mountPath: /opt/ignite/etc/ignite-config.conf


### PR DESCRIPTION
Closes #830

The ignite3 install could wedge at pods `0/1` forever: the `cluster-init` Job was gated behind a bare TCP-10300 readiness probe with no startup/liveness probe, and the image is pulled at runtime. A slow pull or a wedged REST bind → 300s Ready-wait times out / no self-heal → init never runs → SQL never opens. Reproduced during #805 CNI validation; didn't reproduce on a warm-cached AMI — an image-pull/readiness race.

**Hardening (3 kit files, config only — no Kotlin):**
- `cluster-init-job.yaml.template` — self-retrying, idempotent init loop against REST; treats `status: active` as success (exact substring — `status: not initialized` would false-positive on a bare `initialized` match); `cluster init` is itself idempotent. `backoffLimit` 0→5, `activeDeadlineSeconds` 120→600.
- `kit.yaml` — remove the pre-init `kubectl wait Ready` gate; keep the pod-created wait; bump the Job-Complete wait to 600s; add a **post-init** Ready gate (now meaningful) before nodeport/OTLP.
- `statefulset.yaml.template` — readiness→10800 (SQL-ready); add startupProbe (10300, ~600s budget) + livenessProbe (10300, restarts a wedged node).

**Live-verified** on a fresh cluster (AMI from current `main`): `ignite3 start` exit 0 in ~1m41s; the retry loop demonstrably caught the race (`attempt 1/60 failed (REST not ready...)` → `Cluster was initialized successfully`); probes confirmed (readiness :10800, liveness/startup :10300, 0 restarts); SQL round-trip `INSERT (42,'hardened')` → `SELECT` → `42 | hardened`.