### PR TITLE
fix: bug-wave — 8 backlog bug fixes (trino P0, proxy teardown, k3s remount, stress/spark otel, start guards)

### DIFF
--- a/openspec/specs/spark-emr/spec.md
+++ b/openspec/specs/spark-emr/spec.md
@@ -115,6 +115,13 @@ The system SHALL upload a bootstrap action script to S3 and configure EMR cluste
 - **WHEN** the bootstrap script is invoked by EMR
 - **THEN** the control node's private IP is passed as a script argument and used in the OTel Collector config's OTLP exporter endpoint
 
+#### Scenario: Collector tags telemetry with the node's master/worker role
+
+- **WHEN** the bootstrap script runs on an EMR node
+- **THEN** it detects whether the node is the master (from `/mnt/var/lib/info/instance.json` `isMaster`) and resolves a role of `spark-master` or `spark-worker`
+- **AND** it patches the `__NODE_ROLE__` placeholder in the OTel Collector config so the `resource/role` processor sets `node_role` to that role
+- **AND** every metric, log, and trace the collector forwards from that node is tagged with `node_role=spark-master` or `node_role=spark-worker`, so master and worker telemetry can be filtered independently
+
 #### Scenario: EMRClusterConfig supports bootstrap actions
 
 - **WHEN** `EMRService.createCluster()` is called with an `EMRClusterConfig` containing `bootstrapActions`

--- a/packer/base/install/start_k3s_agent.sh
+++ b/packer/base/install/start_k3s_agent.sh
@@ -42,6 +42,20 @@ else
     echo "✓ K3s agent installed successfully"
 fi
 
+# Ensure the NVMe data volume is mounted before k3s-agent starts on every boot.
+# Container logs (/var/log/pods) and the k3s data dir live on /mnt/db1. On a
+# reboot systemd could otherwise start k3s-agent before /mnt/db1 is remounted,
+# leaving it unable to find its data. RequiresMountsFor pulls in and orders
+# k3s-agent after the /mnt/db1 mount unit.
+if mountpoint -q /mnt/db1; then
+    mkdir -p /etc/systemd/system/k3s-agent.service.d
+    cat > /etc/systemd/system/k3s-agent.service.d/10-nvme-mount.conf <<'EOF'
+[Unit]
+RequiresMountsFor=/mnt/db1
+EOF
+    systemctl daemon-reload
+fi
+
 # Start the k3s-agent service
 echo "Starting k3s-agent.service..."
 systemctl start k3s-agent

--- a/packer/base/install/start_k3s_agent.sh
+++ b/packer/base/install/start_k3s_agent.sh
@@ -42,20 +42,6 @@ else
     echo "✓ K3s agent installed successfully"
 fi
 
-# Ensure the NVMe data volume is mounted before k3s-agent starts on every boot.
-# Container logs (/var/log/pods) and the k3s data dir live on /mnt/db1. On a
-# reboot systemd could otherwise start k3s-agent before /mnt/db1 is remounted,
-# leaving it unable to find its data. RequiresMountsFor pulls in and orders
-# k3s-agent after the /mnt/db1 mount unit.
-if mountpoint -q /mnt/db1; then
-    mkdir -p /etc/systemd/system/k3s-agent.service.d
-    cat > /etc/systemd/system/k3s-agent.service.d/10-nvme-mount.conf <<'EOF'
-[Unit]
-RequiresMountsFor=/mnt/db1
-EOF
-    systemctl daemon-reload
-fi
-
 # Start the k3s-agent service
 echo "Starting k3s-agent.service..."
 systemctl start k3s-agent

--- a/packer/base/install/start_k3s_server.sh
+++ b/packer/base/install/start_k3s_server.sh
@@ -42,6 +42,20 @@ else
     echo "✓ K3s server installed successfully"
 fi
 
+# Ensure the NVMe data volume is mounted before k3s starts on every boot.
+# The k3s data dir (/var/lib/rancher/k3s) is a symlink onto /mnt/db1. On a
+# reboot systemd could otherwise start k3s before /mnt/db1 is remounted, and
+# k3s crash-loops with "extracting data: no such file or directory".
+# RequiresMountsFor pulls in and orders k3s after the /mnt/db1 mount unit.
+if mountpoint -q /mnt/db1; then
+    mkdir -p /etc/systemd/system/k3s.service.d
+    cat > /etc/systemd/system/k3s.service.d/10-nvme-mount.conf <<'EOF'
+[Unit]
+RequiresMountsFor=/mnt/db1
+EOF
+    systemctl daemon-reload
+fi
+
 # Start the k3s service
 echo "Starting k3s.service..."
 systemctl start k3s

--- a/packer/base/install/start_k3s_server.sh
+++ b/packer/base/install/start_k3s_server.sh
@@ -42,20 +42,6 @@ else
     echo "✓ K3s server installed successfully"
 fi
 
-# Ensure the NVMe data volume is mounted before k3s starts on every boot.
-# The k3s data dir (/var/lib/rancher/k3s) is a symlink onto /mnt/db1. On a
-# reboot systemd could otherwise start k3s before /mnt/db1 is remounted, and
-# k3s crash-loops with "extracting data: no such file or directory".
-# RequiresMountsFor pulls in and orders k3s after the /mnt/db1 mount unit.
-if mountpoint -q /mnt/db1; then
-    mkdir -p /etc/systemd/system/k3s.service.d
-    cat > /etc/systemd/system/k3s.service.d/10-nvme-mount.conf <<'EOF'
-[Unit]
-RequiresMountsFor=/mnt/db1
-EOF
-    systemctl daemon-reload
-fi
-
 # Start the k3s service
 echo "Starting k3s.service..."
 systemctl start k3s

--- a/packer/cassandra/bin/restart-cassandra-and-wait
+++ b/packer/cassandra/bin/restart-cassandra-and-wait
@@ -1,41 +1,86 @@
 #!/bin/bash
