### PR TITLE
ci: add rustyrazorblade/cassandra-6.0-rustyrazorblade fork to the nightly build matrix

### DIFF
--- a/.github/workflows/build-cassandra-set.yml
+++ b/.github/workflows/build-cassandra-set.yml
@@ -1,10 +1,11 @@
 name: Build Cassandra Set
 
-# Nightly build of the set of Apache Cassandra versions the lab tracks.
+# Nightly build of the set of Cassandra versions/forks the lab tracks.
 #
 # Replaces the old hand-rolled nightly-cassandra-build.yml (JDK 11 for all, tarball
 # only, no 6.0). This drives the reusable build-cassandra-ref.yml engine once per
-# version, so every version gets:
+# matrix entry (each with its own source `repo`, defaulting to apache/cassandra but
+# overridable per entry for forks), so every entry gets:
 #   1. The correct per-version build JDK + runtime base image (auto-mapped in
 #      resolve-build-plan.sh: 5.0 -> JDK 17, 6.0/trunk -> JDK 21).
 #   2. BOTH artifacts — a GHCR container image (moving `:cassandra-<ref>` tag +
@@ -43,14 +44,25 @@ jobs:
           # Actions stringifies to "6", producing apache-cassandra-6-bin.tar.gz
           # instead of the apache-cassandra-6.0-HEAD-bin.tar.gz the versions file
           # references — so keep every version quoted regardless.
-          - ref: cassandra-5.0
+          #
+          # `repo` is explicit on every entry (rather than relying on the reusable
+          # workflow's own apache/cassandra default) so the matrix stays
+          # self-documenting now that not every entry is from apache/cassandra.
+          - repo: apache/cassandra
+            ref: cassandra-5.0
             version: "5.0-HEAD"
-          - ref: cassandra-6.0
+          - repo: apache/cassandra
+            ref: cassandra-6.0
             version: "6.0-HEAD"
-          - ref: trunk
+          - repo: apache/cassandra
+            ref: trunk
             version: "trunk"
+          - repo: rustyrazorblade/cassandra
+            ref: cassandra-6.0-rustyrazorblade
+            version: "6.0-rustyrazorblade-HEAD"
     uses: ./.github/workflows/build-cassandra-ref.yml
     with:
+      repo: ${{ matrix.repo }}
       ref: ${{ matrix.ref }}
       stable_version: ${{ matrix.version }}
     secrets: inherit
@@ -124,9 +136,10 @@ jobs:
             reusable `build-cassandra-ref.yml` engine. Matching GHCR container images
             are published under the moving `:cassandra-<ref>` tag.
 
-            - **5.0-HEAD**: Latest from `cassandra-5.0` branch
-            - **6.0-HEAD**: Latest from `cassandra-6.0` branch
-            - **trunk**: Latest from `trunk` branch
+            - **5.0-HEAD**: Latest from `cassandra-5.0` branch (apache/cassandra)
+            - **6.0-HEAD**: Latest from `cassandra-6.0` branch (apache/cassandra)
+            - **trunk**: Latest from `trunk` branch (apache/cassandra)
+            - **6.0-rustyrazorblade-HEAD**: Latest from `cassandra-6.0-rustyrazorblade` branch (rustyrazorblade/cassandra fork)
 
             ### Stable Download URLs
 
@@ -136,6 +149,7 @@ jobs:
             https://github.com/${{ github.repository }}/releases/download/nightly/apache-cassandra-5.0-HEAD-bin.tar.gz
             https://github.com/${{ github.repository }}/releases/download/nightly/apache-cassandra-6.0-HEAD-bin.tar.gz
             https://github.com/${{ github.repository }}/releases/download/nightly/apache-cassandra-trunk-bin.tar.gz
