### PR TITLE
fix(sysbench kit): make stop.sh robust under set -u; clean up pods by label

### DIFF
--- a/src/main/resources/com/rustyrazorblade/easydblab/kits/sysbench/bin/stop.sh.template
+++ b/src/main/resources/com/rustyrazorblade/easydblab/kits/sysbench/bin/stop.sh.template
@@ -1,10 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-LABELS="easydblab/kit=${KIT_NAME},easydblab/role=sysbench-run"
+# stop has no args of its own, so default any prepare/start-only vars safely
+# to keep the script working under `set -u`. Defaults match the kit.yaml
+# prepare defaults so cleanup drops the standard set of sbtest tables.
+TABLES="${TABLES:-10}"
+WORKLOAD="${WORKLOAD:-oltp_read_write}"
 
-echo "Stopping sysbench run pod..."
-kubectl --kubeconfig="${KUBECONFIG}" delete pods -l "${LABELS}" --ignore-not-found
+echo "Stopping sysbench pods for kit ${KIT_NAME}..."
+kubectl --kubeconfig="${KUBECONFIG}" delete pods \
+  -l "easydblab/kit=${KIT_NAME}" --ignore-not-found
 
 if [ -n "${TARGET_MYSQL_HOST:-}" ]; then
   DB_ARGS="--db-driver=mysql \
@@ -40,5 +45,6 @@ kubectl --kubeconfig="${KUBECONFIG}" wait \
   --timeout=300s \
   pod/"${CLEANUP_POD}"
 
-kubectl --kubeconfig="${KUBECONFIG}" delete pod "${CLEANUP_POD}" --ignore-not-found
+kubectl --kubeconfig="${KUBECONFIG}" delete pods \
+  -l "${CLEANUP_LABELS}" --ignore-not-found
 echo "Sysbench stopped and data cleaned up."


### PR DESCRIPTION
Closes #835

`sysbench <target> stop` aborted under `set -u` with `TABLES: unbound variable` because `stop.sh.template` referenced `${TABLES}`/`${WORKLOAD}` — prepare/start-only args that are unset during `stop`. This defaults those run-only vars safely (matching the kit.yaml prepare defaults) and deletes leftover sysbench pods by kit label selector instead of by name.