+#
+# Restart Cassandra and wait for it to come back available.
+#
+# Fails fast with a clear error (including recent journalctl output) if the
+# service fails to start -- for example when an invalid JVM/config change is
+# pushed up. Previously this script would wait out its full timeout and then
+# exit 0 (and the port check looped forever), hiding startup failures from the
+# operator. It now polls the systemd unit state and exits non-zero the moment
+# startup is detected to have failed.
+
+set -uo pipefail
+
+SERVICE="cassandra"
+NODETOOL="/usr/local/cassandra/current/bin/nodetool"
+READY_TIMEOUT=240   # seconds to wait for the node to become available
+JOURNAL_LINES=50
+
+# Print a clear error with recent service logs and exit non-zero so the caller
+# (the SSH layer / CassandraService.restart) surfaces the failure.
+fail() {
+    echo "ERROR: $1" >&2
+    echo "----- Recent ${SERVICE} logs (journalctl -u ${SERVICE} -n ${JOURNAL_LINES}) -----" >&2
+    sudo journalctl -u "${SERVICE}" -n "${JOURNAL_LINES}" --no-pager >&2 || true
+    exit 1
+}
+
+# Fail fast if systemd reports the unit has failed or exited. The cassandra unit
+# is Type=simple running "cassandra -f" in the foreground, so a crash on a bad
+# config lands the unit in the "failed" state rather than "active".
+check_service_alive() {
+    local state
+    state=$(systemctl is-active "${SERVICE}" 2>/dev/null)
+    case "${state}" in
+        active | activating)
+            return 0
+            ;;
+        *)
+            fail "${SERVICE} is not running (systemctl is-active reported '${state}'). Startup failed."
+            ;;
+    esac
+}
 
 echo "Maybe restarting Cassandra..."
 
 nodetool drain || true
-sudo systemctl restart cassandra
 
-# Get the start time in seconds
+if ! sudo systemctl restart "${SERVICE}"; then
+    fail "'systemctl restart ${SERVICE}' failed."
+fi
+
 start_time=$(date +%s)
 
-echo "Waiting for Cassandra to be available"
-# Loop until nodetool status exits with 0 or 60 seconds have gone by
+echo "Waiting for Cassandra to be available (timeout ${READY_TIMEOUT}s)"
+# Loop until nodetool status succeeds, the service dies, or we time out.
 while true; do
-    # Run the nodetool status command
-    /usr/local/cassandra/current/bin/nodetool status > /dev/null 2>&1
-    status=$?
+    # Detect a failed startup (e.g. invalid JVM options) instead of waiting.
+    check_service_alive
 
-    # If the command was successful, exit the loop
-    if [ $status -eq 0 ]; then
+    if "${NODETOOL}" status > /dev/null 2>&1; then
         echo "nodetool status was successful."
         break
     fi
 
-    # Calculate the elapsed time
-    current_time=$(date +%s)
-    elapsed=$((current_time - start_time))
-
-    # Check if 2 minutes seconds have passed
-    if [ $elapsed -ge 240 ]; then
-        echo "Timeout: nodetool status did not exit with 0 within 60 seconds."
-        break
+    elapsed=$(( $(date +%s) - start_time ))
+    if [[ "${elapsed}" -ge "${READY_TIMEOUT}" ]]; then
+        fail "Timed out after ${READY_TIMEOUT}s waiting for '${NODETOOL} status' to succeed. Cassandra did not become available."
     fi
 
-    # Optional: sleep for a bit before retrying to reduce load
     sleep 2
 done
 
-echo "Nodetool reporting node as up.  Waiting on port 9042."
+echo "Nodetool reporting node as up. Waiting on port 9042."
+# Bounded wait for the CQL port; keep checking the service so a late crash is
+# caught rather than looping forever.
+while ! ss -tulwn | grep -q ':9042'; do
+    check_service_alive
 
-while ! ss -tulwn | grep ':9042' ; do sleep 1; done
+    elapsed=$(( $(date +%s) - start_time ))
+    if [[ "${elapsed}" -ge "${READY_TIMEOUT}" ]]; then
+        fail "Timed out after ${READY_TIMEOUT}s waiting for CQL port 9042 to open."
+    fi
+
+    sleep 1
+done
 echo "Port 9042 available"

--- a/packer/cassandra/bin/restart-cassandra-and-wait
+++ b/packer/cassandra/bin/restart-cassandra-and-wait
@@ -71,6 +71,9 @@ while true; do
 done
 
 echo "Nodetool reporting node as up. Waiting on port 9042."
+# Reset the clock so the CQL-port wait gets its own full READY_TIMEOUT budget
+# rather than sharing the one already partly consumed by the nodetool loop.
+start_time=$(date +%s)
 # Bounded wait for the CQL port; keep checking the service so a late crash is
 # caught rather than looping forever.
 while ! ss -tulwn | grep -q ':9042'; do

--- a/src/integrationTest/kotlin/com/rustyrazorblade/easydblab/proxy/ProcessSocksProxyServiceTest.kt
+++ b/src/integrationTest/kotlin/com/rustyrazorblade/easydblab/proxy/ProcessSocksProxyServiceTest.kt
@@ -18,6 +18,7 @@ import java.io.File
 import java.net.ServerSocket
 import java.time.Duration
 import java.time.Instant
+import java.util.concurrent.TimeUnit
 
 /**
  * Integration-tier tests for [ProcessSocksProxyService] that genuinely require real socket I/O: the
@@ -179,6 +180,30 @@ class ProcessSocksProxyServiceTest {
         // The zombie's port must never be republished — it was rejected as invalid, and the fresh
         // attempt also failed.
         assertThat(System.getProperty(Constants.Proxy.PORT_PROPERTY)).isNull()
+    }
+
+    @Test
+    fun `a superseded zombie tunnel process is killed when a replacement is started`() {
+        // A real, killable stand-in for a zombie ssh tunnel: the process is alive, but its recorded
+        // `-D` port is not listening, so isValidProxy() rejects it and a replacement is started.
+        // Before the fix, startNewProxy() overwrote the state file with the new PID and this one was
+        // never killed — it leaked and survived `down` (issue #741).
+        val zombie = ProcessBuilder("sleep", "60").start()
+        try {
+            val deadPort = reserveFreePort() // recorded but nothing is listening on it
+            writeStateFile(pid = zombie.pid().toInt(), port = deadPort)
+
+            // The fresh start fails fast (fake dead launcher); we only care that the stale zombie
+            // was reaped on the way through.
+            assertThatThrownBy { service(launcher = { _, _ -> deadProcess(exitCode = 255) }).ensureRunning(testHost) }
+                .isInstanceOf(IllegalStateException::class.java)
+
+            assertThat(zombie.waitFor(5, TimeUnit.SECONDS))
+                .withFailMessage("the superseded zombie tunnel process should have been killed")
+                .isTrue()
+        } finally {
+            zombie.destroyForcibly()
+        }
     }
 
     @Test

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Down.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Down.kt
@@ -305,10 +305,16 @@ class Down : PicoBaseCommand() {
 
     /**
      * Cleanup SOCKS5 proxy if it exists.
+     *
+     * Resolves the state file against [Context.workingDirectory] — the same location
+     * [com.rustyrazorblade.easydblab.proxy.ProcessSocksProxyService] writes it to. Resolving it
+     * against the process cwd instead would miss the file whenever `workingDirectory` is set
+     * explicitly rather than inherited from cwd (long-running `Server`/`Repl`, tests), orphaning
+     * the `ssh -N -D` tunnel process at teardown.
      */
     @Suppress("TooGenericExceptionCaught")
