### PR TITLE
docs(sysbench kit): document that --rate far above capacity queue-full aborts

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -323,6 +323,16 @@ tasks.withType<Test>().configureEach {
     }
 }
 
+// SysbenchFlagsDocumentedTest reads this user-guide page off the filesystem to check it
+// documents every kit.yaml flag. Gradle can't infer that dependency, so without declaring it
+// an edit that drops a flag row would be masked by an up-to-date or cached test result.
+tasks.named<Test>("test") {
+    inputs
+        .file("docs/user-guide/sysbench.md")
+        .withPropertyName("sysbenchUserGuide")
+        .withPathSensitivity(PathSensitivity.RELATIVE)
+}
+
 // `./gradlew check` must run BOTH tiers; `./gradlew test` stays UNIT-ONLY (fast, no Docker).
 tasks.named("check") {
     dependsOn(testing.suites.named("integrationTest"))

--- a/docs/user-guide/sysbench.md
+++ b/docs/user-guide/sysbench.md
@@ -44,6 +44,9 @@ cross-kit targeting works.
 | `--workload` | `oltp_read_write` | sysbench built-in workload (`oltp_read_write`, `oltp_read_only`, `oltp_write_only`) |
 | `--scale` | `10` | Number of rows per table, in thousands |
 | `--tables` | `10` | Number of tables |
+| `--rate` | `0` | Target transactions/sec (`0` = unlimited, thread-bound). See [Rate limiting and overload testing](#rate-limiting-and-overload-testing) |
+| `--skip-trx` | `off` | Run statements in autocommit instead of `BEGIN`/`COMMIT` transactions (`on`/`off`) |
+| `--rand-type` | `special` | Key access distribution: `uniform`, `gaussian`, `special`, or `pareto` |
 
 Flags other than `--target` are baked in at install time and apply to every subsequent
 `prepare`/`start`/`stop`. To change them, reinstall the kit.
@@ -84,6 +87,34 @@ easy-db-lab sysbench-tidb stop
 
 Kills any running benchmark pod and runs sysbench cleanup, dropping the test tables from
 the target database.
+
+## Rate limiting and overload testing
+
+By default (`--rate=0`) sysbench is thread-bound: each of the `--threads` worker threads
+issues transactions as fast as the target will answer them, so throughput settles at
+whatever the database can sustain. Setting `--rate` to a non-zero value switches sysbench
+to a fixed target rate — it generates events on a schedule of that many transactions per
+second and hands them to the worker threads, regardless of how fast the target is
+actually responding.
+
+That distinction matters when the requested rate exceeds what the target can sustain. The
+generated events queue up faster than the workers can drain them, sysbench's internal
+event queue fills, and the run hard-aborts with:
+
+```
+FATAL: event queue is full
+```
+
+This typically happens within the first few seconds, so a `--rate` set well above capacity
+does not produce a sustained high-latency window — it produces a run that dies almost
+immediately with no useful results.
+
+For overload and latency testing, drive the target past its limit with concurrency instead
+of with a target rate: leave `--rate=0` and raise `--threads` until latency climbs. A
+thread-bound run applies backpressure naturally — slower responses mean fewer transactions
+issued — so it degrades into a high-latency window rather than aborting. If you do want a
+fixed rate, first measure the target's sustainable throughput with a thread-bound run, then
+set `--rate` at or just above that measured number rather than far above it.
 
 ## Comparing Databases
 

--- a/docs/user-guide/sysbench.md
+++ b/docs/user-guide/sysbench.md
@@ -48,8 +48,13 @@ cross-kit targeting works.
 | `--skip-trx` | `off` | Run statements in autocommit instead of `BEGIN`/`COMMIT` transactions (`on`/`off`) |
 | `--rand-type` | `special` | Key access distribution: `uniform`, `gaussian`, `special`, or `pareto` |
 
-Flags other than `--target` are baked in at install time and apply to every subsequent
-`prepare`/`start`/`stop`. To change them, reinstall the kit.
+`--target` is baked in at install time — to point sysbench at a different database, install
+another instance. Every other flag is passed per invocation, so you can vary them run to run
+without reinstalling:
+
+```bash
+easy-db-lab sysbench-tidb start --threads 32 --rate 2000
+```
 
 ## Lifecycle
 
@@ -105,14 +110,23 @@ event queue fills, and the run hard-aborts with:
 FATAL: event queue is full
 ```
 
-This typically happens within the first few seconds, so a `--rate` set well above capacity
-does not produce a sustained high-latency window — it produces a run that dies almost
-immediately with no useful results.
+The abort is fast — under 15 seconds into the run in the case that prompted this section,
+regardless of the `--duration` you asked for. A `--rate` set well above capacity does not
+produce a sustained high-latency window; it produces a run that dies almost immediately
+with no useful results.
+
+An aborted run is easy to miss after the fact, because it does not look like a failure
+downstream. `last-run.txt` holds only the seeded parameter header with no `SQL statistics`
+block, and the run's p50/p95/p99 series on the Grafana dashboard flatline at 0 — which
+reads as a suspiciously excellent result rather than a crash. If latency drops to zero and
+the summary is truncated, check the pod output for the `FATAL` line.
 
 For overload and latency testing, drive the target past its limit with concurrency instead
 of with a target rate: leave `--rate=0` and raise `--threads` until latency climbs. A
 thread-bound run applies backpressure naturally — slower responses mean fewer transactions
-issued — so it degrades into a high-latency window rather than aborting. If you do want a
+issued — so it degrades into a high-latency window instead of overflowing the event queue.
+It is not immune to aborting for other reasons: sysbench still exits on unhandled SQL
+errors, which a heavily overloaded target is more likely to return. If you do want a
 fixed rate, first measure the target's sustainable throughput with a thread-bound run, then
 set `--rate` at or just above that measured number rather than far above it.
 

--- a/docs/user-guide/sysbench.md
+++ b/docs/user-guide/sysbench.md
@@ -53,7 +53,7 @@ another instance. Every other flag is passed per invocation, so you can vary the
 without reinstalling:
 
 ```bash
-easy-db-lab sysbench-tidb start --threads 32 --rate 2000
+easy-db-lab sysbench-tidb start --threads 32 --duration 300
 ```
 
 ## Lifecycle

--- a/openspec/changes/issue-839/.openspec.yaml
+++ b/openspec/changes/issue-839/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-05

--- a/openspec/changes/issue-839/design.md
+++ b/openspec/changes/issue-839/design.md
@@ -16,7 +16,7 @@ Found during the TiDB×sysbench load-test investigation (2026-07-21); see issue 
 
 **Goals:**
 - Make the hard-abort-on-overflow behavior discoverable *before* a user hits it, via both
-  `kit info sysbench` output (kit.yaml description text) and the user guide.
+  `sysbench-<target> start --help` output (kit.yaml description text) and the user guide.
 - Recommend a concrete alternative for overload/latency testing: thread-bound runs
   (`--rate=0` with a chosen `--threads`) or a rate deliberately set closer to measured
   capacity.
@@ -54,9 +54,12 @@ detection — a documentation problem, not a code problem.
 
 **Decision: document in both `kit.yaml` and the user guide, not just one.**
 
-`kit.yaml`'s `--rate` `description` is rendered verbatim as CLI help text by `kit info
-sysbench` (`KitInfo.kt`) — it's the first place a user sees the flag, so it carries a short
-warning. `docs/user-guide/sysbench.md` carries the fuller explanation (why it aborts instead
+`kit.yaml`'s `--rate` `description` is rendered verbatim as picocli help text on the
+installed instance's start command — `sysbench-<target> start --help` — via
+`KitRunnerCommandFactory.argOptionSpec`. (Note: `kit info sysbench` does *not* show it;
+`KitInfo.buildInfoText` renders only top-level `config.args`, and `--rate` lives under
+`commands.start.args`.) The start command's help is where a user sees the flag while
+choosing a value, so it carries a short warning. `docs/user-guide/sysbench.md` carries the fuller explanation (why it aborts instead
 of degrading, and the recommended alternative) plus the completed Flags table. Putting the
 full explanation only in one place would leave the other as a dead end for users who land
 there first.

--- a/openspec/changes/issue-839/design.md
+++ b/openspec/changes/issue-839/design.md
@@ -1,0 +1,91 @@
+## Context
+
+The sysbench kit's `start.sh.template` passes `--rate="${RATE}"` straight through to the
+`sysbench` binary running in a k8s pod (`kits/sysbench/bin/start.sh.template:37-47`). When
+`--rate` is set well above what the target database can sustain, sysbench's own internal
+rate-limiter event queue overflows and the process hard-aborts with `FATAL: event queue is
+full` in under 15 seconds. This is sysbench's own behavior — easy-db-lab neither computes
+nor controls it. The kit's docs (`docs/user-guide/sysbench.md`) and CLI help text
+(`kit.yaml`) currently say nothing about this, and the Flags table in the docs is also
+missing `--rate`, `--skip-trx`, and `--rand-type` entirely (all three are real `start` args
+in `kit.yaml` today).
+
+Found during the TiDB×sysbench load-test investigation (2026-07-21); see issue #839.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make the hard-abort-on-overflow behavior discoverable *before* a user hits it, via both
+  `kit info sysbench` output (kit.yaml description text) and the user guide.
+- Recommend a concrete alternative for overload/latency testing: thread-bound runs
+  (`--rate=0` with a chosen `--threads`) or a rate deliberately set closer to measured
+  capacity.
+- Close the pre-existing Flags table gap (`--rate`/`--skip-trx`/`--rand-type` missing)
+  while already editing that table.
+
+**Non-Goals:**
+- No validation, pre-flight capacity checks, or rate/threads heuristics — see Decisions
+  below for why this was explicitly rejected.
+- No change to `start.sh.template`'s runtime behavior — sysbench's own error message
+  remains the only in-terminal signal of the abort; this change only prepares the user to
+  recognize and act on it, not to intercept it.
+- No change to how `--rate` is parsed, validated, or passed to sysbench.
+
+## Decisions
+
+**Decision: documentation-only, no runtime/validation code (owner-approved).**
+
+Two options were considered:
+- **Docs only (chosen)**: update `kit.yaml`'s `--rate` description and
+  `docs/user-guide/sysbench.md` to explain the behavior and recommend alternatives. No code
+  changes.
+- **Docs + runtime hint**: additionally pattern-match the literal `"FATAL: event queue is
+  full"` line in `start.sh.template`'s log-streaming loop and echo a hint pointing at the
+  docs.
+
+The owner chose docs-only. Rationale: the precise threshold at which `--rate` overflows the
+queue depends on live target capacity (hardware, workload mix, network) and sysbench's own
+internal queue-sizing, which is not stable across sysbench versions and not derivable from
+`--rate`/`--threads` alone at kit-config time — any pre-flight heuristic would be a guess
+that risks false-positives blocking exactly the overload tests users are trying to run
+(the whole point of overload testing is not knowing the breaking point in advance). sysbench
+itself already fails fast (<15s); the gap is user expectation, not missing failure
+detection — a documentation problem, not a code problem.
+
+**Decision: document in both `kit.yaml` and the user guide, not just one.**
+
+`kit.yaml`'s `--rate` `description` is rendered verbatim as CLI help text by `kit info
+sysbench` (`KitInfo.kt`) — it's the first place a user sees the flag, so it carries a short
+warning. `docs/user-guide/sysbench.md` carries the fuller explanation (why it aborts instead
+of degrading, and the recommended alternative) plus the completed Flags table. Putting the
+full explanation only in one place would leave the other as a dead end for users who land
+there first.
+
+**Decision: fold in the pre-existing `--rate`/`--skip-trx`/`--rand-type` Flags-table gap.**
+
+All three are real `kit.yaml` `start` args today but are missing from the docs Flags table.
+Since the table is already being edited to add `--rate`'s row, adding the other two at the
+same time avoids re-creating the identical gap for two flags immediately after closing it
+for a third.
+
+## Risks / Trade-offs
+
+- **[Risk]** A user who doesn't read the flag description or docs still hits the same
+  cryptic sysbench `FATAL` message with no in-terminal pointer to the explanation. →
+  **Mitigation**: none in this change (by owner's explicit choice — see Decision above); a
+  runtime hint was considered and deferred, not rejected outright, and remains available as
+  future work if this proves insufficient in practice.
+- **[Risk]** The `sysbench-rate-limit-guidance` capability spec is unusually narrow (a
+  documentation contract rather than a runtime behavior contract), since no OpenSpec
+  capability for the sysbench kit exists yet to hang a delta spec off of. → **Mitigation**:
+  scoped explicitly to the `--rate` guidance contract only, not a stand-in for a full
+  sysbench kit spec — a full sysbench capability spec is out of scope for this change and
+  not implied by this one.
+
+## Migration Plan
+
+Not applicable — documentation and CLI help text only, no deployed state to migrate.
+
+## Open Questions
+
+None.

--- a/openspec/changes/issue-839/proposal.md
+++ b/openspec/changes/issue-839/proposal.md
@@ -24,8 +24,11 @@ investigation (2026-07-21); see GitHub issue #839.
   table in `docs/user-guide/sysbench.md` (pre-existing gap in the same table this change is
   already editing; all three are real `start` args in `kit.yaml` today but none appear in
   the table).
-- No code, behavior, or interface changes. `--rate` continues to pass straight through to
-  the sysbench binary unmodified — this is a documentation and CLI-help-text change only.
+- Add a drift-guard test asserting every flag declared in the sysbench `kit.yaml` has a row
+  in the user guide's Flags table, so the gap this change closes cannot silently reopen.
+- No runtime code, behavior, or interface changes. `--rate` continues to pass straight
+  through to the sysbench binary unmodified — this is a documentation and CLI-help-text
+  change only.
 
 ## Capabilities
 
@@ -47,4 +50,10 @@ not change. No existing spec's behavioral requirements change.
 - `src/main/resources/com/rustyrazorblade/easydblab/kits/sysbench/kit.yaml` — `--rate`
   flag description text (also affects `sysbench-<target> start --help` CLI output).
 - `docs/user-guide/sysbench.md` — Flags table + new explanatory subsection.
-- No code, tests, or runtime behavior affected.
+- `src/test/kotlin/com/rustyrazorblade/easydblab/commands/kit/SysbenchFlagsDocumentedTest.kt`
+  — new drift-guard test asserting every `kit.yaml` flag appears in the user guide's Flags
+  table (presence only; never defaults or wording).
+- `build.gradle.kts` — declares `docs/user-guide/sysbench.md` as an input of the `test`
+  task, so a dropped flag row cannot be masked by an up-to-date or cached test result.
+- No runtime behavior affected — the only production artifacts touched are help text and
+  documentation.

--- a/openspec/changes/issue-839/proposal.md
+++ b/openspec/changes/issue-839/proposal.md
@@ -12,7 +12,7 @@ investigation (2026-07-21); see GitHub issue #839.
 ## What Changes
 
 - Update the `--rate` flag's `description` in the sysbench kit's `kit.yaml` (rendered
-  verbatim as CLI help text by `kit info sysbench`) to warn that rates well above cluster
+  verbatim as picocli help text by `sysbench-<target> start --help`) to warn that rates well above cluster
   capacity cause a fast hard-abort rather than a sustained overload window, and to point at
   the docs for the recommended approach.
 - Add a "Rate limiting and overload testing" subsection to `docs/user-guide/sysbench.md`
@@ -45,6 +45,6 @@ not change. No existing spec's behavioral requirements change.
 ## Impact
 
 - `src/main/resources/com/rustyrazorblade/easydblab/kits/sysbench/kit.yaml` — `--rate`
-  flag description text (also affects `kit info sysbench` CLI output).
+  flag description text (also affects `sysbench-<target> start --help` CLI output).
 - `docs/user-guide/sysbench.md` — Flags table + new explanatory subsection.
 - No code, tests, or runtime behavior affected.

--- a/openspec/changes/issue-839/proposal.md
+++ b/openspec/changes/issue-839/proposal.md
@@ -1,0 +1,50 @@
+## Why
+
+sysbench's `--rate` flag limits target transactions/sec, but when a user sets it well above
+what the target cluster can actually sustain, sysbench's own internal rate-limiter event
+queue overflows and the run hard-aborts (`FATAL: event queue is full`) in under 15 seconds.
+For anyone running an overload/latency test — deliberately pushing rate past capacity to
+observe a sustained high-latency window — this is surprising: they expect degraded
+performance, not an immediate crash. Nothing in the kit currently documents this behavior or
+tells the user what to do instead. This was found during the TiDB×sysbench load-test
+investigation (2026-07-21); see GitHub issue #839.
+
+## What Changes
+
+- Update the `--rate` flag's `description` in the sysbench kit's `kit.yaml` (rendered
+  verbatim as CLI help text by `kit info sysbench`) to warn that rates well above cluster
+  capacity cause a fast hard-abort rather than a sustained overload window, and to point at
+  the docs for the recommended approach.
+- Add a "Rate limiting and overload testing" subsection to `docs/user-guide/sysbench.md`
+  explaining: what `--rate` does, why over-capacity rates hard-abort instead of degrading
+  gracefully, and the recommended alternative for overload/latency testing — thread-bound
+  runs (`--rate=0` with a chosen `--threads`) or a rate deliberately set closer to measured
+  capacity rather than far above it.
+- Add the currently-missing `--rate`, `--skip-trx`, and `--rand-type` flags to the Flags
+  table in `docs/user-guide/sysbench.md` (pre-existing gap in the same table this change is
+  already editing; all three are real `start` args in `kit.yaml` today but none appear in
+  the table).
+- No code, behavior, or interface changes. `--rate` continues to pass straight through to
+  the sysbench binary unmodified — this is a documentation and CLI-help-text change only.
+
+## Capabilities
+
+### New Capabilities
+
+- `sysbench-rate-limit-guidance`: documents the observable, user-facing contract for the
+  sysbench kit's `--rate` flag — that CLI help text and the user guide must explain the
+  hard-abort-on-overflow behavior and the recommended alternative. This is scoped narrowly
+  to the guidance/documentation contract for `--rate`, not a spec for the sysbench kit as a
+  whole (which has no existing OpenSpec capability and is out of scope here).
+
+### Modified Capabilities
+
+None — `--rate`'s runtime behavior (passthrough to the sysbench binary, unmodified) does
+not change. No existing spec's behavioral requirements change.
+
+## Impact
+
+- `src/main/resources/com/rustyrazorblade/easydblab/kits/sysbench/kit.yaml` — `--rate`
+  flag description text (also affects `kit info sysbench` CLI output).
+- `docs/user-guide/sysbench.md` — Flags table + new explanatory subsection.
+- No code, tests, or runtime behavior affected.

--- a/openspec/changes/issue-839/specs/sysbench-rate-limit-guidance/spec.md
+++ b/openspec/changes/issue-839/specs/sysbench-rate-limit-guidance/spec.md
@@ -2,12 +2,12 @@
 
 ### Requirement: CLI help text warns about over-capacity `--rate` abort behavior
 
-The sysbench kit's `--rate` flag description (`kit.yaml`, rendered verbatim by `kit info sysbench`) SHALL state that setting `--rate` well above the target's sustainable capacity causes sysbench's internal rate-limiter queue to overflow and the run to hard-abort within seconds, rather than sustaining a high-latency overload window, and SHALL point the user to the user guide for the recommended approach to overload/latency testing.
+The sysbench kit's `--rate` flag description (`kit.yaml`, rendered verbatim as picocli help text on the installed instance's start command, `sysbench-<target> start --help`) SHALL state that setting `--rate` well above the target's sustainable capacity causes sysbench's internal rate-limiter queue to overflow and the run to hard-abort within seconds, rather than sustaining a high-latency overload window, and SHALL point the user to the user guide for the recommended approach to overload/latency testing.
 
 #### Scenario: User inspects sysbench flag help
-- **WHEN** a user runs `easy-db-lab kit info sysbench`
+- **WHEN** a user runs `easy-db-lab sysbench-<target> start --help`
 - **THEN** the `--rate` flag's description mentions that over-capacity rates cause a fast
-  hard-abort (not a sustained overload window) and references the docs for guidance
+  hard-abort (not a sustained overload window) and references the user guide for guidance
 
 ### Requirement: User guide explains rate-limiting semantics and overload-testing guidance
 

--- a/openspec/changes/issue-839/specs/sysbench-rate-limit-guidance/spec.md
+++ b/openspec/changes/issue-839/specs/sysbench-rate-limit-guidance/spec.md
@@ -1,0 +1,30 @@
+## ADDED Requirements
+
+### Requirement: CLI help text warns about over-capacity `--rate` abort behavior
+
+The sysbench kit's `--rate` flag description (`kit.yaml`, rendered verbatim by `kit info sysbench`) SHALL state that setting `--rate` well above the target's sustainable capacity causes sysbench's internal rate-limiter queue to overflow and the run to hard-abort within seconds, rather than sustaining a high-latency overload window, and SHALL point the user to the user guide for the recommended approach to overload/latency testing.
+
+#### Scenario: User inspects sysbench flag help
+- **WHEN** a user runs `easy-db-lab kit info sysbench`
+- **THEN** the `--rate` flag's description mentions that over-capacity rates cause a fast
+  hard-abort (not a sustained overload window) and references the docs for guidance
+
+### Requirement: User guide explains rate-limiting semantics and overload-testing guidance
+
+`docs/user-guide/sysbench.md` SHALL include a section that explains what `--rate` does, why a rate set above the target's sustainable capacity causes sysbench to hard-abort (`FATAL: event queue is full`) rather than degrade gracefully, and the recommended alternative for overload/latency testing — thread-bound runs (`--rate=0` with a chosen `--threads`) or a rate deliberately set closer to measured capacity rather than far above it.
+
+#### Scenario: User reads the sysbench user guide for overload testing guidance
+- **WHEN** a user reads `docs/user-guide/sysbench.md` looking for how to run an
+  overload/latency test
+- **THEN** they find an explanation of why over-capacity `--rate` values hard-abort instead
+  of sustaining a high-latency window, and a recommended alternative (thread-bound runs or a
+  capacity-relative rate)
+
+### Requirement: Flags table lists all `start` command flags
+
+The Flags table in `docs/user-guide/sysbench.md` SHALL list every flag accepted by the sysbench kit's `start` command as declared in `kit.yaml`, including `--rate`, `--skip-trx`, and `--rand-type`.
+
+#### Scenario: User checks the Flags table for a start-command flag
+- **WHEN** a user consults the Flags table in `docs/user-guide/sysbench.md` for any flag
+  declared under the `start` command in `kit.yaml`
+- **THEN** that flag, its default, and its description appear in the table

--- a/openspec/changes/issue-839/tasks.md
+++ b/openspec/changes/issue-839/tasks.md
@@ -1,0 +1,25 @@
+## 1. `kit.yaml` CLI help text
+
+- [ ] 1.1 Update the `--rate` flag's `description` in
+      `src/main/resources/com/rustyrazorblade/easydblab/kits/sysbench/kit.yaml` to warn
+      that rates well above cluster capacity cause sysbench's internal event queue to
+      overflow and hard-abort within seconds (rather than sustaining an overload window),
+      and to point at the user guide for the recommended approach.
+
+## 2. User guide (`docs/user-guide/sysbench.md`)
+
+- [ ] 2.1 Add `--rate`, `--skip-trx`, and `--rand-type` rows to the Flags table (currently
+      missing despite being real `kit.yaml` `start` args).
+- [ ] 2.2 Add a "Rate limiting and overload testing" subsection covering: what `--rate`
+      does, why over-capacity rates hard-abort (`FATAL: event queue is full`) instead of
+      degrading gracefully, and the recommended alternative for overload/latency testing —
+      thread-bound runs (`--rate=0` with a chosen `--threads`) or a rate deliberately set
+      closer to measured capacity.
+
+## 3. Verification
+
+- [ ] 3.1 Confirm `docs/user-guide/sysbench.md` still builds cleanly with mdbook (per
+      `docs/CLAUDE.md`) and that the new section reads consistently with the rest of the
+      page's style.
+- [ ] 3.2 Confirm `kit.yaml` still parses/validates (e.g. `easy-db-lab kit info sysbench`
+      renders the updated `--rate` description correctly).

--- a/openspec/changes/issue-839/tasks.md
+++ b/openspec/changes/issue-839/tasks.md
@@ -16,16 +16,28 @@
       thread-bound runs (`--rate=0` with a chosen `--threads`) or a rate deliberately set
       closer to measured capacity.
 
-## 3. Verification
+## 3. Drift guard
 
-- [x] 3.1 Confirm `docs/user-guide/sysbench.md` still builds cleanly with mdbook (per
+- [x] 3.1 Add `SysbenchFlagsDocumentedTest`
+      (`src/test/kotlin/com/rustyrazorblade/easydblab/commands/kit/SysbenchFlagsDocumentedTest.kt`),
+      which loads the bundled sysbench `kit.yaml` and asserts every declared flag has a row
+      in the user guide's Flags table — presence only, never defaults or wording — so the
+      documentation gap this change closes cannot silently reopen.
+- [x] 3.2 Declare `docs/user-guide/sysbench.md` as an input of the `test` task in
+      `build.gradle.kts`, so an edit dropping a flag row cannot be masked by an up-to-date
+      or cached test result.
+
+## 4. Verification
+
+- [x] 4.1 Confirm `docs/user-guide/sysbench.md` still builds cleanly with mdbook (per
       `docs/CLAUDE.md`) and that the new section reads consistently with the rest of the
       page's style.
-- [x] 3.2 Confirm `kit.yaml` still parses/validates (e.g. `easy-db-lab kit info sysbench`
-      renders the updated `--rate` description correctly).
+- [x] 4.2 Confirm `kit.yaml` still parses/validates and that the updated `--rate`
+      description renders correctly on its actual user-facing surface,
+      `sysbench-<target> start --help`.
       Verified: `kit info sysbench` loads and parses the file (via
-      `InstallTemplateResolver.loadInstallConfig`) with no error. Note for review:
-      `kit info` renders only top-level `args`, not per-command args, so the `--rate`
-      description does not appear in its output. It reaches the user as picocli help text
-      on the installed kit's start command (`sysbench-<target> start --help`) via
+      `InstallTemplateResolver.loadInstallConfig`) with no error. `kit info` renders only
+      top-level `args`, not per-command args, so the `--rate` description does not appear
+      in its output; it reaches the user as picocli help text on the installed kit's start
+      command (`sysbench-<target> start --help`) via
       `KitRunnerCommandFactory.argOptionSpec`.

--- a/openspec/changes/issue-839/tasks.md
+++ b/openspec/changes/issue-839/tasks.md
@@ -1,6 +1,6 @@
 ## 1. `kit.yaml` CLI help text
 
-- [ ] 1.1 Update the `--rate` flag's `description` in
+- [x] 1.1 Update the `--rate` flag's `description` in
       `src/main/resources/com/rustyrazorblade/easydblab/kits/sysbench/kit.yaml` to warn
       that rates well above cluster capacity cause sysbench's internal event queue to
       overflow and hard-abort within seconds (rather than sustaining an overload window),
@@ -8,9 +8,9 @@
 
 ## 2. User guide (`docs/user-guide/sysbench.md`)
 
-- [ ] 2.1 Add `--rate`, `--skip-trx`, and `--rand-type` rows to the Flags table (currently
+- [x] 2.1 Add `--rate`, `--skip-trx`, and `--rand-type` rows to the Flags table (currently
       missing despite being real `kit.yaml` `start` args).
-- [ ] 2.2 Add a "Rate limiting and overload testing" subsection covering: what `--rate`
+- [x] 2.2 Add a "Rate limiting and overload testing" subsection covering: what `--rate`
       does, why over-capacity rates hard-abort (`FATAL: event queue is full`) instead of
       degrading gracefully, and the recommended alternative for overload/latency testing —
       thread-bound runs (`--rate=0` with a chosen `--threads`) or a rate deliberately set
@@ -18,8 +18,14 @@
 
 ## 3. Verification
 
-- [ ] 3.1 Confirm `docs/user-guide/sysbench.md` still builds cleanly with mdbook (per
+- [x] 3.1 Confirm `docs/user-guide/sysbench.md` still builds cleanly with mdbook (per
       `docs/CLAUDE.md`) and that the new section reads consistently with the rest of the
       page's style.
-- [ ] 3.2 Confirm `kit.yaml` still parses/validates (e.g. `easy-db-lab kit info sysbench`
+- [x] 3.2 Confirm `kit.yaml` still parses/validates (e.g. `easy-db-lab kit info sysbench`
       renders the updated `--rate` description correctly).
+      Verified: `kit info sysbench` loads and parses the file (via
+      `InstallTemplateResolver.loadInstallConfig`) with no error. Note for review:
+      `kit info` renders only top-level `args`, not per-command args, so the `--rate`
+      description does not appear in its output. It reaches the user as picocli help text
+      on the installed kit's start command (`sysbench-<target> start --help`) via
+      `KitRunnerCommandFactory.argOptionSpec`.

--- a/src/main/resources/com/rustyrazorblade/easydblab/kits/sysbench/kit.yaml
+++ b/src/main/resources/com/rustyrazorblade/easydblab/kits/sysbench/kit.yaml
@@ -52,7 +52,7 @@ commands:
       - flag: --rate
         variable: RATE
         type: int
-        description: "Target transactions/sec (0 = unlimited, thread-bound)"
+        description: "Target transactions/sec (0 = unlimited, thread-bound). A rate well above the target's sustainable capacity overflows sysbench's internal event queue and hard-aborts the run within seconds instead of sustaining an overload window; see docs/user-guide/sysbench.md for overload testing"
         default: "0"
       - flag: --skip-trx
         variable: SKIP_TRX

--- a/src/main/resources/com/rustyrazorblade/easydblab/kits/sysbench/kit.yaml
+++ b/src/main/resources/com/rustyrazorblade/easydblab/kits/sysbench/kit.yaml
@@ -52,7 +52,7 @@ commands:
       - flag: --rate
         variable: RATE
         type: int
-        description: "Target transactions/sec (0 = unlimited, thread-bound). A rate well above the target's sustainable capacity overflows sysbench's internal event queue and hard-aborts the run within seconds instead of sustaining an overload window; see docs/user-guide/sysbench.md for overload testing"
+        description: "Target transactions/sec (0 = unlimited, thread-bound). A rate well above the target's sustainable capacity hard-aborts the run in seconds instead of sustaining an overload window; see the sysbench user guide's 'Rate limiting and overload testing' section"
         default: "0"
       - flag: --skip-trx
         variable: SKIP_TRX

--- a/src/test/kotlin/com/rustyrazorblade/easydblab/commands/kit/SysbenchFlagsDocumentedTest.kt
+++ b/src/test/kotlin/com/rustyrazorblade/easydblab/commands/kit/SysbenchFlagsDocumentedTest.kt
@@ -1,0 +1,82 @@
+package com.rustyrazorblade.easydblab.commands.kit
+
+import com.rustyrazorblade.easydblab.BaseKoinTest
+import com.rustyrazorblade.easydblab.services.InstallTemplateResolver
+import com.rustyrazorblade.easydblab.services.KitSourcesProvider
+import com.rustyrazorblade.easydblab.services.TemplateService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.koin.core.module.Module
+import org.koin.dsl.module
+import java.io.File
+
+/**
+ * Guards the sysbench kit's user-guide Flags table against drift from its kit.yaml.
+ *
+ * `--rate`, `--skip-trx`, and `--rand-type` were real kit.yaml args for a long time while
+ * being absent from the docs table (issue #839), so a user reading the guide had no way to
+ * discover them. This test fails when a flag is added to kit.yaml without a matching row.
+ *
+ * Asserts flag presence only — never defaults or description wording, so rewording the docs
+ * does not break the build.
+ */
+class SysbenchFlagsDocumentedTest : BaseKoinTest() {
+    override fun additionalTestModules(): List<Module> =
+        listOf(
+            module {
+                single { TemplateService(get(), get()) }
+                single { KitSourcesProvider(get()) }
+                single { InstallTemplateResolver(get(), get()) }
+            },
+        )
+
+    private fun declaredFlags(): List<String> {
+        val resolver = getKoin().get<InstallTemplateResolver>()
+        val source = resolver.resolve(KIT_NAME)
+        val config = resolver.loadInstallConfig(source) ?: error("No kit.yaml for $KIT_NAME")
+        return (config.args + config.commands.values.flatMap { it.args })
+            .map { it.flag }
+            .distinct()
+    }
+
+    /**
+     * Pulls the flags out of the `## Flags` table only — a flag mentioned elsewhere in the
+     * prose is not the same as one a reader can find in the table.
+     */
+    private fun documentedFlags(): List<String> {
+        val docs = File(DOCS_PATH)
+        assertThat(docs)
+            .describedAs("sysbench user guide, resolved from working dir ${File(".").absolutePath}")
+            .exists()
+
+        val flagsSection =
+            docs
+                .readLines()
+                .dropWhile { it.trim() != "## Flags" }
+                .drop(1)
+                .takeWhile { !it.startsWith("## ") }
+
+        return flagsSection.mapNotNull { line ->
+            TABLE_FLAG.find(line)?.groupValues?.get(1)
+        }
+    }
+
+    @Test
+    fun `every sysbench kit flag appears in the user guide Flags table`() {
+        val declared = declaredFlags()
+        val documented = documentedFlags()
+
+        assertThat(declared).isNotEmpty()
+        assertThat(documented)
+            .describedAs("flags in the Flags table of $DOCS_PATH")
+            .containsAll(declared)
+    }
+
+    companion object {
+        private const val KIT_NAME = "sysbench"
+        private const val DOCS_PATH = "docs/user-guide/sysbench.md"
+
+        /** Matches the leading `| `--flag` |` cell of a Flags-table row. */
+        private val TABLE_FLAG = Regex("""^\|\s*`(--[a-z0-9-]+)`\s*\|""")
+    }
+}


### PR DESCRIPTION
Closes #839

## Summary

Documents that sysbench's `--rate` set well above target capacity causes sysbench's own internal rate-limiter event queue to overflow and hard-abort (`FATAL: event queue is full`) within seconds — not a sustained high-latency overload window, as one might expect. Docs-only change, no runtime behavior or code changes to the sysbench kit itself.

- `kit.yaml`'s `--rate` description (rendered as picocli help text on `sysbench-<target> start --help`) now warns about the fast hard-abort and points to the user guide.
- New "Rate limiting and overload testing" section in `docs/user-guide/sysbench.md`: what `--rate` does, why over-capacity rates abort instead of degrading, the recommended alternative (thread-bound runs via `--rate=0`, or a capacity-relative rate), and how to recognize an aborted run after the fact (truncated `last-run.txt`, latency dashboard flatlined at 0).
- Flags table gets the previously-missing `--rate`/`--skip-trx`/`--rand-type` rows, plus a corrected install-time-vs-per-invocation explanation (the old sentence claiming all flags needed a reinstall to change was wrong and now contradicted the new guidance).
- New drift-guard unit test (`SysbenchFlagsDocumentedTest`) asserting every `kit.yaml` flag has a Flags-table row, so this gap can't silently reopen; `build.gradle.kts` declares the docs page as a test input so the guard can't be masked by an up-to-date/cached result.

## Review

Two rounds through the five-lens panel (spec, code-review, security-review, test-rigor, observability). Round 1 found 1 blocker + 2 major findings — both correctness bugs in the *committed spec/docs*, not runtime code: the spec incorrectly claimed the new warning surfaces via `kit info sysbench` (it doesn't — verified against `KitInfo.kt`; the real surface is `sysbench-<target> start --help`), and the docs' pre-existing "reinstall to change flags" sentence was factually wrong and contradicted the new guidance. Both fixed and independently re-verified by 2 lenses each in round 2 — **all five lenses approved round 2**, no blockers/majors remaining.

The **unit tier ran locally throughout** (`./gradlew test`, plus ktlintCheck/detekt); the full/integration suite runs in CI on this PR.

## Surfaced, non-blocking

Left as-is (owner's call, none block this change):
- A one-directional test-guard nit: `SysbenchFlagsDocumentedTest` catches a flag added to `kit.yaml` without a docs row, but not the reverse (a stale docs row for a removed flag). Two lenses independently judged the current asymmetry defensible, not an oversight.
- `build.gradle.kts` declaring the docs page as a `test`-task input invalidates the whole unit tier's cache on any edit to that one file — correct and necessary, but worth knowing the blast radius.
- A timing-dependent edge case in the new "how to recognize an aborted run" guidance: if the sysbench pod dies before `kubectl wait --for=condition=ready` observes it Ready, `last-run.txt` from a *previous* run is left in place (stale, not truncated) and no metric is pushed at all — the documented check (truncated file + flatlined dashboard) wouldn't catch that specific case.
- Filed separately as its own backlog issue (not part of this PR): **#874** — no kit `start.sh.template` (project-wide, not sysbench-specific) checks the workload pod's exit code, so an aborted run like this one still exits 0 and reports "success" upstream.