### PR TITLE
fix(trino kit): scope web-ui.* config to the coordinator so workers start

### DIFF
--- a/src/main/resources/com/rustyrazorblade/easydblab/kits/trino/values.yaml.template
+++ b/src/main/resources/com/rustyrazorblade/easydblab/kits/trino/values.yaml.template
@@ -1,9 +1,13 @@
 server:
   workers: __WORKERS__
-
-additionalConfigProperties:
-  - "web-ui.authentication.type=FIXED"
-  - "web-ui.user=trino"
+  # web-ui.* properties are coordinator-only (the web UI runs only on the
+  # coordinator). Placing them in the shared `additionalConfigProperties` sends
+  # them to workers too, which reject the unused properties and crash on startup
+  # (exit 100). coordinatorExtraConfig is appended only to the coordinator's
+  # config.properties, keeping the workers clean.
+  coordinatorExtraConfig: |
+    web-ui.authentication.type=FIXED
+    web-ui.user=trino
 
 image:
   tag: "__VERSION__"


### PR DESCRIPTION
Closes #827

## Root cause

`trino start` brought the coordinator up **Running** but every worker went into **CrashLoopBackOff (exit 100)** on config validation:

```
Configuration property 'web-ui.authentication.type' was not used
Configuration property 'web-ui.user' was not used
```

`values.yaml.template` set these two properties under the top-level `additionalConfigProperties`:

```yaml
additionalConfigProperties:
  - "web-ui.authentication.type=FIXED"
  - "web-ui.user=trino"
```

The `trinodb/trino` Helm chart ranges `additionalConfigProperties` into **both** the coordinator **and** worker `config.properties` (`templates/configmap-coordinator.yaml` and `templates/configmap-worker.yaml`). `web-ui.*` are **coordinator-only** properties — the web UI only runs on the coordinator — so workers received properties they never use, Trino flagged them as unused, and startup aborted.

## Fix

Scope the two properties to the coordinator only (config fix, **not** removal — the web-UI auth is preserved). Moved them from the shared `additionalConfigProperties` into **`server.coordinatorExtraConfig`**, the chart's coordinator-only config key, which is appended solely to the coordinator's `config.properties`. There were no genuinely-shared properties left, so the top-level `additionalConfigProperties` is dropped and workers now render clean.

## Chart key verification

- Chart ref: `helm repo add trinodb https://trinodb.github.io/charts` → `helm upgrade --install trino trinodb/trino` (unpinned → latest), from `bin/start.sh.template` and `bin/update-catalogs.sh.template`.
- Confirmed against the chart source that this version has **no** `coordinator.additionalConfigProperties`; the coordinator-only knob is **`server.coordinatorExtraConfig`** (raw string, `worker` has `server.workerExtraConfig`). The coordinator configmap appends it via `{{- .Values.server.coordinatorExtraConfig | nindent 4 }}`, and the worker configmap never references it.
- Rendered the fixed values with `helm template` against the real chart: the two `web-ui.*` lines appear in the coordinator's `config.properties` and are **absent** from the worker's.

## Live re-smoke steps (must run on a real cluster to fully confirm)

Draft because "workers become Ready + `SELECT 1`" can only be confirmed live:

1. `trino start` (with app nodes / workers).
2. `kubectl get pods -n default -l app.kubernetes.io/name=trino` → coordinator **and all workers** `Running`/`Ready`, no CrashLoopBackOff.
3. `kubectl logs` on a worker → no "Configuration property 'web-ui.*' was not used" / exit 100.
4. `trino sql "SELECT 1"` → returns `1`.