+            https://github.com/${{ github.repository }}/releases/download/nightly/apache-cassandra-6.0-rustyrazorblade-HEAD-bin.tar.gz
             ```
 
             ### Build Information

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -196,7 +196,7 @@ easy-db-lab cassandra use <version> [options]
 | `--java` | Java version to use |
 | `--hosts` | Filter to specific hosts |
 
-Versions: 3.0, 3.11, 4.0, 4.1, 5.0, 5.0-HEAD, 6.0-HEAD, trunk
+Versions: 3.0, 3.11, 4.0, 4.1, 5.0, 5.0-HEAD, 6.0-HEAD, 6.0-rustyrazorblade, trunk
 
 ### cassandra write-config
 

--- a/docs/user-guide/installing-cassandra.md
+++ b/docs/user-guide/installing-cassandra.md
@@ -15,6 +15,7 @@ easy-db-lab supports the following Cassandra versions:
 | 5.0 | 11 | **Latest stable (recommended)** |
 | 5.0-HEAD | 11 | Nightly build from 5.0 branch |
 | 6.0-HEAD | 21 | Nightly build from 6.0 branch |
+| 6.0-rustyrazorblade | 21 | Personal fork build (rustyrazorblade/cassandra, branch cassandra-6.0-rustyrazorblade) |
 | trunk | 17 | Development branch |
 
 ## Quick Start

--- a/docs/user-guide/tutorial.md
+++ b/docs/user-guide/tutorial.md
@@ -161,7 +161,7 @@ This command:
 - Downloads configuration files to your local directory
 - Applies any existing patch configuration
 
-Available versions: 3.0, 3.11, 4.0, 4.1, 5.0, 5.0-HEAD, 6.0-HEAD, trunk
+Available versions: 3.0, 3.11, 4.0, 4.1, 5.0, 5.0-HEAD, 6.0-HEAD, 6.0-rustyrazorblade, trunk
 
 ### Step 2: Customize Configuration (Optional)
 

--- a/packer/cassandra/cassandra_versions.yaml
+++ b/packer/cassandra/cassandra_versions.yaml
@@ -33,6 +33,12 @@
   java: "21"
   python: "3.11.9"
 
+- version: "6.0-rustyrazorblade"
+  java: "21"
+  python: "3.11.9"
+  url: "https://github.com/rustyrazorblade/cassandra.git"
+  branch: "cassandra-6.0-rustyrazorblade"
+
 - version: "trunk"
   url: https://github.com/rustyrazorblade/easy-db-lab/releases/download/nightly/apache-cassandra-trunk-bin.tar.gz
   java: "21"

--- a/packer/cassandra/cassandra_versions.yaml
+++ b/packer/cassandra/cassandra_versions.yaml
@@ -34,10 +34,9 @@
   python: "3.11.9"
 
 - version: "6.0-rustyrazorblade"
+  url: https://github.com/rustyrazorblade/easy-db-lab/releases/download/cassandra-6.0-alpha2-8c88f0159960/apache-cassandra-6.0-alpha2-8c88f0159960-bin.tar.gz
   java: "21"
   python: "3.11.9"
-  url: "https://github.com/rustyrazorblade/cassandra.git"
-  branch: "cassandra-6.0-rustyrazorblade"
 
 - version: "trunk"
   url: https://github.com/rustyrazorblade/easy-db-lab/releases/download/nightly/apache-cassandra-trunk-bin.tar.gz


### PR DESCRIPTION
## Summary
- Add an explicit `repo:` field to all 3 existing matrix entries (previously implicit `apache/cassandra` default) so the matrix is self-documenting once entries diverge.
- Add a 4th matrix entry: repo `rustyrazorblade/cassandra`, ref `cassandra-6.0-rustyrazorblade`, stable_version `6.0-rustyrazorblade-HEAD`.
- Update the `publish-nightly` release notes body to list the new build in both the tracked-build bullet list and the Stable Download URLs block.

Validated by manually dispatching the reusable `build-cassandra-ref.yml` engine directly against the fork (repo=rustyrazorblade/cassandra, ref=cassandra-6.0-rustyrazorblade) — build + Docker image + CQL smoke test all passed: https://github.com/rustyrazorblade/easy-db-lab/actions/runs/30406460393

## Second commit: wire the fork into the lab's own AMI-bake install path
- Add a `version: "6.0-rustyrazorblade"` entry to `packer/cassandra/cassandra_versions.yaml` (java 21, python 3.11.9), pointing `url`/`branch` at `rustyrazorblade/cassandra` / `cassandra-6.0-rustyrazorblade`.
- This is a distinct concern from the GitHub Actions matrix above: it lets `install_cassandra.sh` git-clone and `ant`-build this branch directly when baking the lab's Cassandra AMI (`easy-db-lab build-cassandra`), the same git-build mechanism already used for custom builds documented in `docs/user-guide/installing-cassandra.md`.
- Validated structurally only (YAML parses, no `version` key collision with existing entries). No AMI bake was run as part of this change — that's a separate, deliberately deferred step.

## Third commit: document the new version in the supported-versions table
- Add `6.0-rustyrazorblade` to the "Supported Versions" table in `docs/user-guide/installing-cassandra.md`, positioned after `6.0-HEAD`, labeled as a personal fork build (not an official/nightly build) to avoid confusion with the `6.0-HEAD` nightly row above it.
- Update the two other docs pages that enumerate the same closed version list (`docs/user-guide/tutorial.md`, `docs/reference/commands.md`) so they stay consistent with the table.