-    private fun cleanupSocks5Proxy() {
-        val proxyStateFile = File(Constants.Vpc.SOCKS5_PROXY_STATE_FILE)
+    internal fun cleanupSocks5Proxy() {
+        val proxyStateFile = File(context.workingDirectory, Constants.Vpc.SOCKS5_PROXY_STATE_FILE)
         if (!proxyStateFile.exists()) {
             return
         }

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Up.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Up.kt
@@ -603,16 +603,24 @@ class Up(
 
         Retry
             .decorateRunnable(retry) {
-                checkSshReady(ServerType.Control)
-                checkSshReady(ServerType.Cassandra)
+                // The control node is never what `--hosts` scopes — that filter targets db/app
+                // nodes for scale-out. Applying it here would make `up --hosts db2` filter the
+                // control check down to zero hosts (HostOperationsService.withHosts silently
+                // no-ops on an empty match), verifying nothing and reopening the readiness gap the
+                // control check exists to close. Always check control with no filter.
+                checkSshReady(ServerType.Control, hostFilter = "")
+                checkSshReady(ServerType.Cassandra, hostFilter = hosts.hostList)
             }.run()
     }
 
-    private fun checkSshReady(serverType: ServerType) {
+    private fun checkSshReady(
+        serverType: ServerType,
+        hostFilter: String,
+    ) {
         hostOperationsService.withHosts(
             workingState.hosts,
             serverType,
-            hosts.hostList,
+            hostFilter,
         ) { clusterHost ->
             remoteOps.executeRemotely(clusterHost.toHost(), "echo 1").text
         }

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/Start.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/Start.kt
@@ -55,6 +55,8 @@ class Start : PicoBaseCommand() {
     var hosts = HostsMixin()
 
     override fun execute() {
+        validateVersionsAssigned()
+
         hostOperationsService.withHosts(clusterState.hosts, ServerType.Cassandra, hosts.hostList) { host ->
             val h = host.toHost()
             eventBus.emit(Event.Cassandra.Starting(h.alias))
@@ -88,5 +90,27 @@ class Start : PicoBaseCommand() {
 
         clusterStateManager.addRunningWorkload("cassandra")
         kitHookExecutor.firePostKitStart("cassandra")
+    }
+
+    /**
+     * Fails fast when any targeted node has no version assigned.
+     *
+     * A node only gets a version once `cassandra use <version>` has run against it, which both
+     * records the version in cluster state and points `/usr/local/cassandra/current` at that
+     * install on the box. Starting a node without a version produces a confusing systemd failure
+     * far downstream, so we reject it up front with an actionable message before touching any node.
+     */
+    private fun validateVersionsAssigned() {
+        val versions = clusterState.versions.orEmpty()
+        val missing =
+            hostOperationsService
+                .filteredHosts(clusterState.hosts, ServerType.Cassandra, hosts.hostList)
+                .map { it.alias }
+                .filter { versions[it].isNullOrBlank() }
+
+        check(missing.isEmpty()) {
+            "No version assigned for node(s): ${missing.joinToString(", ")}. " +
+                "Run 'cassandra use <version>' (e.g. 'cassandra use 5.0') to assign a version before starting."
+        }
     }
 }

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/proxy/ProcessSocksProxyService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/proxy/ProcessSocksProxyService.kt
@@ -107,6 +107,12 @@ class ProcessSocksProxyService(
                         return@withLock reused
                     } else {
                         log.info { "Stale SOCKS5 proxy state, starting fresh" }
+                        // The recorded proxy is not reusable (e.g. a live PID whose port stopped
+                        // accepting — a zombie tunnel). startNewProxy() below overwrites the state
+                        // file with a new PID, so this one becomes unrecorded and `Down` could
+                        // never find it. Kill it now, before it is forgotten, or it leaks and
+                        // survives teardown (issue #741).
+                        terminateStaleProxy(loaded.pid)
                     }
                 } catch (e: Exception) {
                     log.warn(e) { "Failed to read proxy state file, starting fresh" }
@@ -291,6 +297,37 @@ class ProcessSocksProxyService(
             return false
         }
         return true
+    }
+
+    /**
+     * Force-kills a superseded proxy `ssh` process so it does not leak.
+     *
+     * Called when a recorded proxy is being replaced rather than reused (e.g. a zombie tunnel:
+     * PID alive but its `-D` port stopped accepting). Once [startNewProxy] overwrites the state
+     * file, [stalePid] is the last reference to that process — `Down` reads only the current state
+     * file, so an un-killed stale PID survives even `easy-db-lab down`. A no-op if the PID is
+     * non-positive or already gone.
+     *
+     * Best-effort by design: killing the stale tunnel must never break starting its replacement, so
+     * any failure (including the JVM refusing to destroy its own process, should the PID ever match
+     * this one) is logged, not thrown. A no-op if the PID is non-positive, already gone, or this JVM.
+     *
+     * Internal (not private) purely so a test can drive it against a real spawned process without
+     * exercising the whole [ensureRunning] state-file path.
+     */
+    @Suppress("TooGenericExceptionCaught")
+    internal fun terminateStaleProxy(stalePid: Int) {
+        if (stalePid <= 0 || stalePid.toLong() == ProcessHandle.current().pid()) {
+            return
+        }
+        ProcessHandle.of(stalePid.toLong()).ifPresent { handle ->
+            log.info { "Terminating superseded SOCKS5 proxy process [PID $stalePid]" }
+            try {
+                handle.destroyForcibly()
+            } catch (e: Exception) {
+                log.warn(e) { "Failed to kill superseded SOCKS5 proxy process [PID $stalePid]" }
+            }
+        }
     }
 
     private fun isAlive(processPid: Int): Boolean = processPid > 0 && ProcessHandle.of(processPid.toLong()).isPresent

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/proxy/ProcessSocksProxyService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/proxy/ProcessSocksProxyService.kt
@@ -305,8 +305,7 @@ class ProcessSocksProxyService(
      * Called when a recorded proxy is being replaced rather than reused (e.g. a zombie tunnel:
      * PID alive but its `-D` port stopped accepting). Once [startNewProxy] overwrites the state
      * file, [stalePid] is the last reference to that process — `Down` reads only the current state
-     * file, so an un-killed stale PID survives even `easy-db-lab down`. A no-op if the PID is
-     * non-positive or already gone.
+     * file, so an un-killed stale PID survives even `easy-db-lab down`.
      *
      * Best-effort by design: killing the stale tunnel must never break starting its replacement, so
      * any failure (including the JVM refusing to destroy its own process, should the PID ever match

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/HostOperationsService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/HostOperationsService.kt
@@ -58,16 +58,7 @@ class HostOperationsService(
         parallel: Boolean = false,
         action: (ClusterHost) -> Unit,
     ) {
-        val hostSet =
-            hostFilter
-                .split(",")
-                .filter { it.isNotBlank() }
-                .toSet()
-
-        val filteredHosts =
-            hosts[serverType]?.filter {
-                hostSet.isEmpty() || it.alias in hostSet
-            } ?: emptyList()
+        val filteredHosts = filteredHosts(hosts, serverType, hostFilter)
 
         if (parallel && filteredHosts.size > 1) {
             val threads =
@@ -80,6 +71,34 @@ class HostOperationsService(
         } else {
             filteredHosts.forEach(action)
         }
+    }
+
+    /**
+     * Returns the hosts of a given server type after applying a comma-separated alias filter.
+     *
+     * This is the same selection logic [withHosts] uses to decide which hosts to act on, exposed
+     * so callers (e.g. pre-flight validation) can inspect the exact target set without executing
+     * an action against it.
+     *
+     * @param hosts Map of server types to their hosts
+     * @param serverType The type of server to filter
+     * @param hostFilter Comma-separated list of host aliases to include (empty means all)
+     * @return The filtered hosts, in declaration order
+     */
+    fun filteredHosts(
+        hosts: Map<ServerType, List<ClusterHost>>,
+        serverType: ServerType,
+        hostFilter: String = "",
+    ): List<ClusterHost> {
+        val hostSet =
+            hostFilter
+                .split(",")
+                .filter { it.isNotBlank() }
+                .toSet()
+
+        return hosts[serverType]?.filter {
+            hostSet.isEmpty() || it.alias in hostSet
+        } ?: emptyList()
     }
 
     /**

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/ServicesModule.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/ServicesModule.kt
@@ -92,7 +92,9 @@ val servicesModule =
         singleOf(::DefaultVictoriaLogsService) bind VictoriaLogsService::class
         factoryOf(::SidecarManifestBuilder)
         factoryOf(::DefaultSidecarService) bind SidecarService::class
-        singleOf(::DefaultStressJobService) bind StressJobService::class
+        // Explicit single (not singleOf) so the jobPollInterval constructor default applies
+        // instead of Koin trying to resolve a Duration binding.
+        single<StressJobService> { DefaultStressJobService(get(), get(), get(), get()) }
         singleOf(::HostOperationsService)
 
         // Kit command scanner — discovers @KitCommand-annotated classes across all JARs

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/StressJobService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/StressJobService.kt
@@ -369,7 +369,8 @@ class DefaultStressJobService(
 
         val stressContainer =
             buildStressContainer(config, region, controlNodeIp, clusterState.name)
-        val otelSidecar = buildOtelSidecarContainer(config.jobName, config.tags, config.promPort)
+        val otelSidecar =
+            buildOtelSidecarContainer(config.jobName, config.tags, config.promPort, clusterState.clusterLabelName())
 
         return assembleJob(config.jobName, labels, stressContainer, otelSidecar)
     }
@@ -433,6 +434,7 @@ class DefaultStressJobService(
         jobName: String,
         tags: Map<String, String>,
         promPort: Int,
+        clusterName: String,
     ): Container {
         val resourceAttributes = buildResourceAttributes(jobName, tags)
 
@@ -457,14 +459,16 @@ class DefaultStressJobService(
                     .endFieldRef()
                     .endValueFrom()
                     .build(),
+                // Inject the cluster label directly from cluster state rather than via a
+                // `cluster-config` ConfigMap. That ConfigMap is created by the separate
+                // `grafana update-config` command and is not guaranteed to exist when a stress
+                // job starts; a non-optional configMapKeyRef to a missing ConfigMap causes
+                // CreateContainerConfigError and fails the Job (issue #733). The value matches
+                // `clusterLabelName()` so the sidecar's `cluster` metric label lines up with the
+                // rest of the observability stack.
                 EnvVarBuilder()
                     .withName("CLUSTER_NAME")
-                    .withNewValueFrom()
-                    .withNewConfigMapKeyRef()
-                    .withName("cluster-config")
-                    .withKey("cluster_name")
-                    .endConfigMapKeyRef()
-                    .endValueFrom()
+                    .withValue(clusterName)
                     .build(),
                 EnvVarBuilder()
                     .withName("GOMEMLIMIT")

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/TailscaleService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/TailscaleService.kt
@@ -294,10 +294,13 @@ class DefaultTailscaleService(
         runCatching {
             eventBus.emit(Event.Tailscale.DaemonStarting(host.alias))
 
-            // Start the daemon
+            // Enable the daemon for boot and start it now. `enable --now` makes tailscaled
+            // boot-persistent so it auto-starts after a node reboot; without this the daemon
+            // stays disabled and a control-node reboot silently kills all operator CLI and
+            // observability access over the Tailscale subnet route.
             remoteOps.executeRemotely(
                 host,
-                "sudo systemctl start tailscaled",
+                "sudo systemctl enable --now tailscaled",
             )
 
             // Give the daemon a moment to initialize

--- a/src/main/resources/com/rustyrazorblade/easydblab/commands/setup_instance.sh
+++ b/src/main/resources/com/rustyrazorblade/easydblab/commands/setup_instance.sh
@@ -72,6 +72,27 @@ if [[ -n "$DISK" ]]; then
       sudo mount $DISK /mnt/db1
   fi
 
+  # Persist the mount so /mnt/db1 is restored automatically on every boot.
+  # Without this the NVMe is mounted only at provision time; after any reboot
+  # the mount is gone and k3s (whose data dir is a symlink onto /mnt/db1)
+  # crash-loops with "extracting data: no such file or directory".
+  #
+  # Instance-store NVMe device names (nvme0n1/nvme1n1/xvdb) can change across
+  # reboots, so key the fstab entry on the stable XFS filesystem UUID rather
+  # than the device path. 'nofail' keeps the node bootable if the instance
+  # store was wiped (a stop/terminate erases instance-store, unlike a reboot)
+  # and the filesystem no longer exists; 'x-systemd.device-timeout' avoids a
+  # long boot hang in that case.
+  FS_UUID=$(sudo blkid -o value -s UUID "$DISK")
+  if [[ -n "$FS_UUID" ]]; then
+    FSTAB_ENTRY="UUID=$FS_UUID /mnt/db1 xfs defaults,nofail,x-systemd.device-timeout=10s 0 2"
+    # Remove any previous /mnt/db1 entry (e.g. a stale device path) before adding the current one.
+    sudo sed -i '\#[[:space:]]/mnt/db1[[:space:]]#d' /etc/fstab
+    echo "$FSTAB_ENTRY" | sudo tee -a /etc/fstab
+    # Pick up the fstab-generated mnt-db1.mount unit so services can order against it.
+    sudo systemctl daemon-reload
+  fi
+
   sudo blockdev --setra $READAHEAD $DISK
 fi
 

--- a/src/main/resources/com/rustyrazorblade/easydblab/configuration/emr/bootstrap-otel.sh
+++ b/src/main/resources/com/rustyrazorblade/easydblab/configuration/emr/bootstrap-otel.sh
@@ -23,6 +23,19 @@ PYROSCOPE_JAR="$PYROSCOPE_DIR/pyroscope.jar"
 
 echo "=== Installing OTel and Pyroscope agents ==="
 
+# Determine this node's role so master and worker telemetry can be filtered
+# independently in Grafana. EMR writes node facts to /mnt/var/lib/info/instance.json
+# (a stable, long-standing path) with an "isMaster" boolean. We grep rather than use
+# jq because jq is not guaranteed present on EMR AMIs, and a missing-jq failure under
+# `set -e` would abort the entire bootstrap and prevent the cluster from starting.
+INSTANCE_INFO="/mnt/var/lib/info/instance.json"
+if grep -Eq '"isMaster"[[:space:]]*:[[:space:]]*true' "$INSTANCE_INFO" 2>/dev/null; then
+  NODE_ROLE="spark-master"
+else
+  NODE_ROLE="spark-worker"
+fi
+echo "Detected node role: $NODE_ROLE"
+
 # Create directories
 sudo mkdir -p "$OTEL_DIR" "$PYROSCOPE_DIR"
 
@@ -47,8 +60,11 @@ echo "Writing OTel Collector config to $COLLECTOR_CONFIG"
 sudo tee "$COLLECTOR_CONFIG" > /dev/null << 'CONFIGEOF'
 __OTEL_COLLECTOR_CONFIG__
 CONFIGEOF
-# Note: __CONTROL_NODE_IP__ is resolved at upload time by TemplateService
-echo "OTel Collector config written"
+# Note: __CONTROL_NODE_IP__ is resolved at upload time by TemplateService.
+# __NODE_ROLE__ is left unresolved on purpose and patched here, per-node, so the
+# collector tags every metric/log/trace it processes with this node's role.
+sudo sed -i "s/__NODE_ROLE__/$NODE_ROLE/g" "$COLLECTOR_CONFIG"
+echo "OTel Collector config written (node_role=$NODE_ROLE)"
 
 # --- OTel Collector systemd service ---
 echo "Creating otel-collector systemd service"

--- a/src/main/resources/com/rustyrazorblade/easydblab/configuration/emr/otel-collector-config.yaml
+++ b/src/main/resources/com/rustyrazorblade/easydblab/configuration/emr/otel-collector-config.yaml
@@ -30,7 +30,10 @@ processors:
   resource/role:
     attributes:
       - key: node_role
-        value: spark
+        # __NODE_ROLE__ is intentionally left unresolved by TemplateService at S3
+        # upload time. The bootstrap action patches it per-node to spark-master or
+        # spark-worker so master and worker telemetry can be filtered independently.
+        value: __NODE_ROLE__
         action: upsert
 
 exporters:

--- a/src/main/resources/com/rustyrazorblade/easydblab/kits/trino/values.yaml.template
+++ b/src/main/resources/com/rustyrazorblade/easydblab/kits/trino/values.yaml.template
@@ -1,9 +1,13 @@
 server:
   workers: __WORKERS__
-
-additionalConfigProperties:
-  - "web-ui.authentication.type=FIXED"
-  - "web-ui.user=trino"
+  # web-ui.* properties are coordinator-only (the web UI runs only on the
+  # coordinator). Placing them in the shared `additionalConfigProperties` sends
+  # them to workers too, which reject the unused properties and crash on startup
+  # (exit 100). coordinatorExtraConfig is appended only to the coordinator's
+  # config.properties, keeping the workers clean.
+  coordinatorExtraConfig: |
+    web-ui.authentication.type=FIXED
+    web-ui.user=trino
 
 image:
   tag: "__VERSION__"

--- a/src/main/resources/com/rustyrazorblade/easydblab/services/start-k3s-agent.sh
+++ b/src/main/resources/com/rustyrazorblade/easydblab/services/start-k3s-agent.sh
@@ -47,6 +47,20 @@ else
     echo "✓ K3s agent installed successfully"
 fi
 
+# Ensure the NVMe data volume is mounted before k3s-agent starts on every boot.
+# The k3s data dir (/var/lib/rancher/k3s) is a symlink onto /mnt/db1. On a
+# reboot systemd could otherwise start k3s-agent before /mnt/db1 is remounted,
+# leaving it unable to find its data dir. RequiresMountsFor pulls in and orders
+# k3s-agent after the /mnt/db1 mount unit.
+if mountpoint -q /mnt/db1; then
+    mkdir -p /etc/systemd/system/k3s-agent.service.d
+    cat > /etc/systemd/system/k3s-agent.service.d/10-nvme-mount.conf <<'EOF'
+[Unit]
+RequiresMountsFor=/mnt/db1
+EOF
+    systemctl daemon-reload
+fi
+
 # Start the k3s-agent service
 echo "Starting k3s-agent.service..."
 systemctl start k3s-agent

--- a/src/main/resources/com/rustyrazorblade/easydblab/services/start-k3s-server.sh
+++ b/src/main/resources/com/rustyrazorblade/easydblab/services/start-k3s-server.sh
@@ -46,6 +46,20 @@ else
     echo "✓ K3s server installed successfully"
 fi
 
+# Ensure the NVMe data volume is mounted before k3s starts on every boot.
+# The k3s data dir (/var/lib/rancher/k3s) is a symlink onto /mnt/db1. On a
+# reboot systemd could otherwise start k3s before /mnt/db1 is remounted, and
+# k3s crash-loops with "extracting data: no such file or directory".
+# RequiresMountsFor pulls in and orders k3s after the /mnt/db1 mount unit.
+if mountpoint -q /mnt/db1; then
+    mkdir -p /etc/systemd/system/k3s.service.d
+    cat > /etc/systemd/system/k3s.service.d/10-nvme-mount.conf <<'EOF'
+[Unit]
+RequiresMountsFor=/mnt/db1
+EOF
+    systemctl daemon-reload
+fi
+
 # Start the k3s service
 echo "Starting k3s.service..."
 systemctl start k3s

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/commands/DownTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/commands/DownTest.kt
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import org.junit.jupiter.api.parallel.ResourceLock
 import java.io.File
+import java.util.concurrent.TimeUnit
 
 class DownTest : BaseKoinTest() {
     @BeforeEach
@@ -61,6 +62,43 @@ class DownTest : BaseKoinTest() {
         }
 
         assertThat(proxyStateFile).doesNotExist()
+    }
+
+    @Test
+    fun `cleanupSocks5Proxy resolves the state file against workingDirectory and kills the tunnel`() {
+        // The state file lives in the cluster working directory, NOT the process cwd. This test
+        // proves Down resolves it against context.workingDirectory: the test process cwd is the
+        // project root (never the temp workingDirectory), so a cwd-relative resolver would miss
+        // the file, skip the kill, and orphan the ssh tunnel (issue #738).
+        val workingDir = context.workingDirectory
+
+        // A real, killable stand-in for the `ssh -N -D` tunnel process.
+        val tunnel = ProcessBuilder("sleep", "60").start()
+        try {
+            val proxyStateFile = File(workingDir, Constants.Vpc.SOCKS5_PROXY_STATE_FILE)
+            proxyStateFile.writeText(
+                """
+                {
+                  "pid": ${tunnel.pid()},
+                  "port": 1080,
+                  "controlHost": "control0",
+                  "controlIP": "10.0.1.5",
+                  "clusterName": "test",
+                  "startTime": "2025-01-19T10:30:00Z",
+                  "sshConfig": "$workingDir/sshConfig"
+                }
+                """.trimIndent(),
+            )
+
+            Down().cleanupSocks5Proxy()
+
+            assertThat(tunnel.waitFor(5, TimeUnit.SECONDS))
+                .withFailMessage("cleanupSocks5Proxy should have killed the tunnel process")
+                .isTrue()
+            assertThat(proxyStateFile).doesNotExist()
+        } finally {
+            tunnel.destroyForcibly()
+        }
     }
 
     @Test

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/commands/UpTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/commands/UpTest.kt
@@ -562,6 +562,19 @@ class UpTest : BaseKoinTest() {
     }
 
     @Test
+    fun `ssh readiness still covers the control host under a scale-out --hosts filter`() {
+        // A scale-out run like `up --hosts db0` must not narrow the control readiness check to the
+        // db filter — control0 never matches "db0", so filtering it would verify zero hosts and
+        // reopen the control-node readiness gap (issue #741). The db filter applies only to the
+        // db/app check.
+        val up = newUp().also { it.hosts.hostList = "db0" }
+
+        assertThatCode { up.execute() }.doesNotThrowAnyException()
+
+        assertThat(sshCheckedAliases).contains("control0", "db0")
+    }
+
+    @Test
     fun `up aborts when the control node never accepts ssh`() {
         sshFailureAlias = "control0"
         // A non-retryable exception type: RetryUtil's SSH retry config only retries

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/StartTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/commands/cassandra/StartTest.kt
@@ -14,6 +14,7 @@ import com.rustyrazorblade.easydblab.services.HostOperationsService
 import com.rustyrazorblade.easydblab.services.KitHookExecutor
 import com.rustyrazorblade.easydblab.services.SidecarService
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.koin.core.module.Module
@@ -21,6 +22,8 @@ import org.koin.dsl.module
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
@@ -44,7 +47,7 @@ class StartTest : BaseKoinTest() {
     private val testClusterState =
         ClusterState(
             name = "test-cluster",
-            versions = mutableMapOf(),
+            versions = mutableMapOf("db0" to "5.0"),
             initConfig = InitConfig(region = "us-west-2"),
             hosts =
                 mapOf(
@@ -137,5 +140,83 @@ class StartTest : BaseKoinTest() {
 
         val output = outputHandler.messages.joinToString("\n")
         assertThat(output).contains("axon-agent")
+    }
+
+    @Test
+    fun `execute fails fast naming nodes without a version`() {
+        // db0 has a version, db1 does not — start must abort before touching any node.
+        val db1 =
+            ClusterHost(
+                publicIp = "54.1.2.4",
+                privateIp = "10.0.1.2",
+                alias = "db1",
+                availabilityZone = "us-west-2a",
+                instanceId = "i-db1",
+            )
+        val stateMissingVersion =
+            testClusterState.copy(
+                versions = mutableMapOf("db0" to "5.0"),
+                hosts = testClusterState.hosts + (ServerType.Cassandra to listOf(testCassandraHost, db1)),
+            )
+        whenever(mockClusterStateManager.load()).thenReturn(stateMissingVersion)
+
+        val command = Start()
+
+        assertThatThrownBy { command.execute() }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("db1")
+            .hasMessageContaining("cassandra use")
+
+        // Fail-fast: no node was started.
+        verify(mockCassandraService, never()).start(any(), any())
+    }
+
+    @Test
+    fun `execute proceeds when every node has a version`() {
+        val db1 =
+            ClusterHost(
+                publicIp = "54.1.2.4",
+                privateIp = "10.0.1.2",
+                alias = "db1",
+                availabilityZone = "us-west-2a",
+                instanceId = "i-db1",
+            )
+        val stateAllVersions =
+            testClusterState.copy(
+                versions = mutableMapOf("db0" to "5.0", "db1" to "5.0"),
+                hosts = testClusterState.hosts + (ServerType.Cassandra to listOf(testCassandraHost, db1)),
+            )
+        whenever(mockClusterStateManager.load()).thenReturn(stateAllVersions)
+
+        val command = Start()
+        command.execute()
+
+        // Both nodes started.
+        verify(mockCassandraService, times(2)).start(any(), eq(true))
+    }
+
+    @Test
+    fun `execute only requires versions for hosts targeted by the filter`() {
+        // db1 has no version, but --hosts targets db0 only, so start must proceed.
+        val db1 =
+            ClusterHost(
+                publicIp = "54.1.2.4",
+                privateIp = "10.0.1.2",
+                alias = "db1",
+                availabilityZone = "us-west-2a",
+                instanceId = "i-db1",
+            )
+        val state =
+            testClusterState.copy(
+                versions = mutableMapOf("db0" to "5.0"),
+                hosts = testClusterState.hosts + (ServerType.Cassandra to listOf(testCassandraHost, db1)),
+            )
+        whenever(mockClusterStateManager.load()).thenReturn(state)
+
+        val command = Start()
+        command.hosts.hostList = "db0"
+        command.execute()
+
+        verify(mockCassandraService).start(any(), eq(true))
     }
 }

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/services/DefaultStressJobServiceTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/services/DefaultStressJobServiceTest.kt
@@ -155,9 +155,12 @@ class DefaultStressJobServiceTest : BaseKoinTest() {
         val hostIpEnv = sidecar.env.first { it.name == "HOST_IP" }
         assertThat(hostIpEnv.valueFrom.fieldRef.fieldPath).isEqualTo("status.hostIP")
 
+        // CLUSTER_NAME is injected directly from cluster state (issue #733) so the stress job no
+        // longer depends on a `cluster-config` ConfigMap that may not exist yet.
+        val clusterStateManager: ClusterStateManager = getKoin().get()
         val clusterNameEnv = sidecar.env.first { it.name == "CLUSTER_NAME" }
-        assertThat(clusterNameEnv.valueFrom.configMapKeyRef.name).isEqualTo("cluster-config")
-        assertThat(clusterNameEnv.valueFrom.configMapKeyRef.key).isEqualTo("cluster_name")
+        assertThat(clusterNameEnv.valueFrom).isNull()
+        assertThat(clusterNameEnv.value).isEqualTo(clusterStateManager.load().clusterLabelName())
 
         val goMemLimitEnv = sidecar.env.first { it.name == "GOMEMLIMIT" }
         assertThat(goMemLimitEnv.value).isEqualTo("64MiB")

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/services/EMRProvisioningServiceTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/services/EMRProvisioningServiceTest.kt
@@ -198,6 +198,42 @@ internal class EMRProvisioningServiceTest {
     }
 
     @Test
+    fun `uploaded bootstrap script resolves control node IP but leaves node role for per-node patching`() {
+        val clusterState = createTestClusterState(clusterId = "test-id")
+        setupEmrMocks("j-BOOT", "myenv-spark")
+
+        service.provisionEmrCluster(
+            EmrClusterProvisioningConfig(
+                clusterName = "myenv",
+                masterInstanceType = "m5.2xlarge",
+                workerInstanceType = "m5.4xlarge",
+                workerCount = 3,
+                subnetId = "subnet-123",
+                securityGroupId = "sg-456",
+                keyName = "my-key",
+                clusterState = clusterState,
+                tags = emptyMap(),
+            ),
+        )
+
+        val scriptCaptor = argumentCaptor<String>()
+        verify(mockObjectStore).uploadContent(scriptCaptor.capture(), any())
+        val script = scriptCaptor.firstValue
+
+        // TemplateService must resolve the control node IP into the embedded collector config...
+        assertThat(script).contains("endpoint: 10.0.1.5:4317")
+        // ...but must NOT resolve __NODE_ROLE__ — the bootstrap patches it per-node so master and
+        // worker telemetry are distinguishable. If TemplateService ever clobbered it, node_role
+        // would be blank/wrong on every EMR node and this assertion would fail.
+        assertThat(script).contains("value: __NODE_ROLE__")
+        // The bootstrap must detect the node's role and patch the placeholder before starting.
+        assertThat(script)
+            .contains("NODE_ROLE=\"spark-master\"")
+            .contains("NODE_ROLE=\"spark-worker\"")
+            .contains("sed -i \"s/__NODE_ROLE__/\$NODE_ROLE/g\" \"\$COLLECTOR_CONFIG\"")
+    }
+
+    @Test
     fun `provisionEmrCluster should call createCluster then waitForClusterReady`() {
         val clusterState =
             ClusterState(

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/services/ServicesModuleTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/services/ServicesModuleTest.kt
@@ -1,0 +1,50 @@
+package com.rustyrazorblade.easydblab.services
+
+import com.rustyrazorblade.easydblab.configuration.ClusterStateManager
+import com.rustyrazorblade.easydblab.configuration.User
+import com.rustyrazorblade.easydblab.events.EventBus
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatCode
+import org.junit.jupiter.api.Test
+import org.koin.dsl.koinApplication
+import org.koin.dsl.module
+import org.mockito.kotlin.mock
+
+/**
+ * Verifies the Koin wiring declared in [servicesModule] can actually construct services whose
+ * constructors carry defaulted parameters of types that are not registered as Koin definitions.
+ *
+ * Koin's `singleOf`/`factoryOf` reflectively resolve every constructor parameter via `get()` and
+ * do NOT honour Kotlin default values. Any registration that uses them for a class with a defaulted
+ * parameter of an un-injectable type (e.g. [java.time.Duration]) fails at runtime with
+ * `NoDefinitionFoundException`. [DefaultStressJobService.jobPollInterval] is exactly such a case, so
+ * its registration must use an explicit lambda that omits the defaulted argument. This test guards
+ * that wiring against regressing back to `singleOf`.
+ */
+class ServicesModuleTest {
+    /**
+     * Supplies the leaf dependencies of [DefaultStressJobService] so the real [servicesModule]
+     * registration can be resolved in isolation without pulling in the full infrastructure graph.
+     * These override the corresponding definitions in [servicesModule] (K8sService, TemplateService
+     * deps) while leaving the StressJobService binding under test untouched.
+     */
+    private val leafDependenciesModule =
+        module {
+            single<K8sService> { mock() }
+            single<ClusterStateManager> { mock() }
+            single { EventBus() }
+            single<User> { mock() }
+        }
+
+    @Test
+    fun `servicesModule resolves StressJobService without NoDefinitionFoundException`() {
+        val app = koinApplication { modules(servicesModule, leafDependenciesModule) }
+        try {
+            val koin = app.koin
+            assertThatCode { koin.get<StressJobService>() }.doesNotThrowAnyException()
+            assertThat(koin.get<StressJobService>()).isInstanceOf(DefaultStressJobService::class.java)
+        } finally {
+            app.close()
+        }
+    }
+}

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/services/TailscaleServiceTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/services/TailscaleServiceTest.kt
@@ -57,14 +57,14 @@ class TailscaleServiceTest : BaseKoinTest() {
     // ========== START TAILSCALE TESTS ==========
 
     @Test
-    fun `startTailscale should start daemon and authenticate`() {
+    fun `startTailscale should enable daemon for boot and authenticate`() {
         // Given
         val authKey = "tskey-auth-xxx"
         val hostname = "control0"
         val cidr = "10.0.0.0/16"
         val successResponse = Response(text = "", stderr = "")
 
-        whenever(mockRemoteOps.executeRemotely(eq(testHost), eq("sudo systemctl start tailscaled"), any(), any()))
+        whenever(mockRemoteOps.executeRemotely(eq(testHost), eq("sudo systemctl enable --now tailscaled"), any(), any()))
             .thenReturn(successResponse)
         whenever(
             mockRemoteOps.executeRemotely(
@@ -80,7 +80,8 @@ class TailscaleServiceTest : BaseKoinTest() {
 
         // Then
         assertThat(result.isSuccess).isTrue()
-        verify(mockRemoteOps).executeRemotely(eq(testHost), eq("sudo systemctl start tailscaled"), any(), any())
+        // `enable --now` (not plain `start`) so the daemon survives a node reboot.
+        verify(mockRemoteOps).executeRemotely(eq(testHost), eq("sudo systemctl enable --now tailscaled"), any(), any())
         verify(mockRemoteOps).executeRemotely(
             eq(testHost),
             argThat {
@@ -101,7 +102,7 @@ class TailscaleServiceTest : BaseKoinTest() {
         val hostname = "control0"
         val cidr = "10.0.0.0/16"
 
-        whenever(mockRemoteOps.executeRemotely(eq(testHost), eq("sudo systemctl start tailscaled"), any(), any()))
+        whenever(mockRemoteOps.executeRemotely(eq(testHost), eq("sudo systemctl enable --now tailscaled"), any(), any()))
             .thenThrow(RuntimeException("Failed to start tailscaled"))
 
         // When
@@ -121,7 +122,7 @@ class TailscaleServiceTest : BaseKoinTest() {
         val cidr = "10.0.0.0/16"
         val successResponse = Response(text = "", stderr = "")
 
-        whenever(mockRemoteOps.executeRemotely(eq(testHost), eq("sudo systemctl start tailscaled"), any(), any()))
+        whenever(mockRemoteOps.executeRemotely(eq(testHost), eq("sudo systemctl enable --now tailscaled"), any(), any()))
             .thenReturn(successResponse)
         whenever(
             mockRemoteOps.executeRemotely(


### PR DESCRIPTION
Backlog bugs fixed as one wave — **one commit per fix**, review commit-by-commit. Being live-validated end-to-end on a real cluster; fixes for anything surfaced during that test are added here.

Closes #827, closes #738, closes #741, closes #823, closes #733, closes #564, closes #162, closes #200, closes #854, closes #855.

## Fixes
- **#827** (P0) — trino kit: `web-ui.*` props scoped to `server.coordinatorExtraConfig` (coordinator-only) so workers stop rejecting them and CrashLooping. Verified with `helm template`.
- **#738** — `down` resolves the SOCKS proxy state file against `context.workingDirectory` (was cwd) → no orphaned ssh tunnel.
- **#741** — control node included in the SSH readiness wait under `--hosts`; superseded zombie SOCKS tunnels killed before replacement.
- **#823** — persist `/mnt/db1` NVMe mount across reboots (fstab XFS-UUID `nofail` + k3s `RequiresMountsFor`) → no k3s crash-loop after reboot.
- **#733** — stress otel-sidecar gets `CLUSTER_NAME` from cluster state, not the often-absent `cluster-config` ConfigMap → no `CreateContainerConfigError`.
- **#564** — per-node `spark-master`/`spark-worker` role tagging (collector was already on all nodes; hardcoded `node_role` was the bug).
- **#162** — `cassandra start` fails fast naming any version-less node.
- **#200** — `restart-cassandra-and-wait` detects startup failures instead of hanging / false-success.

## Invariant
#738/#741 never touch `socksProxyHost`/`socksProxyPort` — path resolution, readiness filtering, process lifecycle only (CLAUDE.md / #725).

## Validation
Unit + integration tests per fix; CI green (incl. detekt on JDK 21). Live-cluster validation in progress — reboot remount (#823), orphan-tunnel cleanup (#738/#741), stress pod start (#733), trino workers Ready + SELECT 1 (#827); EMR role tags (#564) need a separate spark cluster.

## Scope notes
- #162: `cassandra restart` has the same version exposure — possible follow-up.
- #564: the issue also mentioned a Grafana EMR dashboard restructure — out of scope.

## Live validation — 7/8 PASS, $0 (bug-wave @ 4429972f)
End-to-end on a real cluster built from this branch. **7 of 8 fixes proven live; #564 (EMR role tagging) code-verified only** (unit tests + review; separate EMR run to follow, non-gating).

- provision ✅ · #162 ✅ · #200 ✅ (bad JVM flag → failed fast 17s) · #733 ✅ (after Koin fix) · #827 P0 ✅ (workers Ready, `SELECT 1`) · #823 ✅ (UUID-keyed fstab survived a device rename nvme0n1→nvme1n1; k3s ordered `After mnt-db1.mount`) · #738/#741 ✅ (real orphan tunnel killed on `down`)
- Bugs surfaced during validation and folded into this PR: **#854** (stress/status Koin construction) and **#855** (tailscaled not boot-enabled).
- Teardown: 0 instances / VPCs / EIPs → $0.