### PR TITLE
feat(packer): bake Cilium ENI networkd config into base AMI; apply IMDS hop-limit 2 to all node types

### DIFF
--- a/packer/README.md
+++ b/packer/README.md
@@ -67,6 +67,16 @@ To manually rebuild:
 docker build -t easy-db-lab-packer-test .
 ```
 
+## Base AMI networking (Cilium ENI mode)
+
+Cilium ENI native-routing requires the OS to leave Cilium's runtime-attached secondary ENIs
+alone. `base/install/configure_cilium_eni_networkd.sh` bakes two systemd-networkd drop-ins into
+the image: `05-cilium-eni-primary.network` keeps the primary interface (`ens5`) OS-managed via
+DHCP, and `06-cilium-eni-unmanaged.network` marks secondary ENIs (`ens6+`) `Unmanaged=yes` so
+Cilium owns them. Without this the OS DHCPs `ens6` and adds a competing default route, multi-homing
+the host and breaking IMDS/egress/kubelet. The drop-ins are inert on Flannel (no secondary ENIs are
+ever attached) and are covered by `./gradlew testPackerBase`.
+
 ## Documentation
 
 See [TESTING.md](TESTING.md) for comprehensive testing documentation including:

--- a/packer/base/base.pkr.hcl
+++ b/packer/base/base.pkr.hcl
@@ -191,6 +191,13 @@ build {
     script = "install/install_cilium_cli.sh"
   }
 
+  # Leave Cilium's secondary ENIs (ens6+) unmanaged by systemd-networkd so the OS does not
+  # DHCP them and hijack host routing (see the script header for the full rationale). Inert on
+  # Flannel; must be baked in because the ENIs are attached at runtime.
+  provisioner "shell" {
+    script = "install/configure_cilium_eni_networkd.sh"
+  }
+
   # install OpenTelemetry Java agent for workload instrumentation
   provisioner "shell" {
     script = "install/install_otel_agent.sh"

--- a/packer/base/install/configure_cilium_eni_networkd.sh
+++ b/packer/base/install/configure_cilium_eni_networkd.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# Leave Cilium's secondary ENIs (ens6+) unmanaged by the OS network stack.
+#
+# WHY: In Cilium ENI IPAM native-routing mode the cilium-operator attaches a SECOND ENI
+# (ens6) to a node at runtime once it runs more than ~7 pods. On our Ubuntu Nitro image,
+# systemd-networkd (fed by cloud-init/netplan) then DHCPs ens6 and installs a COMPETING
+# default route. That multi-homes the host and breaks IMDS, egress, and the node's
+# kubelet->apiserver channel -> the node goes NotReady, observability pods never become
+# Ready, and `up` fails at GrafanaUpdateConfig. Cilium documents this exact requirement:
+# "AWS ENI" -> "Node Configuration" says the OS must NOT manage newly attached ENI devices
+# (https://docs.cilium.io -> Installation -> AWS ENI). We satisfy it by having networkd
+# fully own the PRIMARY interface (ens5) and mark every SECONDARY ENI (ens6+) Unmanaged so
+# Cilium owns them.
+#
+# PRECEDENCE (why the 05-/06- prefixes matter): cloud-init/netplan renders
+# /run/systemd/network/10-netplan-ens6.network which DHCPs ens6. systemd-networkd selects
+# the LEXICALLY-FIRST matching .network file per link across all config dirs, so our files
+# MUST sort before 10-netplan-*. The 05-/06- prefixes guarantee that; a 99- file would lose
+# and never take effect.
+#
+# ROBUSTNESS (why drop-ins in /etc, and why NOT disable cloud-init networking): the drop-ins
+# live in /etc/systemd/network so they persist in the baked image and survive reboots. Because
+# they sort ahead of 10-netplan-*, they win the first-match selection even if cloud-init
+# REGENERATES the 10-netplan-* files on a later boot -- a regenerated 10-netplan-ens6.network
+# can never override our 06- file. Crucially our own 05- file fully configures ens5 via DHCP,
+# so PRIMARY networking never depends on cloud-init's output. That is why we deliberately do
+# NOT disable cloud-init's network management (e.g. a 99-disable-network-config.cfg): doing so
+# risks breaking ens5 DHCP/SSH on a fresh instance if the baked netplan does not match the new
+# instance's interface, and buys us nothing the lexical precedence above does not already give.
+#
+# TIMING: ens6 is attached at RUNTIME (post-boot), so these drop-ins must PRE-EXIST in the
+# image. This therefore belongs in the BASE AMI provisioning, not a post-attach hook.
+#
+# INERT ON FLANNEL: the 06- match only hits ens6+, which only exist on Cilium ENI-IPAM nodes.
+# A Flannel cluster never attaches a secondary ENI, so 06- matches nothing there and is a
+# no-op. The 05- file just gives ens5 normal DHCP, which is what a Flannel node wants anyway.
+# Hence this is safe to bake unconditionally into the base AMI -- no CNI conditional needed.
+set -euo pipefail
+
+echo "=== Running: configure_cilium_eni_networkd.sh ==="
+
+NET_DIR="/etc/systemd/network"
+PRIMARY="${NET_DIR}/05-cilium-eni-primary.network"
+SECONDARY="${NET_DIR}/06-cilium-eni-unmanaged.network"
+
+sudo mkdir -p "${NET_DIR}"
+
+# Primary ENI (ens5): OS-managed via DHCP.
+sudo tee "${PRIMARY}" >/dev/null <<'EOF2'
+[Match]
+Name=ens5
+
+[Network]
+DHCP=ipv4
+EOF2
+
+# Secondary ENIs (ens6+): left Unmanaged so Cilium owns them.
+sudo tee "${SECONDARY}" >/dev/null <<'EOF2'
+[Match]
+Name=ens[6-9] ens[1-9][0-9]
+
+[Link]
+Unmanaged=yes
+EOF2
+
+sudo chmod 0644 "${PRIMARY}" "${SECONDARY}"
+
+# Self-verify: fail the build if either drop-in is missing or does not carry the load-bearing
+# directive. Keeps the packer script test (./gradlew testPackerBase) meaningful, since the
+# harness only checks the exit code.
+grep -q '^Name=ens5$' "${PRIMARY}"
+grep -q '^DHCP=ipv4$' "${PRIMARY}"
+grep -q '^Name=ens\[6-9\] ens\[1-9\]\[0-9\]$' "${SECONDARY}"
+grep -q '^Unmanaged=yes$' "${SECONDARY}"
+
+echo "✓ wrote ${PRIMARY} (ens5 OS-managed) and ${SECONDARY} (ens6+ Unmanaged)"
+echo "✓ configure_cilium_eni_networkd.sh completed successfully"

--- a/packer/docker-compose.yml
+++ b/packer/docker-compose.yml
@@ -41,6 +41,7 @@ services:
       bash /packer/base/install/install_helm.sh &&
       bash /packer/base/install/install_kubectl.sh &&
       bash /packer/base/install/install_cilium_cli.sh &&
+      bash /packer/base/install/configure_cilium_eni_networkd.sh &&
       bash /packer/base/install/install_otel_agent.sh &&
       echo 'Base provisioning complete!'
       "

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Init.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Init.kt
@@ -4,10 +4,12 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import com.rustyrazorblade.easydblab.annotations.McpCommand
 import com.rustyrazorblade.easydblab.annotations.RequireProfileSetup
 import com.rustyrazorblade.easydblab.commands.converters.PicoAZConverter
+import com.rustyrazorblade.easydblab.commands.converters.PicoCniModeConverter
 import com.rustyrazorblade.easydblab.commands.mixins.OpenSearchInitMixin
 import com.rustyrazorblade.easydblab.commands.mixins.SparkInitMixin
 import com.rustyrazorblade.easydblab.configuration.Arch
 import com.rustyrazorblade.easydblab.configuration.ClusterState
+import com.rustyrazorblade.easydblab.configuration.CniMode
 import com.rustyrazorblade.easydblab.configuration.InitConfig
 import com.rustyrazorblade.easydblab.configuration.User
 import com.rustyrazorblade.easydblab.events.Event
@@ -235,10 +237,14 @@ class Init : PicoBaseCommand() {
     var cidr: String? = null
 
     @Option(
-        names = ["--cilium"],
-        description = ["Install Cilium CNI instead of the default Flannel CNI"],
+        names = ["--cni"],
+        description = [
+            "Pod-network CNI: 'flannel' (default) uses K3s's built-in Flannel overlay; " +
+                "'cilium' uses Cilium (opt-in, installed in the standard VXLAN-tunnel mode).",
+        ],
+        converter = [PicoCniModeConverter::class],
     )
-    var cilium = false
+    var cni: CniMode = CniMode.Flannel
 
     /**
      * Resolved number of database instances: the namespaced `--db.count` when supplied, otherwise

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Up.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/Up.kt
@@ -12,6 +12,7 @@ import com.rustyrazorblade.easydblab.commands.tailscale.TailscaleStart
 import com.rustyrazorblade.easydblab.configuration.Arch
 import com.rustyrazorblade.easydblab.configuration.ClusterHost
 import com.rustyrazorblade.easydblab.configuration.ClusterState
+import com.rustyrazorblade.easydblab.configuration.CniMode
 import com.rustyrazorblade.easydblab.configuration.InfrastructureState
 import com.rustyrazorblade.easydblab.configuration.InitConfig
 import com.rustyrazorblade.easydblab.configuration.ServerType
@@ -711,7 +712,7 @@ class Up(
         // Configure registry TLS before K3s starts so registries.yaml is in place
         configureRegistryTls()
 
-        val ciliumEnabled = workingState.initConfig?.ciliumEnabled ?: false
+        val ciliumEnabled = workingState.initConfig?.cni == CniMode.Cilium
         val config =
             K3sClusterConfig(
                 controlHost = controlHosts.first(),

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/commands/converters/PicoCniModeConverter.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/commands/converters/PicoCniModeConverter.kt
@@ -1,0 +1,24 @@
+package com.rustyrazorblade.easydblab.commands.converters
+
+import com.rustyrazorblade.easydblab.configuration.CniMode
+import picocli.CommandLine.ITypeConverter
+import picocli.CommandLine.TypeConversionException
+
+/**
+ * PicoCLI converter for `--cni` values.
+ *
+ * Converts case-insensitive string input to a [CniMode] so users can pass the natural
+ * lowercase forms `cilium` / `flannel` rather than the PascalCase enum constant names.
+ *
+ * @throws TypeConversionException if the input is not a recognized CNI
+ */
+class PicoCniModeConverter : ITypeConverter<CniMode> {
+    override fun convert(value: String): CniMode =
+        when (value.lowercase().trim()) {
+            "cilium" -> CniMode.Cilium
+            "flannel" -> CniMode.Flannel
+            else -> throw TypeConversionException(
+                "Invalid CNI: $value. Must be cilium or flannel",
+            )
+        }
+}

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/ClusterState.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/configuration/ClusterState.kt
@@ -39,6 +39,19 @@ enum class InfrastructureStatus {
 }
 
 /**
+ * Container Network Interface (CNI) selection for the K3s pod network.
+ *
+ * The datapath is mutually exclusive by construction — a cluster runs exactly one CNI.
+ * [Flannel] is K3s's built-in VXLAN-overlay CNI (the current default). [Cilium] selects
+ * Cilium (see [com.rustyrazorblade.easydblab.services.CiliumService]). Modeled as an enum
+ * rather than a boolean so future datapaths can be added without another flag.
+ */
+enum class CniMode {
+    Cilium,
+    Flannel,
+}
+
+/**
  * EMR cluster state tracking for Spark jobs
  */
 data class EMRClusterState(
@@ -108,7 +121,7 @@ data class InitConfig(
     val opensearchVersion: String = "2.11",
     val opensearchEbsSize: Int = 100,
     val cidr: String? = null,
-    val ciliumEnabled: Boolean = false,
+    val cni: CniMode = CniMode.Flannel,
 ) {
     companion object {
         /**
@@ -164,7 +177,7 @@ data class InitConfig(
                 opensearchVersion = init.opensearch.version,
                 opensearchEbsSize = init.opensearch.ebsSize,
                 cidr = init.cidr,
-                ciliumEnabled = init.cilium,
+                cni = init.cni,
             )
     }
 }

--- a/src/main/kotlin/com/rustyrazorblade/easydblab/services/aws/EC2InstanceService.kt
+++ b/src/main/kotlin/com/rustyrazorblade/easydblab/services/aws/EC2InstanceService.kt
@@ -142,17 +142,17 @@ class EC2InstanceService(
             requestBuilder.blockDeviceMappings(blockDeviceMappings)
         }
 
-        // Control nodes need hop limit of 2 so containers (K3s pods) can access IMDS
-        if (config.serverType == ServerType.Control) {
-            requestBuilder.metadataOptions(
-                InstanceMetadataOptionsRequest
-                    .builder()
-                    .httpTokens(HttpTokensState.REQUIRED)
-                    .httpPutResponseHopLimit(2)
-                    .httpEndpoint("enabled")
-                    .build(),
-            )
-        }
+        // All node types need hop limit of 2 so containers (K3s pods) can access IMDS.
+        // In particular the non-hostNetwork cilium-operator pod may schedule on a db/app
+        // node and must reach IMDS to obtain credentials for ENI allocation.
+        requestBuilder.metadataOptions(
+            InstanceMetadataOptionsRequest
+                .builder()
+                .httpTokens(HttpTokensState.REQUIRED)
+                .httpPutResponseHopLimit(2)
+                .httpEndpoint("enabled")
+                .build(),
+        )
 
         val request = requestBuilder.build()
 

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/commands/InitTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/commands/InitTest.kt
@@ -2,6 +2,7 @@ package com.rustyrazorblade.easydblab.commands
 
 import com.rustyrazorblade.easydblab.BaseKoinTest
 import com.rustyrazorblade.easydblab.configuration.ClusterStateManager
+import com.rustyrazorblade.easydblab.configuration.CniMode
 import com.rustyrazorblade.easydblab.output.BufferedOutputHandler
 import com.rustyrazorblade.easydblab.output.OutputHandler
 import com.rustyrazorblade.easydblab.services.TemplateService
@@ -301,6 +302,32 @@ class InitTest : BaseKoinTest() {
             // save is called twice: once in prepareEnvironment, once after setting VPC
             verify(mockClusterStateManager, atLeastOnce()).save(
                 argThat { vpcId == "vpc-existing123" },
+            )
+        }
+    }
+
+    @Nested
+    inner class CniOptions {
+        @Test
+        fun `execute persists Flannel as the default cni when --cni is omitted`() {
+            val command = Init()
+            command.clean = true
+            command.execute()
+
+            verify(mockClusterStateManager).save(
+                argThat { initConfig?.cni == CniMode.Flannel },
+            )
+        }
+
+        @Test
+        fun `execute persists Cilium when cni is set to Cilium`() {
+            val command = Init()
+            command.clean = true
+            command.cni = CniMode.Cilium
+            command.execute()
+
+            verify(mockClusterStateManager).save(
+                argThat { initConfig?.cni == CniMode.Cilium },
             )
         }
     }

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/commands/UpTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/commands/UpTest.kt
@@ -6,6 +6,7 @@ import com.rustyrazorblade.easydblab.configuration.Arch
 import com.rustyrazorblade.easydblab.configuration.ClusterHost
 import com.rustyrazorblade.easydblab.configuration.ClusterState
 import com.rustyrazorblade.easydblab.configuration.ClusterStateManager
+import com.rustyrazorblade.easydblab.configuration.CniMode
 import com.rustyrazorblade.easydblab.configuration.Host
 import com.rustyrazorblade.easydblab.configuration.InitConfig
 import com.rustyrazorblade.easydblab.configuration.ServerType
@@ -21,6 +22,7 @@ import com.rustyrazorblade.easydblab.services.ClusterConfigurationService
 import com.rustyrazorblade.easydblab.services.ClusterProvisioningService
 import com.rustyrazorblade.easydblab.services.CommandExecutor
 import com.rustyrazorblade.easydblab.services.HostOperationsService
+import com.rustyrazorblade.easydblab.services.K3sClusterConfig
 import com.rustyrazorblade.easydblab.services.K3sClusterService
 import com.rustyrazorblade.easydblab.services.K3sSetupResult
 import com.rustyrazorblade.easydblab.services.K8sService
@@ -43,6 +45,7 @@ import org.junit.jupiter.api.Test
 import org.koin.core.module.Module
 import org.koin.dsl.module
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
@@ -72,6 +75,7 @@ class UpTest : BaseKoinTest() {
     private lateinit var mockClusterProvisioningService: ClusterProvisioningService
     private lateinit var mockClusterConfigurationService: ClusterConfigurationService
     private lateinit var mockK3sClusterService: K3sClusterService
+    private lateinit var mockCiliumService: CiliumService
     private lateinit var mockK8sService: K8sService
     private lateinit var mockCommandExecutor: CommandExecutor
     private lateinit var outputHandler: BufferedOutputHandler
@@ -115,7 +119,7 @@ class UpTest : BaseKoinTest() {
                 single<ClusterProvisioningService> { mock<ClusterProvisioningService>().also { mockClusterProvisioningService = it } }
                 single<ClusterConfigurationService> { mock<ClusterConfigurationService>().also { mockClusterConfigurationService = it } }
                 single<K3sClusterService> { mock<K3sClusterService>().also { mockK3sClusterService = it } }
-                single<CiliumService> { mock<CiliumService>() }
+                single<CiliumService> { mock<CiliumService>().also { mockCiliumService = it } }
                 single<K8sService> { mock<K8sService>().also { mockK8sService = it } }
                 single<RegistryService> { mock<RegistryService>() }
                 single<SocksProxyService> { mock<SocksProxyService>() }
@@ -189,6 +193,7 @@ class UpTest : BaseKoinTest() {
         mockClusterProvisioningService = getKoin().get()
         mockClusterConfigurationService = getKoin().get()
         mockK3sClusterService = getKoin().get()
+        mockCiliumService = getKoin().get()
         mockK8sService = getKoin().get()
         mockCommandExecutor = getKoin().get()
         outputHandler = getKoin().get<OutputHandler>() as BufferedOutputHandler
@@ -228,6 +233,7 @@ class UpTest : BaseKoinTest() {
             .thenReturn(Result.success(Unit))
 
         whenever(mockK3sClusterService.setupCluster(any())).thenReturn(K3sSetupResult(serverStarted = true))
+        whenever(mockCiliumService.install(any())).thenReturn(Result.success(Unit))
 
         whenever(mockK8sService.labelNode(any(), any(), any())).thenReturn(Result.success(Unit))
         whenever(mockK8sService.ensureLocalStorageClass(any())).thenReturn(Result.success(Unit))
@@ -302,6 +308,43 @@ class UpTest : BaseKoinTest() {
         verify(mockK8sService).labelNode(eq(testControlHost), eq("app0"), any())
         verify(mockK8sService).ensureLocalStorageClass(eq(testControlHost))
         verify(mockK8sService).ensureLocalStorageWfcClass(eq(testControlHost))
+    }
+
+    // =========================================================================
+    // Group: CNI selection (`--cni`, replacing the old `--cilium` boolean)
+    // =========================================================================
+
+    @Test
+    fun `up starts K3s with Flannel by default and never installs Cilium`() {
+        assertThatCode { newUp().execute() }.doesNotThrowAnyException()
+
+        val configCaptor = argumentCaptor<K3sClusterConfig>()
+        verify(mockK3sClusterService).setupCluster(configCaptor.capture())
+        assertThat(configCaptor.firstValue.useCustomCni).isFalse()
+        assertThat(configCaptor.firstValue.onServerReady == null).isTrue()
+
+        verify(mockCiliumService, never()).install(any())
+    }
+
+    @Test
+    fun `up starts K3s with a custom CNI and installs Cilium via onServerReady when cni is Cilium`() {
+        val ciliumState = happyState()
+        whenever(mockClusterStateManager.load()).thenReturn(
+            ciliumState.copy(initConfig = ciliumState.initConfig?.copy(cni = CniMode.Cilium)),
+        )
+
+        assertThatCode { newUp().execute() }.doesNotThrowAnyException()
+
+        val configCaptor = argumentCaptor<K3sClusterConfig>()
+        verify(mockK3sClusterService).setupCluster(configCaptor.capture())
+        val config = configCaptor.firstValue
+        assertThat(config.useCustomCni).isTrue()
+
+        val onServerReady = config.onServerReady
+        assertThat(onServerReady == null).isFalse()
+        onServerReady?.invoke()
+
+        verify(mockCiliumService).install(testControlHost.toHost())
     }
 
     // =========================================================================

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/commands/converters/PicoCniModeConverterTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/commands/converters/PicoCniModeConverterTest.kt
@@ -1,0 +1,63 @@
+package com.rustyrazorblade.easydblab.commands.converters
+
+import com.rustyrazorblade.easydblab.configuration.CniMode
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import picocli.CommandLine.TypeConversionException
+
+class PicoCniModeConverterTest {
+    private val converter = PicoCniModeConverter()
+
+    @Test
+    fun `converts cilium to CniMode Cilium`() {
+        val result = converter.convert("cilium")
+        assertThat(result).isEqualTo(CniMode.Cilium)
+    }
+
+    @Test
+    fun `converts flannel to CniMode Flannel`() {
+        val result = converter.convert("flannel")
+        assertThat(result).isEqualTo(CniMode.Flannel)
+    }
+
+    @Test
+    fun `handles uppercase input`() {
+        assertThat(converter.convert("CILIUM")).isEqualTo(CniMode.Cilium)
+        assertThat(converter.convert("FLANNEL")).isEqualTo(CniMode.Flannel)
+    }
+
+    @Test
+    fun `handles mixed case input`() {
+        assertThat(converter.convert("Cilium")).isEqualTo(CniMode.Cilium)
+        assertThat(converter.convert("FlAnNeL")).isEqualTo(CniMode.Flannel)
+    }
+
+    @Test
+    fun `trims whitespace from input`() {
+        assertThat(converter.convert("  cilium  ")).isEqualTo(CniMode.Cilium)
+        assertThat(converter.convert("\tflannel\t")).isEqualTo(CniMode.Flannel)
+    }
+
+    @Test
+    fun `throws TypeConversionException for invalid CNI`() {
+        assertThatThrownBy { converter.convert("calico") }
+            .isInstanceOf(TypeConversionException::class.java)
+            .hasMessageContaining("Invalid CNI: calico")
+            .hasMessageContaining("cilium or flannel")
+    }
+
+    @Test
+    fun `throws TypeConversionException for empty input`() {
+        assertThatThrownBy { converter.convert("") }
+            .isInstanceOf(TypeConversionException::class.java)
+            .hasMessageContaining("Invalid CNI")
+    }
+
+    @Test
+    fun `throws TypeConversionException for whitespace-only input`() {
+        assertThatThrownBy { converter.convert("   ") }
+            .isInstanceOf(TypeConversionException::class.java)
+            .hasMessageContaining("Invalid CNI")
+    }
+}

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/services/aws/EC2InstanceServiceTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/services/aws/EC2InstanceServiceTest.kt
@@ -6,6 +6,8 @@ import com.rustyrazorblade.easydblab.providers.aws.InstanceCreationConfig
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.mock
@@ -17,6 +19,7 @@ import software.amazon.awssdk.services.ec2.model.DescribeInstanceTypesRequest
 import software.amazon.awssdk.services.ec2.model.DescribeInstanceTypesResponse
 import software.amazon.awssdk.services.ec2.model.DescribeInstancesRequest
 import software.amazon.awssdk.services.ec2.model.DescribeInstancesResponse
+import software.amazon.awssdk.services.ec2.model.HttpTokensState
 import software.amazon.awssdk.services.ec2.model.Instance
 import software.amazon.awssdk.services.ec2.model.InstanceState
 import software.amazon.awssdk.services.ec2.model.InstanceStateName
@@ -378,6 +381,51 @@ internal class EC2InstanceServiceTest {
         // - Second instance (instanceIndex=4): subnet[4 % 3] = subnet-b
         assertThat(capturedRequests[0].subnetId()).isEqualTo("subnet-a")
         assertThat(capturedRequests[1].subnetId()).isEqualTo("subnet-b")
+    }
+
+    @ParameterizedTest
+    @EnumSource(ServerType::class)
+    fun `createInstances requires IMDSv2 with hop limit 2 for every node type`(serverType: ServerType) {
+        // The non-hostNetwork cilium-operator can schedule on a db or app node and must reach
+        // IMDS (two hops from inside a pod) to obtain credentials for ENI allocation. Previously
+        // only Control nodes received hop limit 2, which deadlocked ENI IPAM.
+        val config =
+            InstanceCreationConfig(
+                serverType = serverType,
+                count = 1,
+                instanceType = "m5.large",
+                amiId = "ami-123",
+                keyName = "test-key",
+                securityGroupId = "sg-123",
+                subnetIds = listOf("subnet-a"),
+                iamInstanceProfile = "test-profile",
+                ebsConfig = null,
+                tags = mapOf("easy_cass_lab" to "1"),
+                clusterName = "test-cluster",
+                startIndex = 0,
+            )
+
+        val mockInstance =
+            Instance
+                .builder()
+                .instanceId("i-test")
+                .publicIpAddress("1.2.3.4")
+                .privateIpAddress("10.0.0.1")
+                .placement(Placement.builder().availabilityZone("us-east-1a").build())
+                .build()
+
+        whenever(mockEc2Client.runInstances(any<RunInstancesRequest>()))
+            .thenReturn(RunInstancesResponse.builder().instances(mockInstance).build())
+
+        ec2InstanceService.createInstances(config)
+
+        val requestCaptor = argumentCaptor<RunInstancesRequest>()
+        verify(mockEc2Client).runInstances(requestCaptor.capture())
+
+        val metadataOptions = requestCaptor.firstValue.metadataOptions()
+        assertThat(metadataOptions).isNotNull
+        assertThat(metadataOptions.httpPutResponseHopLimit()).isEqualTo(2)
+        assertThat(metadataOptions.httpTokens()).isEqualTo(HttpTokensState.REQUIRED)
     }
 
     @Test


### PR DESCRIPTION
Closes #857

This extracts three safe, decoupled pieces from the in-progress #805 Cilium ENI native-routing work (PR #820) so they can land now, independently of that still-under-validation effort. Nothing else from #805/#820 is included here.

## 1. Bake Cilium ENI networkd config into the base AMI

New `packer/base/install/configure_cilium_eni_networkd.sh`, wired into `packer/base/base.pkr.hcl` (packer provisioner) and `packer/docker-compose.yml` (local script testing), plus a new `packer/README.md` section.

In Cilium ENI IPAM native-routing mode, the cilium-operator attaches a second ENI (`ens6`) to a node at runtime once it runs enough pods. Without this change, systemd-networkd (fed by cloud-init/netplan) DHCPs that secondary ENI and installs a competing default route, multi-homing the host and breaking IMDS/egress/kubelet. The script bakes two systemd-networkd drop-ins into the image: `05-cilium-eni-primary.network` keeps `ens5` OS-managed via DHCP, and `06-cilium-eni-unmanaged.network` marks `ens6+` `Unmanaged=yes` so Cilium owns them. It's a no-op on Flannel clusters, which never attach a secondary ENI, so it's safe to bake in unconditionally.

## 2. IMDS hop-limit 2 for all node types

`EC2InstanceService` previously only set `httpPutResponseHopLimit(2)` for Control nodes. The non-hostNetwork cilium-operator pod can schedule on a db or app node and needs two hops to reach IMDS for ENI-allocation credentials, so this now applies to every `ServerType`. Independently correct for IMDSv2 regardless of the CNI-selection feature landing later.

Covered by `EC2InstanceServiceTest` (parameterized over every `ServerType`) and `./gradlew testPackerBase`.

## 3. `--cni=<cilium|flannel>` flag (replaces the old `--cilium` boolean)

Pure CLI flag surface, no behavior change beyond how the flag is spelled and stored:

- New `CniMode` enum (`Cilium` / `Flannel`) in `configuration/ClusterState.kt`, replacing `InitConfig.ciliumEnabled: Boolean` with `InitConfig.cni: CniMode` (default `Flannel`).
- New `PicoCniModeConverter` for case-insensitive `--cni` parsing.
- `Init.kt`: `--cni` replaces `--cilium`.
- `Up.kt`: reads `initConfig?.cni == CniMode.Cilium` instead of the old boolean.

Cilium continues to install exactly as it does on `main` today — the existing single-argument, VXLAN-tunnel-mode `CiliumService.install(controlHost)` call is unchanged. Only the flag syntax and the persisted state field changed; the ENI native-routing install logic itself stays exclusively on #805/PR #820, still on hold.

Covered by `PicoCniModeConverterTest`, and adapted `InitTest`/`UpTest` cases asserting the `cni` field persists correctly and that `up` still installs Cilium via the existing `onServerReady` callback when `cni == Cilium`.