### PR TITLE
feat(sysbench kit): persist final run summary to last-run.txt

### DIFF
--- a/docs/user-guide/sysbench.md
+++ b/docs/user-guide/sysbench.md
@@ -70,6 +70,12 @@ Runs the benchmark for `--duration` seconds, streaming sysbench's interval outpu
 your terminal. Each 10-second interval report (TPS, QPS, p99 latency, errors/s) is also
 pushed to VictoriaMetrics.
 
+When the run finishes, the final sysbench summary (SQL statistics, throughput, latency
+percentiles, and errors) is written to `last-run.txt` in the kit's workspace directory
+(e.g. `sysbench-tidb/last-run.txt`), prefixed with the run's parameters. Each run
+overwrites the file, so a completed run's numbers survive after the terminal output
+scrolls away.
+
 ### stop
 
 ```bash

--- a/src/main/resources/com/rustyrazorblade/easydblab/kits/sysbench/bin/start.sh.template
+++ b/src/main/resources/com/rustyrazorblade/easydblab/kits/sysbench/bin/start.sh.template
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+KIT_DIR="$(dirname "${SCRIPT_DIR}")"
+# Persist the final sysbench summary so a run's numbers survive after stdout scrolls away.
+LAST_RUN_FILE="${KIT_DIR}/last-run.txt"
+
 SYSBENCH_IMAGE="docker.io/severalnines/sysbench"
 POD_NAME="sysbench-${KIT_NAME}-$(date +%s)"
 LABELS="easydblab/kit=${KIT_NAME},easydblab/role=sysbench-run"
@@ -45,10 +50,33 @@ kubectl --kubeconfig="${KUBECONFIG}" wait \
   --timeout=60s \
   pod/"${POD_NAME}"
 
-# Stream logs, echo every line, and push interval stats to VictoriaMetrics.
+# Seed the persisted summary file with run metadata; the final sysbench report
+# (SQL statistics / Throughput / Latency percentiles / errors) is appended below.
+{
+  echo "sysbench run summary"
+  echo "workload:  ${WORKLOAD}"
+  echo "threads:   ${THREADS}"
+  echo "duration:  ${DURATION}s"
+  echo "rate:      ${RATE}"
+  echo "skip-trx:  ${SKIP_TRX}"
+  echo "rand-type: ${RAND_TYPE}"
+  echo "started:   $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  echo
+} > "${LAST_RUN_FILE}"
+
+# Stream logs, echo every line, push interval stats to VictoriaMetrics, and
+# persist the final summary block to LAST_RUN_FILE.
 # Interval lines match: "[ Ns ] thds: N tps: N.NN qps: N.NN ... lat (ms,99%): N.NN err/s: N.NN ..."
+# The summary block starts at "SQL statistics:" and runs to the end of the log.
+IN_SUMMARY=0
 kubectl --kubeconfig="${KUBECONFIG}" logs -f "${POD_NAME}" | while IFS= read -r line; do
   echo "$line"
+  if [[ "$line" == "SQL statistics:"* ]]; then
+    IN_SUMMARY=1
+  fi
+  if [[ "${IN_SUMMARY}" == "1" ]]; then
+    printf '%s\n' "$line" >> "${LAST_RUN_FILE}"
+  fi
   if [[ "$line" =~ ^\[\ [0-9]+s\ \] ]]; then
     read -r TPS QPS LAT ERR <<< "$(echo "$line" | awk '{
       for (i=1; i<=NF; i++) {
@@ -66,3 +94,5 @@ sysbench_lat_p99_ms{kit=\"${KIT_NAME}\"} ${LAT:-0}
 sysbench_errors_per_second{kit=\"${KIT_NAME}\"} ${ERR:-0}" 2>/dev/null || true
   fi
 done
+
+echo "Run summary written to ${LAST_RUN_FILE}"


### PR DESCRIPTION
Closes #841

## Problem
sysbench results lived only on stdout — the streamed interval output and the final summary block were never persisted, so a run's numbers were lost once the terminal scrolled away unless captured manually.

## Change
`kits/sysbench/bin/start.sh.template` now captures the final sysbench summary block (SQL statistics, throughput, latency percentiles, errors) from the streamed log and writes it to `last-run.txt` in the kit's workspace directory (e.g. `sysbench-tidb/last-run.txt`).

- The kit dir is derived from the script's own location via `BASH_SOURCE` (the same `SCRIPT_DIR` convention already used by the presto/trino kits).
- The file is seeded with a small header (workload, threads, duration, rate, skip-trx, rand-type, start timestamp) before the run, then the summary block — detected at the `SQL statistics:` line and captured to end of log — is appended inside the existing streaming loop.
- Existing behavior is untouched: every line still streams to stdout, and per-interval TPS/QPS/p99/errors are still pushed to VictoriaMetrics.
- Each run overwrites `last-run.txt` (a "last run" artifact, as the issue requests).

Docs: `docs/user-guide/sysbench.md` `start` section documents the new artifact.

## Verification
- `bash -n` passes on the template.
- Simulated a full sysbench log through the streaming loop: interval lines stream to stdout only; the summary block from `SQL statistics:` onward is persisted with the parameter header.