### PR TITLE
fix(tidb kit): set configUpdateStrategy: RollingUpdate so config changes roll

### DIFF
--- a/src/main/resources/com/rustyrazorblade/easydblab/kits/tidb/tidbcluster.yaml.template
+++ b/src/main/resources/com/rustyrazorblade/easydblab/kits/tidb/tidbcluster.yaml.template
@@ -9,6 +9,9 @@ spec:
   # Delete PVs when the TidbCluster is removed so clusters stay ephemeral.
   pvReclaimPolicy: Delete
   enableDynamicConfiguration: true
+  # Roll pods when spec.<component>.config changes; the default InPlace only updates
+  # the ConfigMap and never restarts TiKV, so config changes would silently not apply.
+  configUpdateStrategy: RollingUpdate
 
   pd:
     baseImage: pingcap/pd


### PR DESCRIPTION
Closes #834

The tidb kit's TidbCluster CR relied on the operator default `configUpdateStrategy: InPlace`, which updates the ConfigMap but never restarts TiKV, so `spec.tikv.config` changes silently never applied. Setting `configUpdateStrategy: RollingUpdate` at the top-level spec makes the operator roll the affected pods when config changes.